### PR TITLE
Add basic support for generating code coverage reports

### DIFF
--- a/.code-coverage/coverlet.settings.xml
+++ b/.code-coverage/coverlet.settings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura,lcov</Format>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,6 +31,54 @@
                 "reveal": "always",
                 "panel": "dedicated"
             }
+        },
+        {
+            "label": "test with coverage",
+            "command": "dotnet",
+            "type": "shell",
+            "group": "test",
+            "args": [
+                "test",
+                "${workspaceFolder}/Git-Credential-Manager.sln",
+                "--collect",
+                "'XPlat Code Coverage'",
+                "--settings",
+                "${workspaceFolder}/.code-coverage/coverlet.settings.xml"
+            ],
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
+        },
+        {
+            "label": "report coverage - nix",
+            "command": "dotnet",
+            "type": "shell",
+            "group": "test",
+            "args": [
+                "~/.nuget/packages/reportgenerator/*/*/net5.0/ReportGenerator.dll",
+                "-reports:${workspaceFolder}/**/TestResults/**/coverage.cobertura.xml",
+                "-targetdir:${workspaceFolder}/out/code-coverage"
+            ],
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
+        },
+        {
+            "label": "report coverage - win",
+            "command": "dotnet",
+            "type": "shell",
+            "group": "test",
+            "args": [
+                "${env:USERROFILE}/.nuget/packages/reportgenerator/*/*/net5.0/ReportGenerator.dll",
+                "-reports:${workspaceFolder}/**/TestResults/**/coverage.cobertura.xml",
+                "-targetdir:${workspaceFolder}/out/code-coverage"
+            ],
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
         }
     ]
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,3 +95,40 @@ $ GCM_TRACE=1 git-credential-manager-core version
 > 18:47:56.526712 ...er/Application.cs:69 trace: [RunInternalAsync] Git Credential Manager version 2.0.124-beta+e1ebbe1517 (macOS, .NET 5.0) 'version'
 > Git Credential Manager version 2.0.124-beta+e1ebbe1517 (macOS, .NET 5.0)
 ```
+
+### Code coverage metrics
+
+If you want code coverage metrics these can be generated either from the command line:
+
+```shell
+$ dotnet test --collect:"XPlat Code Coverage" --settings=./.code-coverage/coverlet.settings.xml
+```
+
+Or via the VSCode Terminal/Run Task:
+
+```
+test with coverage
+```
+
+HTML reports can be generated using ReportGenerator, this should be installed during the build process, from the command line:
+
+```shell
+$ dotnet ~/.nuget/packages/reportgenerator/*/*/net5.0/ReportGenerator.dll -reports:./**/TestResults/**/coverage.cobertura.xml -targetdir:./out/code-coverage
+```
+or
+
+```shell
+$ dotnet {$env:USERPROFILE}/.nuget/packages/reportgenerator/*/*/net5.0/ReportGenerator.dll -reports:./**/TestResults/**/coverage.cobertura.xml -targetdir:./out/code-coverage
+```
+
+Or via VSCode Terminal/Run Task:
+
+```
+report coverage - nix
+```
+
+or
+
+```
+report coverage - win
+```

--- a/src/shared/Atlassian.Bitbucket.Tests/Atlassian.Bitbucket.Tests.csproj
+++ b/src/shared/Atlassian.Bitbucket.Tests/Atlassian.Bitbucket.Tests.csproj
@@ -8,7 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/shared/Core.Tests/Core.Tests.csproj
+++ b/src/shared/Core.Tests/Core.Tests.csproj
@@ -9,7 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/shared/GitHub.Tests/GitHub.Tests.csproj
+++ b/src/shared/GitHub.Tests/GitHub.Tests.csproj
@@ -8,7 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/shared/Microsoft.AzureRepos.Tests/Microsoft.AzureRepos.Tests.csproj
+++ b/src/shared/Microsoft.AzureRepos.Tests/Microsoft.AzureRepos.Tests.csproj
@@ -8,7 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/shared/TestInfrastructure/TestInfrastructure.csproj
+++ b/src/shared/TestInfrastructure/TestInfrastructure.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>


### PR DESCRIPTION
**Problem**

I'd like to refactor parts of the Bitbucket code, but I'm uncomfortable about the level of security provided by the automated testing to avoid regressions.

I'd like to expand the testing, so I'd like to know what is currently tested or not.

**Solution**

This adds a first pass at adding basic code coverage metrics and reporting. 
They have to be run manually, they are not currently wired up to CI etc, I'd suggest doing that in a follow up.