### PR TITLE
Issue/218

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,6 +196,34 @@ git config --global credential.bitbucketAuthModes "oauth,basic"
 
 ---
 
+### credential.bitbucketAlwaysRefreshCredentials
+
+Forces GCM to ignore any existing stored Basic Auth or OAuth access tokens and always run through the process to refresh the credentials before returning them to Git.
+
+This is especially relevant to OAuth credentials. Bitbucket.org access tokens expire after 2 hours, after that the refresh token must be used to get a new access token.
+
+Enabling this option will improve performance when using Oauth2 and interacting with Bitbucket.org if, on average, commits are done less frequently than every 2 hours.
+
+Enabling this option will decrease performance when using Basic Auth by requiring the user the re-enter credentials everytime.
+
+
+Value|Refresh Credentials Before Returning
+-|-
+`true`, `1`, `yes`, `on` |Always
+`false`, `0`, `no`, `off`_(default)_|Only when the credentials are found to be invalid
+
+#### Example
+
+```shell
+git config --global credential.bitbucketAlwaysRefreshCredentials 1
+```
+
+Defaults to false/disabled.
+
+**Also see: [GCM_BITBUCKET_ALWAYS_REFRESH_CREDENTIALS](environment.md#GCM_BITBUCKET_ALWAYS_REFRESH_CREDENTIALS)**
+
+---
+
 ### credential.gitHubAuthModes
 
 Override the available authentication modes presented during GitHub authentication.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -343,6 +343,40 @@ export GCM_BITBUCKET_AUTHMODES="oauth,basic"
 
 ---
 
+### GCM_BITBUCKET_ALWAYS_REFRESH_CREDENTIALS
+
+Forces GCM to ignore any existing stored Basic Auth or OAuth access tokens and always run through the process to refresh the credentials before returning them to Git.
+
+This is especially relevant to OAuth credentials. Bitbucket.org access tokens expire after 2 hours, after that the refresh token must be used to get a new access token.
+
+Enabling this option will improve performance when using Oauth2 and interacting with Bitbucket.org if, on average, commits are done less frequently than every 2 hours.
+
+Enabling this option will decrease performance when using Basic Auth by requiring the user the re-enter credentials everytime.
+
+
+Value|Refresh Credentials Before Returning
+-|-
+`true`, `1`, `yes`, `on` |Always
+`false`, `0`, `no`, `off`_(default)_|Only when the credentials are found to be invalid
+
+##### Windows
+
+```batch
+SET GCM_BITBUCKET_ALWAYS_REFRESH_CREDENTIALS=1
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_BITBUCKET_ALWAYS_REFRESH_CREDENTIALS=1
+```
+
+Defaults to false/disabled.
+
+**Also see: [credential.bitbucketAlwaysRefreshCredentials](configuration.md#bitbucketAlwaysRefreshCredentials)**
+
+---
+
 ### GCM_GITHUB_AUTHMODES
 
 Override the available authentication modes presented during GitHub authentication.

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketAuthenticationTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketAuthenticationTest.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using GitCredentialManager.Tests.Objects;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests
+{
+    public class BitbucketAuthenticationTest
+    {
+        [Theory]
+        [InlineData("jsquire", "password")]
+        public async Task BitbucketAuthentication_GetBasicCredentialsAsync_SucceedsAfterUserInput(string username, string password)
+        {
+            var context = new TestCommandContext();
+            context.Terminal.Prompts["Username"] = username;
+            context.Terminal.SecretPrompts["Password"] = password;
+            System.Uri targetUri = null;
+
+            var bitbucketAuthentication = new BitbucketAuthentication(context);
+
+            var result = await bitbucketAuthentication.GetBasicCredentialsAsync(targetUri, username);
+
+            Assert.NotNull(result);
+            Assert.Equal(username, result.Account);
+            Assert.Equal(password, result.Password);
+        }
+
+        [Theory]
+        [InlineData("jsquire", "password")]
+        public async Task BitbucketAuthentication_ShowOAuthRequiredPromptAsync_SucceedsAfterUserInput(string username, string password)
+        {
+            var context = new TestCommandContext();
+            context.Terminal.Prompts["Press enter to continue..."] = " ";
+
+            var bitbucketAuthentication = new BitbucketAuthentication(context);
+
+            var result = await bitbucketAuthentication.ShowOAuthRequiredPromptAsync();
+
+            Assert.True(result);
+            Assert.Equal($"Your account has two-factor authentication enabled.{Environment.NewLine}" +
+                                           $"To continue you must complete authentication in your web browser.{Environment.NewLine}", context.Terminal.Messages[0].Item1);
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketAuthenticationTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketAuthenticationTest.cs
@@ -25,9 +25,8 @@ namespace Atlassian.Bitbucket.Tests
             Assert.Equal(password, result.Password);
         }
 
-        [Theory]
-        [InlineData("jsquire", "password")]
-        public async Task BitbucketAuthentication_ShowOAuthRequiredPromptAsync_SucceedsAfterUserInput(string username, string password)
+        [Fact]
+        public async Task BitbucketAuthentication_ShowOAuthRequiredPromptAsync_SucceedsAfterUserInput()
         {
             var context = new TestCommandContext();
             context.Terminal.Prompts["Press enter to continue..."] = " ";

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -56,7 +56,7 @@ namespace Atlassian.Bitbucket.Tests
         {
             InputArguments input = null;
             var provider = new BitbucketHostProvider(new TestCommandContext());
-            Assert.Equal(false, provider.IsSupported(input));
+            Assert.False(provider.IsSupported(input));
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Atlassian.Bitbucket.Tests
         {
             HttpResponseMessage httpResponseMessage = null;
             var provider = new BitbucketHostProvider(new TestCommandContext());
-            Assert.Equal(false, provider.IsSupported(httpResponseMessage));
+            Assert.False(provider.IsSupported(httpResponseMessage));
         }
 
         [Theory]

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -361,11 +361,11 @@ namespace Atlassian.Bitbucket.Tests
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
 
-            Assert.Equal(context.CredentialStore.Count, 0);
+            Assert.Equal(0, context.CredentialStore.Count);
 
             await provider.StoreCredentialAsync(input);
 
-            Assert.Equal(context.CredentialStore.Count, 1);
+            Assert.Equal(1, context.CredentialStore.Count);
         }
         
         [Theory]
@@ -380,11 +380,11 @@ namespace Atlassian.Bitbucket.Tests
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
 
-            Assert.Equal(context.CredentialStore.Count, 1);
+            Assert.Equal(1, context.CredentialStore.Count);
 
             await provider.EraseCredentialAsync(input);
 
-            Assert.Equal(context.CredentialStore.Count, 0);
+            Assert.Equal(0, context.CredentialStore.Count);
         }
 
         #endregion

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -12,22 +12,27 @@ namespace Atlassian.Bitbucket.Tests
 {
     public class BitbucketHostProviderTest
     {
+        #region Tests
+
         private const string MOCK_ACCESS_TOKEN = "at-0987654321";
         private const string MOCK_REFRESH_TOKEN = "rt-1234567809";
+        private const string BITBUCKET_DOT_ORG_HOST = "bitbucket.org";
+        private const string DC_SERVER_HOST = "example.com";
         private Mock<IBitbucketAuthentication> bitbucketAuthentication = new Mock<IBitbucketAuthentication>(MockBehavior.Strict);
         private Mock<IBitbucketRestApi> bitbucketApi = new Mock<IBitbucketRestApi>(MockBehavior.Strict);
 
         [Theory]
+        [InlineData("https", null, false)]
         // We report that we support unencrypted HTTP here so that we can fail and
         // show a helpful error message in the call to `GenerateCredentialAsync` instead.
-        [InlineData("http", "bitbucket.org", true)]
-        [InlineData("ssh", "bitbucket.org", false)]
-        [InlineData("https", "bitbucket.org", true)]
+        [InlineData("http", BITBUCKET_DOT_ORG_HOST, true)]
+        [InlineData("ssh", BITBUCKET_DOT_ORG_HOST, false)]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, true)]
         [InlineData("https", "api.bitbucket.org", true)] // Currently does support sub domains.
 
         [InlineData("https", "bitbucket.ogg", false)] // No support of phony similar tld.
         [InlineData("https", "bitbucket.com", false)] // No support of wrong tld.
-        [InlineData("https", "example.com", false)] // No support of non bitbucket domains.
+        [InlineData("https", DC_SERVER_HOST, false)] // No support of non bitbucket domains.
 
         [InlineData("http", "bitbucket.my-company-server.com", false)]  // Currently no support for named on-premise instances
         [InlineData("https", "my-company-server.com", false)]
@@ -46,6 +51,22 @@ namespace Atlassian.Bitbucket.Tests
             Assert.Equal(expected, provider.IsSupported(input));
         }
 
+        [Fact]
+        public void BitbucketHostProvider_IsSupported_FailsForNullInput()
+        {
+            InputArguments input = null;
+            var provider = new BitbucketHostProvider(new TestCommandContext());
+            Assert.Equal(false, provider.IsSupported(input));
+        }
+
+        [Fact]
+        public void BitbucketHostProvider_IsSupported_FailsForNullHttpResponseMessage()
+        {
+            HttpResponseMessage httpResponseMessage = null;
+            var provider = new BitbucketHostProvider(new TestCommandContext());
+            Assert.Equal(false, provider.IsSupported(httpResponseMessage));
+        }
+
         [Theory]
         [InlineData("X-AREQUESTID", "123456789", true)] // only the specific header is acceptable
         [InlineData("X-REQUESTID", "123456789", false)]
@@ -62,109 +83,133 @@ namespace Atlassian.Bitbucket.Tests
             Assert.Equal(expected, provider.IsSupported(input));
         }
 
-
         [Theory]
-        // DC
-        [InlineData("https", "example.com", "jsquire", "password", false, false, false)]
-        [InlineData("https", "example.com", "jsquire", "password", false, true, true)]
-        [InlineData("https", "example.com", "jsquire", "password", true, null, true)]
-        // cloud
-        [InlineData("https", "bitbucket.org", "jsquire", "password", false, false, false)]
-        [InlineData("https", "bitbucket.org", "jsquire", "password", false, true, true)]
-        [InlineData("https", "bitbucket.org", "jsquire", "password", true, null, true)]
-        // Basic Auth works
-        public void BitbucketHostProvider_GetCredentialAsync_ForBasicAuth(string protocol, string host, string username,string password, bool storedAccount, bool? userEntersCredentials, bool expected)
+        [InlineData("https", DC_SERVER_HOST, "jsquire", "password")]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password")]
+        public void BitbucketHostProvider_GetCredentialAsync_Succeeds_ForValidStoredBasicAuthAccount(string protocol, string host, string username,string password)
         {
             InputArguments input = MockInput(protocol, host, username);
 
             var context = new TestCommandContext();
 
-            if (storedAccount)
-            {
-                MockStoredBasicAccount(context, input, password);
-            }
-
-            if (userEntersCredentials.HasValue && userEntersCredentials.Value)
-            {
-                MockUserEnteredBasicCredentials(bitbucketAuthentication, input, password);
-            }
-            else
-            {
-                MockUserDidNotEnteredBasicCredentials(bitbucketAuthentication);
-            }
-
-            MockValidRemoteAccount(bitbucketApi, input, password, false);
+            MockStoredAccount(context, input, password);
+            MockRemoteBasicAuthAccountIsValidNo2FA(bitbucketApi, input, password);
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
 
-            if (userEntersCredentials.HasValue && !userEntersCredentials.Value)
-            {
-                Assert.ThrowsAsync<Exception>(async () => await provider.GetCredentialAsync(input));
-                return;
-            }
-
             var credential = provider.GetCredentialAsync(input);
 
-            VerifyBasicAuthFlowRan(password, storedAccount, expected, input, credential, null);
+            //verify bitbucket.org credentials were validated
+            if (BITBUCKET_DOT_ORG_HOST.Equals(host)) 
+            {
+                VerifyValidateBasicAuthCredentialsRan();
+            }
+            else
+            {
+                //verify DC/Server credentials were not validated
+                VerifyValidateBasicAuthCredentialsNeverRan();
+            }
 
-            VerifyOAuthFlowWasNotRun(password, storedAccount, expected, input, credential);
+            // Stored credentials so don't ask for more
+            VerifyInteractiveBasicAuthFlowNeverRan(password, input, credential);
+
+            // Valid Basic Auth credentials so don't run Oauth
+            VerifyInteractiveOAuthFlowNeverRan(input, credential);
         }
 
         [Theory]
-        //cloud
-        [InlineData("https", "bitbucket.org", "jsquire", "password", true, null, true)]
-        [InlineData("https", "bitbucket.org", "jsquire", "password", false, true, true)]
-        [InlineData("https", "bitbucket.org", "jsquire", "password", false, false, false)]
-        // Basic Auth works
-        public void BitbucketHostProvider_GetCredentialAsync_ForOAuth(string protocol, string host, string username, string password, bool storedAccount, bool? userEntersCredentials, bool expected)
+        // DC/Server does not currently support OAuth
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password")]
+        public void BitbucketHostProvider_GetCredentialAsync_Succeeds_ForValidStoredOAuthAccount(string protocol, string host, string username,string token)
+        {
+            InputArguments input = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+
+            MockStoredAccount(context, input, token);
+            MockRemoteOAuthAccountIsValid(bitbucketApi, input, token, false);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
+
+            var credential = provider.GetCredentialAsync(input);
+
+            //verify bitbucket.org credentials were validated
+            VerifyValidateOAuthCredentialsRan();
+
+            // Stored credentials so don't ask for more
+            VerifyInteractiveBasicAuthFlowNeverRan(token, input, credential);
+
+            // Valid Basic Auth credentials so don't run Oauth
+            VerifyInteractiveOAuthFlowNeverRan(input, credential);
+        }
+
+        [Theory]
+        // DC
+        [InlineData("https", DC_SERVER_HOST, "jsquire", "password")]
+        // cloud
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password")]
+        public void BitbucketHostProvider_GetCredentialAsync_Succeeds_ForFreshValidBasicAuthAccount(string protocol, string host, string username,string password)
+        {
+            InputArguments input = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+
+            MockUserEntersValidBasicCredentials(bitbucketAuthentication, input, password);
+
+            if(BITBUCKET_DOT_ORG_HOST.Equals(host)) 
+            {
+                MockRemoteOAuthAccountIsValid(bitbucketApi, input, password, true);
+            }
+
+            MockRemoteBasicAuthAccountIsValidNo2FA(bitbucketApi, input, password);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
+
+            var credential = provider.GetCredentialAsync(input);
+
+            VerifyBasicAuthFlowRan(password, true, input, credential, null);
+
+            VerifyOAuthFlowDidNotRun(password, true, input, credential);
+        }
+
+        [Theory]
+        // DC/Server does not currently support OAuth
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", MOCK_ACCESS_TOKEN)]
+        public void BitbucketHostProvider_GetCredentialAsync_Succeeds_ForFreshValid2FAAcccount(string protocol, string host, string username, string password)
         {
             var input = MockInput(protocol, host, username);
 
             var context = new TestCommandContext();
 
-            if (storedAccount)
-            {
-                MockStoredOAuthAccount(context, input);
-            }
-
-            if (userEntersCredentials.HasValue && userEntersCredentials.Value)
-            {
-                MockUserEnteredBasicCredentials(bitbucketAuthentication, input, password);
-            }
-            else
-            {
-                MockUserDidNotEnteredBasicCredentials(bitbucketAuthentication);
-            }
-
-            MockValidRemoteAccount(bitbucketApi, input, password, true);
+            // user is prompted for basic auth credentials
+            MockUserEntersValidBasicCredentials(bitbucketAuthentication, input, password);
+            // basic auth credentials are valid but 2FA is ON
+            MockRemoteBasicAuthAccountIsValidRequires2FA(bitbucketApi, input, password);
+            MockRemoteOAuthAccountIsValid(bitbucketApi, input, password, true);
             MockRemoteValidRefreshToken();
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
 
-            if (userEntersCredentials.HasValue && !userEntersCredentials.Value)
-            {
-                Assert.ThrowsAsync<Exception>(async () => await provider.GetCredentialAsync(input));
-                return;
-            }
+            //if (userEntersCredentials.HasValue && !userEntersCredentials.Value)
+            //{
+            //    Assert.ThrowsAsync<Exception>(async () => await provider.GetCredentialAsync(input));
+            //    return;
+            //}
 
             var credential = provider.GetCredentialAsync(input);
 
-            if (expected)
-            {
-                VerifyOAuthFlowRan(password, storedAccount, expected, input, credential, null);
-            }
+            VerifyOAuthFlowRan(password, false, true, input, credential, null);
 
-            VerifyBasicAuthFlowDidNotRun(password, expected, input, storedAccount, credential, null);
+            VerifyBasicAuthFlowNeverRan(password, input, false, null);
         }
 
         [Theory]
         // cloud
-        [InlineData("https", "bitbucket.org", "jsquire", "password", null, true)]
-        [InlineData("https", "bitbucket.org", "jsquire", "password", "basic", true)]
-        [InlineData("https", "bitbucket.org", "jsquire", "password", "oauth", true)]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password", "basic")]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password", "oauth")]
         // Basic Auth works
-        public void BitbucketHostProvider_GetCredentialAsync_ForOAuth_NoStorage_ForcedAuthMode(string protocol, string host, string username, string password, 
-            string preconfiguredAuthModes, bool expected)
+        public void BitbucketHostProvider_GetCredentialAsync_ForcedAuthMode_IsRespected(string protocol, string host, string username, string password, 
+            string preconfiguredAuthModes)
         {
             var input = MockInput(protocol, host, username);
 
@@ -174,30 +219,77 @@ namespace Atlassian.Bitbucket.Tests
                 context.Environment.Variables.Add(BitbucketConstants.EnvironmentVariables.AuthenticationModes, preconfiguredAuthModes);
             }
 
-            MockUserEnteredBasicCredentials(bitbucketAuthentication, input, password);
-            MockValidRemoteAccount(bitbucketApi, input, password, true);
-            MockRemoteValidRefreshToken();
+            MockUserEntersValidBasicCredentials(bitbucketAuthentication, input, password);
+            MockRemoteBasicAuthAccountIsValidRequires2FA(bitbucketApi, input, password);
+            bitbucketAuthentication.Setup(m => m.ShowOAuthRequiredPromptAsync()).ReturnsAsync(true);
+            //MockRemoteValidRefreshToken();
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
 
             var credential = provider.GetCredentialAsync(input);
 
-            if (preconfiguredAuthModes == null)
+            Assert.NotNull(credential);
+
+            if (preconfiguredAuthModes.Contains("basic"))
             {
-                VerifyBasicAuthFlowRan(password, false, expected, input, credential, preconfiguredAuthModes);
+                VerifyInteractiveBasicAuthFlowRan(password, input, credential);
+                VerifyInteractiveOAuthFlowNeverRan(input, credential);
             }
 
-            if (preconfiguredAuthModes != null && preconfiguredAuthModes.Contains("basic"))
+            if (preconfiguredAuthModes.Contains("oauth"))
             {
-                VerifyBasicAuthFlowRan(password, false, expected, input, credential, preconfiguredAuthModes);
-                VerifyOAuthFlowWasNotRun(password, false, expected, input, credential);
+                VerifyInteractiveBasicAuthFlowNeverRan(password, input, credential);
+                VerifyInteractiveOAuthFlowRan(password, input, credential);
+            }
+        }
+
+        [Theory]
+        // cloud
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password", "false")]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password", "0")]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password", "true")]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password", "1")]
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password", null)]
+        // DC
+        [InlineData("https", DC_SERVER_HOST, "jsquire", "password", "false")]
+        [InlineData("https", DC_SERVER_HOST, "jsquire", "password", "0")]
+        [InlineData("https", DC_SERVER_HOST, "jsquire", "password", "1")]
+        [InlineData("https", DC_SERVER_HOST, "jsquire", "password", "true")]
+        [InlineData("https", DC_SERVER_HOST, "jsquire", "password", null)]
+        public void BitbucketHostProvider_GetCredentialAsync_AlwaysRefreshCredentials_IsRespected(string protocol, string host, string username, string password, 
+            string alwaysRefreshCredentials)
+        {
+            var input = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+            if (alwaysRefreshCredentials != null)
+            {
+                context.Environment.Variables.Add(BitbucketConstants.EnvironmentVariables.AlwaysRefreshCredentials, alwaysRefreshCredentials.ToString());
             }
 
-            if (preconfiguredAuthModes != null && preconfiguredAuthModes.Contains("oauth"))
+            MockStoredAccount(context, input, password);
+            MockUserEntersValidBasicCredentials(bitbucketAuthentication, input, password);
+            MockRemoteOAuthAccountIsValid(bitbucketApi, input, password, true);
+            MockRemoteBasicAuthAccountIsValidNo2FA(bitbucketApi, input, password);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
+
+            var credential = provider.GetCredentialAsync(input);
+
+            var alwaysRefreshCredentialsBool = "1".Equals(alwaysRefreshCredentials) 
+                || "on".Equals(alwaysRefreshCredentials) 
+                || "true".Equals(alwaysRefreshCredentials) ? true : false;
+
+            if (alwaysRefreshCredentialsBool)
             {
-                VerifyOAuthFlowRan(password, false, expected, input, credential, preconfiguredAuthModes);
-                VerifyBasicAuthFlowDidNotRun(password, expected, input, false, credential, preconfiguredAuthModes);
+                VerifyBasicAuthFlowRan(password, true, input, credential, null);
             }
+            else
+            {
+                VerifyBasicAuthFlowNeverRan(password, input, true, null);
+            }
+
+            VerifyOAuthFlowDidNotRun(password, true, input, credential);
         }
 
         [Theory]
@@ -219,8 +311,9 @@ namespace Atlassian.Bitbucket.Tests
 
             var context = new TestCommandContext { };
             if (bitbucketAuthModes != null)
+            {
                 context.Environment.Variables.Add(BitbucketConstants.EnvironmentVariables.AuthenticationModes, bitbucketAuthModes);
-
+            }
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
 
@@ -229,6 +322,81 @@ namespace Atlassian.Bitbucket.Tests
             Assert.Equal(expectedModes, actualModes);
         }
         
+        [Theory]
+        // DC
+        [InlineData("https", DC_SERVER_HOST, "jsquire", "password")]
+        [InlineData("http", DC_SERVER_HOST, "jsquire", "password")]
+        // cloud
+        [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password")]
+        [InlineData("http", BITBUCKET_DOT_ORG_HOST, "jsquire", "password")]
+        public async Task BitbucketHostProvider_GetCredentialAsync_ValidateTargetUriAsync(string protocol, string host, string username, string password)
+        {
+            var input = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
+
+            if (protocol.ToLower().Equals("http") && host.ToLower().Equals(BITBUCKET_DOT_ORG_HOST))
+            {
+                // only fail for http://bitbucket.org
+                await Assert.ThrowsAsync<Exception>(async () => await provider.GetCredentialAsync(input));
+            }
+            else
+            {
+                MockUserEntersValidBasicCredentials(bitbucketAuthentication, input, password);
+                MockRemoteBasicAuthAccountIsValidRequires2FA(bitbucketApi, input, password);
+                MockRemoteValidRefreshToken();
+                bitbucketAuthentication.Setup(m => m.ShowOAuthRequiredPromptAsync()).ReturnsAsync(true);
+                bitbucketAuthentication.Setup(m => m.CreateOAuthCredentialsAsync(It.IsAny<Uri>())).ReturnsAsync(new OAuth2TokenResult(MOCK_ACCESS_TOKEN, "access_token"));
+                var userInfo = new UserInfo() { IsTwoFactorAuthenticationEnabled = false };
+                bitbucketApi.Setup(x => x.GetUserInformationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
+
+                var credential = await provider.GetCredentialAsync(input);
+            }
+
+            
+        }
+
+        [Theory]
+        [InlineData("https", DC_SERVER_HOST, "jsquire")]
+        public async Task BitbucketHostProvider_StoreCredentialAsync(string protocol, string host, string username)
+        {
+            var input = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
+
+            Assert.Equal(context.CredentialStore.Count, 0);
+
+            await provider.StoreCredentialAsync(input);
+
+            Assert.Equal(context.CredentialStore.Count, 1);
+        }
+        
+        [Theory]
+        [InlineData("https", DC_SERVER_HOST, "jsquire", "password")]
+        public async Task BitbucketHostProvider_EraseCredentialAsync(string protocol, string host, string username, string password)
+        {
+            var input = MockInput(protocol, host, username);
+
+            var context = new TestCommandContext();
+
+            MockStoredAccount(context, input, password);
+
+            var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
+
+            Assert.Equal(context.CredentialStore.Count, 1);
+
+            await provider.EraseCredentialAsync(input);
+
+            Assert.Equal(context.CredentialStore.Count, 0);
+        }
+
+        #endregion
+
+        #region Test helpers
         private static InputArguments MockInput(string protocol, string host, string username)
         {
             return new InputArguments(new Dictionary<string, string>
@@ -239,37 +407,40 @@ namespace Atlassian.Bitbucket.Tests
             });
         }
 
-        private void VerifyBasicAuthFlowRan(string password, bool storedAccount, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential,
+        private void VerifyBasicAuthFlowRan(string password, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential,
             string preconfiguredAuthModes)
         {
             Assert.Equal(expected, credential != null);
 
             var remoteUri = input.GetRemoteUri();
 
-            if (storedAccount)
-            {
-                // stored username/password so no need to prompt the user for them
-                bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Never);
-            }
-            else
-            {
-                // no username/password credentials so prompt the user for them
-                bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Once);
-            }
+            bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Once);
 
             // check username/password for Bitbucket.org
-            if ((preconfiguredAuthModes == null && "bitbucket.org" == remoteUri.Host)
+            if ((preconfiguredAuthModes == null && BITBUCKET_DOT_ORG_HOST == remoteUri.Host)
                 || (preconfiguredAuthModes != null && preconfiguredAuthModes.Contains("oauth")))
             {
                 bitbucketApi.Verify(m => m.GetUserInformationAsync(input.UserName, password, false), Times.Once);
             }
         }
 
-        private void VerifyBasicAuthFlowDidNotRun(string password, bool expected, InputArguments input, bool storedAccount, System.Threading.Tasks.Task<ICredential> credential,
+        private void VerifyInteractiveBasicAuthFlowRan(string password, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
+        {
+            var remoteUri = input.GetRemoteUri();
+
+            // verify users was prompted for username/password credentials
+            bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Once);
+
+            // check username/password for Bitbucket.org
+            if (BITBUCKET_DOT_ORG_HOST == remoteUri.Host)
+            {
+                bitbucketApi.Verify(m => m.GetUserInformationAsync(input.UserName, password, false), Times.Once);
+            }
+        }
+
+        private void VerifyBasicAuthFlowNeverRan(string password, InputArguments input, bool storedAccount,
             string preconfiguredAuthModes)
         {
-            Assert.Equal(expected, credential != null);
-
             var remoteUri = input.GetRemoteUri();
 
             if (!storedAccount &&
@@ -283,6 +454,13 @@ namespace Atlassian.Bitbucket.Tests
                 // never prompt the user for basic credentials
                 bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Never);
             }
+        }
+
+        private void VerifyInteractiveBasicAuthFlowNeverRan(string password, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
+        {
+            var remoteUri = input.GetRemoteUri();
+
+            bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Never);
         }
 
         private void VerifyOAuthFlowRan(string password, bool storedAccount, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential,
@@ -316,7 +494,16 @@ namespace Atlassian.Bitbucket.Tests
             }
         }
 
-        private void VerifyOAuthFlowWasNotRun(string password, bool storedAccount, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
+        private void VerifyInteractiveOAuthFlowRan(string password, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
+        {
+            var remoteUri = input.GetRemoteUri();
+
+            // Basic Auth 403-ed so push user through OAuth flow
+            bitbucketAuthentication.Verify(m => m.ShowOAuthRequiredPromptAsync(), Times.Once);
+                
+        }
+
+        private void VerifyOAuthFlowDidNotRun(string password, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
         {
             Assert.Equal(expected, credential != null);
 
@@ -330,6 +517,44 @@ namespace Atlassian.Bitbucket.Tests
 
             // never check access token works
             bitbucketApi.Verify(m => m.GetUserInformationAsync(null, MOCK_ACCESS_TOKEN, true), Times.Never);
+        }
+
+        private void VerifyInteractiveOAuthFlowNeverRan(InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
+        {
+            var remoteUri = input.GetRemoteUri();
+
+            // never prompt user through OAuth flow
+            bitbucketAuthentication.Verify(m => m.ShowOAuthRequiredPromptAsync(), Times.Never);
+
+            // Never try to refresh Access Token
+            bitbucketAuthentication.Verify(m => m.RefreshOAuthCredentialsAsync(It.IsAny<string>()), Times.Never);
+
+            // never check access token works
+            bitbucketApi.Verify(m => m.GetUserInformationAsync(null, MOCK_ACCESS_TOKEN, true), Times.Never);
+        }
+
+        private void VerifyValidateBasicAuthCredentialsNeverRan() 
+        {
+            // never check username/password works
+            bitbucketApi.Verify(m => m.GetUserInformationAsync(It.IsAny<string>(), It.IsAny<string>(), BitbucketHostProvider.USE_BASIC_TOKEN), Times.Never);
+        }
+
+        private void VerifyValidateBasicAuthCredentialsRan() 
+        {
+            // check username/password works
+            bitbucketApi.Verify(m => m.GetUserInformationAsync(It.IsAny<string>(), It.IsAny<string>(), BitbucketHostProvider.USE_BASIC_TOKEN), Times.Once);
+        }
+
+        private void VerifyValidateOAuthCredentialsNeverRan() 
+        {
+            // never check username/password works
+            bitbucketApi.Verify(m => m.GetUserInformationAsync(null, It.IsAny<string>(), BitbucketHostProvider.USE_BASIC_TOKEN), Times.Never);
+        }
+
+        private void VerifyValidateOAuthCredentialsRan() 
+        {
+            // check username/password works
+            bitbucketApi.Verify(m => m.GetUserInformationAsync(null, It.IsAny<string>(), BitbucketHostProvider.USE_BEARER_TOKEN), Times.Once);
         }
 
         private void MockStoredOAuthAccount(TestCommandContext context, InputArguments input)
@@ -352,24 +577,51 @@ namespace Atlassian.Bitbucket.Tests
             bitbucketApi.Setup(x => x.GetUserInformationAsync(It.IsAny<String>(), It.IsAny<String>(), false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.Unauthorized));
 
         }
-        private static void MockUserEnteredBasicCredentials(Mock<IBitbucketAuthentication> bitbucketAuthentication, InputArguments input, string password)
+        private static void MockUserEntersValidBasicCredentials(Mock<IBitbucketAuthentication> bitbucketAuthentication, InputArguments input, string password)
         {
             var remoteUri = input.GetRemoteUri();
             bitbucketAuthentication.Setup(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName)).ReturnsAsync(new TestCredential(input.Host, input.UserName, password));
         }
 
-        private static void MockUserDidNotEnteredBasicCredentials(Mock<IBitbucketAuthentication> bitbucketAuthentication)
+        private static void MockUserDoesNotEntersValidBasicCredentials(Mock<IBitbucketAuthentication> bitbucketAuthentication)
         {
             bitbucketAuthentication.Setup(m => m.GetBasicCredentialsAsync(It.IsAny<Uri>(), It.IsAny<String>())).ReturnsAsync((TestCredential)null);
         }
 
-        private static void MockValidRemoteAccount(Mock<IBitbucketRestApi> bitbucketApi, InputArguments input, string password, bool twoFAEnabled)
+        private static void MockRemoteBasicAuthAccountIsValid(Mock<IBitbucketRestApi> bitbucketApi, InputArguments input, string password, bool twoFAEnabled)
         {
             var userInfo = new UserInfo() { IsTwoFactorAuthenticationEnabled = twoFAEnabled };
-            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
+            // Basic
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, BitbucketHostProvider.USE_BASIC_TOKEN)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
+
+        }
+            
+        private static void MockRemoteBasicAuthAccountIsValidRequires2FA(Mock<IBitbucketRestApi> bitbucketApi, InputArguments input, string password)
+        {
+            MockRemoteBasicAuthAccountIsValid(bitbucketApi, input, password, true);
         }
 
-        private static void MockStoredBasicAccount(TestCommandContext context, InputArguments input, string password)
+        private static void MockRemoteBasicAuthAccountIsValidNo2FA(Mock<IBitbucketRestApi> bitbucketApi, InputArguments input, string password)
+        {
+            MockRemoteBasicAuthAccountIsValid(bitbucketApi, input, password, false);
+        }
+
+        private static void MockRemoteBasicAuthAccountIsInvalid(Mock<IBitbucketRestApi> bitbucketApi, InputArguments input, string password)
+        {
+            var userInfo = new UserInfo();
+            // Basic
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, BitbucketHostProvider.USE_BASIC_TOKEN)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.Forbidden, userInfo));
+
+        }
+
+        private static void MockRemoteOAuthAccountIsValid(Mock<IBitbucketRestApi> bitbucketApi, InputArguments input, string password, bool twoFAEnabled)
+        {
+            var userInfo = new UserInfo() { IsTwoFactorAuthenticationEnabled = twoFAEnabled };
+            // OAuth
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(null, password, BitbucketHostProvider.USE_BEARER_TOKEN)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
+        }
+
+        private static void MockStoredAccount(TestCommandContext context, InputArguments input, string password)
         {
             var remoteUri = input.GetRemoteUri();
             var remoteUrl = remoteUri.AbsoluteUri.Substring(0, remoteUri.AbsoluteUri.Length - 1);
@@ -382,5 +634,7 @@ namespace Atlassian.Bitbucket.Tests
             bitbucketApi.Setup(x => x.GetUserInformationAsync("jsquire", "password1", false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
             context.CredentialStore.Add("https://bitbucket.org", new TestCredential("https://bitbucket.org", "jsquire", "password1"));
         }
+
+        #endregion
     }
 }

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -156,7 +156,7 @@ namespace Atlassian.Bitbucket.Tests
 
             MockUserEntersValidBasicCredentials(bitbucketAuthentication, input, password);
 
-            if(BITBUCKET_DOT_ORG_HOST.Equals(host)) 
+            if (BITBUCKET_DOT_ORG_HOST.Equals(host)) 
             {
                 MockRemoteOAuthAccountIsValid(bitbucketApi, input, password, true);
             }
@@ -190,12 +190,6 @@ namespace Atlassian.Bitbucket.Tests
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
 
-            //if (userEntersCredentials.HasValue && !userEntersCredentials.Value)
-            //{
-            //    Assert.ThrowsAsync<Exception>(async () => await provider.GetCredentialAsync(input));
-            //    return;
-            //}
-
             var credential = provider.GetCredentialAsync(input);
 
             VerifyOAuthFlowRan(password, false, true, input, credential, null);
@@ -222,7 +216,6 @@ namespace Atlassian.Bitbucket.Tests
             MockUserEntersValidBasicCredentials(bitbucketAuthentication, input, password);
             MockRemoteBasicAuthAccountIsValidRequires2FA(bitbucketApi, input, password);
             bitbucketAuthentication.Setup(m => m.ShowOAuthRequiredPromptAsync()).ReturnsAsync(true);
-            //MockRemoteValidRefreshToken();
 
             var provider = new BitbucketHostProvider(context, bitbucketAuthentication.Object, bitbucketApi.Object);
 
@@ -536,25 +529,25 @@ namespace Atlassian.Bitbucket.Tests
         private void VerifyValidateBasicAuthCredentialsNeverRan() 
         {
             // never check username/password works
-            bitbucketApi.Verify(m => m.GetUserInformationAsync(It.IsAny<string>(), It.IsAny<string>(), BitbucketHostProvider.USE_BASIC_TOKEN), Times.Never);
+            bitbucketApi.Verify(m => m.GetUserInformationAsync(It.IsAny<string>(), It.IsAny<string>(), false), Times.Never);
         }
 
         private void VerifyValidateBasicAuthCredentialsRan() 
         {
             // check username/password works
-            bitbucketApi.Verify(m => m.GetUserInformationAsync(It.IsAny<string>(), It.IsAny<string>(), BitbucketHostProvider.USE_BASIC_TOKEN), Times.Once);
+            bitbucketApi.Verify(m => m.GetUserInformationAsync(It.IsAny<string>(), It.IsAny<string>(), false), Times.Once);
         }
 
         private void VerifyValidateOAuthCredentialsNeverRan() 
         {
             // never check username/password works
-            bitbucketApi.Verify(m => m.GetUserInformationAsync(null, It.IsAny<string>(), BitbucketHostProvider.USE_BASIC_TOKEN), Times.Never);
+            bitbucketApi.Verify(m => m.GetUserInformationAsync(null, It.IsAny<string>(), false), Times.Never);
         }
 
         private void VerifyValidateOAuthCredentialsRan() 
         {
             // check username/password works
-            bitbucketApi.Verify(m => m.GetUserInformationAsync(null, It.IsAny<string>(), BitbucketHostProvider.USE_BEARER_TOKEN), Times.Once);
+            bitbucketApi.Verify(m => m.GetUserInformationAsync(null, It.IsAny<string>(), true), Times.Once);
         }
 
         private void MockStoredOAuthAccount(TestCommandContext context, InputArguments input)
@@ -592,7 +585,7 @@ namespace Atlassian.Bitbucket.Tests
         {
             var userInfo = new UserInfo() { IsTwoFactorAuthenticationEnabled = twoFAEnabled };
             // Basic
-            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, BitbucketHostProvider.USE_BASIC_TOKEN)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
 
         }
             
@@ -610,7 +603,7 @@ namespace Atlassian.Bitbucket.Tests
         {
             var userInfo = new UserInfo();
             // Basic
-            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, BitbucketHostProvider.USE_BASIC_TOKEN)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.Forbidden, userInfo));
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.Forbidden, userInfo));
 
         }
 
@@ -618,7 +611,7 @@ namespace Atlassian.Bitbucket.Tests
         {
             var userInfo = new UserInfo() { IsTwoFactorAuthenticationEnabled = twoFAEnabled };
             // OAuth
-            bitbucketApi.Setup(x => x.GetUserInformationAsync(null, password, BitbucketHostProvider.USE_BEARER_TOKEN)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(null, password, true)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
         }
 
         private static void MockStoredAccount(TestCommandContext context, InputArguments input, string password)

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketOauth2ClientTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketOauth2ClientTest.cs
@@ -79,7 +79,7 @@ namespace Atlassian.Bitbucket.Tests
             Assert.Equal(refresh_token, result.RefreshToken);
             IEnumerable<char> tokenType = null;
             Assert.Equal(tokenType, result.TokenType);
-            Assert.Equal(null, result.Scopes);
+            Assert.Null(result.Scopes);
         }
 
         private void VerifyAuthorizationCodeResult(OAuth2AuthorizationCodeResult result)

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketOauth2ClientTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketOauth2ClientTest.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager;
+using GitCredentialManager.Authentication.OAuth;
+using Moq;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests
+{
+    public class BitbucketOAuth2ClientTest
+    {
+        private Mock<HttpClient> httpClient = new Mock<HttpClient>(MockBehavior.Strict);
+        private Mock<ISettings> settings = new Mock<ISettings>(MockBehavior.Loose);
+        private Mock<IOAuth2WebBrowser> browser = new Mock<IOAuth2WebBrowser>(MockBehavior.Strict);
+        private Mock<IOAuth2CodeGenerator> codeGenerator = new Mock<IOAuth2CodeGenerator>(MockBehavior.Strict);
+        private IEnumerable<string> scopes = new List<string>();
+        private CancellationToken ct = new CancellationToken();
+        private Uri rootCallbackUri = new Uri("http://localhost:34106/");
+        private string nonce = "12345";
+        private string pkceCodeVerifier = "abcde";
+        private string pkceCodeChallenge = "xyz987";
+        private string authorization_code = "authorization_token";
+
+        [Fact]
+        public async Task BitbucketOAuth2Client_GetAuthorizationCodeAsync_ReturnsCode()
+        {
+            MockClientIdOverride(false, "never used");
+
+            Uri finalCallbackUri = MockFinalCallbackUri();
+
+            MockGetAuthenticationCodeAsync(finalCallbackUri, null);
+
+            MockCodeGenerator();
+
+            BitbucketOAuth2Client client = GetBitbucketOAuth2Client();
+
+            var result = await client.GetAuthorizationCodeAsync(scopes, browser.Object, ct);
+
+            VerifyAuthorizationCodeResult(result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("i234")]
+        public async Task BitbucketOAuth2Client_GetAuthorizationCodeAsync_RespectsClientIdOverride_ReturnsCode(string clientId)
+        {
+            MockClientIdOverride(clientId != null, clientId);
+
+            Uri finalCallbackUri = MockFinalCallbackUri();
+
+            MockGetAuthenticationCodeAsync(finalCallbackUri, clientId);
+
+            MockCodeGenerator();
+
+            BitbucketOAuth2Client client = GetBitbucketOAuth2Client();
+
+            var result = await client.GetAuthorizationCodeAsync(scopes, browser.Object, ct);
+
+            VerifyAuthorizationCodeResult(result);
+        }
+
+        [Fact]
+        public async Task BitbucketOAuth2Client_GetDeviceCodeAsync()
+        {
+            var client = new BitbucketOAuth2Client(httpClient.Object, settings.Object);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await client.GetDeviceCodeAsync(scopes, ct));
+        }
+
+        private void VerifyOAuth2TokenResult(OAuth2TokenResult result)
+        {
+            Assert.NotNull(result);
+            IEnumerable<char> access_token = null;
+            Assert.Equal(access_token, result.AccessToken);
+            IEnumerable<char> refresh_token = null;
+            Assert.Equal(refresh_token, result.RefreshToken);
+            IEnumerable<char> tokenType = null;
+            Assert.Equal(tokenType, result.TokenType);
+            Assert.Equal(null, result.Scopes);
+            //Assert.Equal(pkceCodeVerifier, result.ExpiresIn);
+        }
+
+        private void VerifyAuthorizationCodeResult(OAuth2AuthorizationCodeResult result)
+        {
+            Assert.NotNull(result);
+            Assert.Equal(authorization_code, result.Code);
+            Assert.Equal(rootCallbackUri, result.RedirectUri);
+            Assert.Equal(pkceCodeVerifier, result.CodeVerifier);
+        }
+
+        private BitbucketOAuth2Client GetBitbucketOAuth2Client()
+        {
+            var client = new BitbucketOAuth2Client(httpClient.Object, settings.Object);
+            client.CodeGenerator = codeGenerator.Object;
+            return client;
+        }
+
+        private void MockCodeGenerator()
+        {
+            codeGenerator.Setup(c => c.CreateNonce()).Returns(nonce);
+            codeGenerator.Setup(c => c.CreatePkceCodeVerifier()).Returns(pkceCodeVerifier);
+            codeGenerator.Setup(c => c.CreatePkceCodeChallenge(OAuth2PkceChallengeMethod.Sha256, pkceCodeVerifier)).Returns(pkceCodeChallenge);
+        }
+
+        private void MockGetAuthenticationCodeAsync(Uri finalCallbackUri, string overrideClientId)
+        {
+            var authorizationUri = new UriBuilder(BitbucketConstants.OAuth2AuthorizationEndpoint)
+            {
+                Query = "?response_type=code"
+             + "&client_id=" + (overrideClientId ?? BitbucketConstants.OAuth2ClientId)
+             + "&state=12345"
+             + "&code_challenge_method=" + OAuth2Constants.AuthorizationEndpoint.PkceChallengeMethodS256
+             + "&code_challenge=" + WebUtility.UrlEncode(pkceCodeChallenge).ToLower()
+             + "&redirect_uri=" + WebUtility.UrlEncode(rootCallbackUri.AbsoluteUri).ToLower()
+            }.Uri;
+
+            browser.Setup(b => b.GetAuthenticationCodeAsync(authorizationUri, rootCallbackUri, ct)).Returns(Task.FromResult(finalCallbackUri));
+        }
+
+        private Uri MockFinalCallbackUri()
+        {
+            var finalUri = new Uri(rootCallbackUri, "?state=" + nonce + "&code=" + authorization_code);
+            browser.Setup(b => b.UpdateRedirectUri(rootCallbackUri)).Returns(rootCallbackUri);
+            return finalUri;
+        }
+
+        private string MockeClientIdOverride(bool set)
+        {
+            return MockClientIdOverride(set, null);
+        }
+        private string MockClientIdOverride(bool set, string value)
+        {
+            settings.Setup(s => s.TryGetSetting(
+                BitbucketConstants.EnvironmentVariables.DevOAuthClientId,
+                Constants.GitConfiguration.Credential.SectionName, BitbucketConstants.GitConfiguration.Credential.DevOAuthClientId,
+                out value)).Returns(set);
+            return value;
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketOauth2ClientTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketOauth2ClientTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -81,7 +80,6 @@ namespace Atlassian.Bitbucket.Tests
             IEnumerable<char> tokenType = null;
             Assert.Equal(tokenType, result.TokenType);
             Assert.Equal(null, result.Scopes);
-            //Assert.Equal(pkceCodeVerifier, result.ExpiresIn);
         }
 
         private void VerifyAuthorizationCodeResult(OAuth2AuthorizationCodeResult result)

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketRestApiTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketRestApiTest.cs
@@ -33,7 +33,7 @@ namespace Atlassian.Bitbucket.Tests
             var httpHandler = new TestHttpMessageHandler();
             httpHandler.Setup(HttpMethod.Get, expectedRequestUri, request =>
             {
-                if(isBearerToken)
+                if (isBearerToken)
                 {
                     RestTestUtilities.AssertBearerAuth(request, password);
                 }
@@ -41,7 +41,7 @@ namespace Atlassian.Bitbucket.Tests
                 {
                     RestTestUtilities.AssertBasicAuth(request, username, password);
                 }
-                //AssertAuthCode(request, testAuthCode);
+
                 return httpResponse;
             });
             context.HttpClientFactory.MessageHandler = httpHandler;

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketRestApiTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketRestApiTest.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using GitCredentialManager.Tests;
+using GitCredentialManager.Tests.Objects;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests
+{
+    public class BitbucketRestApiTest
+    {
+        [Theory]
+        [InlineData("jsquire", "token", true)]
+        [InlineData("jsquire", "password", false)]
+        public async Task BitbucketRestApi_GetUserInformationAsync_ReturnsUserInfo_ForSuccessfulRequest(string username, string password, bool isBearerToken) 
+        {
+            var twoFactorAuthenticationEnabled = false;
+            var uuid = Guid.NewGuid();
+            var accountId = "1234";
+
+            var context = new TestCommandContext();
+
+            var expectedRequestUri = new Uri("https://api.bitbucket.org/2.0/user");
+
+            var userinfoResponseJson = $"{{ \"username\": \"{username}\" , \"has_2fa_enabled\": \"{twoFactorAuthenticationEnabled}\", \"account_id\": \"{accountId}\", \"uuid\": \"{uuid}\"}}";
+
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(userinfoResponseJson)
+            };
+
+            var httpHandler = new TestHttpMessageHandler();
+            httpHandler.Setup(HttpMethod.Get, expectedRequestUri, request =>
+            {
+                if(isBearerToken)
+                {
+                    RestTestUtilities.AssertBearerAuth(request, password);
+                }
+                else
+                {
+                    RestTestUtilities.AssertBasicAuth(request, username, password);
+                }
+                //AssertAuthCode(request, testAuthCode);
+                return httpResponse;
+            });
+            context.HttpClientFactory.MessageHandler = httpHandler;
+
+            var api = new BitbucketRestApi(context);
+            var result = await api.GetUserInformationAsync(username, password, isBearerToken);
+
+            Assert.NotNull(result);
+            Assert.Equal(username, result.Response.UserName);
+            Assert.Equal(accountId, result.Response.AccountId);
+            Assert.Equal(uuid, result.Response.Uuid);
+            Assert.Equal(twoFactorAuthenticationEnabled, result.Response.IsTwoFactorAuthenticationEnabled);
+
+            httpHandler.AssertRequest(HttpMethod.Get, expectedRequestUri, 1);
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
@@ -33,6 +33,7 @@ namespace Atlassian.Bitbucket
             public const string DevOAuthClientSecret = "GCM_DEV_BITBUCKET_CLIENTSECRET";
             public const string DevOAuthRedirectUri = "GCM_DEV_BITBUCKET_REDIRECTURI";
             public const string AuthenticationModes = "GCM_BITBUCKET_AUTHMODES";
+            public const string AlwaysRefreshCredentials = "GCM_BITBUCKET_ALWAYS_REFRESH_CREDENTIALS";
         }
 
         public static class GitConfiguration
@@ -44,6 +45,7 @@ namespace Atlassian.Bitbucket
                 public const string DevOAuthClientSecret = "bitbucketDevClientSecret";
                 public const string DevOAuthRedirectUri = "bitbucketDevRedirectUri";
                 public const string AuthenticationModes = "bitbucketAuthModes";
+                public const string AlwaysRefreshCredentials = "bitbucketAlwaysRefreshCredentials";
             }
         }
 

--- a/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -144,9 +144,6 @@ namespace Atlassian.Bitbucket
                 // There is no refresh token either because this is a non-2FA enabled account (where OAuth is not
                 // required), or because we previously erased the RT.
 
-                // Check for the presence of a credential in the store
-                string credentialService = GetServiceName(input);
-
                 if (SupportsBasicAuth(authModes))
                 {
                     _context.Trace.WriteLine("Prompt for Basic Auth...");
@@ -181,9 +178,6 @@ namespace Atlassian.Bitbucket
             {
                 _context.Trace.WriteLineSecrets($"Found stored refresh token: {{0}}", new object[] { refreshToken });
 
-                // It's very likely that any access token expired between the last time we used/stored it.
-                // To ensure the AT is as 'fresh' as it can be, always first try to use the refresh token
-                // (which lives longer) to create a new AT (and possibly also a new RT).
                 try
                 {
                     return await GetOAuthCredentialsViaRefreshFlow(input, refreshToken);

--- a/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -65,7 +65,7 @@ namespace Atlassian.Bitbucket
             }
 
             // Identify Bitbucket on-prem instances from the HTTP response using the Atlassian specific header X-AREQUESTID
-            var supported =  response.Headers.Contains("X-AREQUESTID");
+            var supported = response.Headers.Contains("X-AREQUESTID");
 
             _context.Trace.WriteLine($"Host is{(supported ? null : "n't")} supported as Bitbucket");
 
@@ -94,8 +94,8 @@ namespace Atlassian.Bitbucket
 
         private async Task<ICredential> GetStoredCredentials(InputArguments input)
         {
-            if (_context.Settings.TryGetSetting(BitbucketConstants.EnvironmentVariables.AlwaysRefreshCredentials, 
-                Constants.GitConfiguration.Credential.SectionName, BitbucketConstants.GitConfiguration.Credential.AlwaysRefreshCredentials, 
+            if (_context.Settings.TryGetSetting(BitbucketConstants.EnvironmentVariables.AlwaysRefreshCredentials,
+                Constants.GitConfiguration.Credential.SectionName, BitbucketConstants.GitConfiguration.Credential.AlwaysRefreshCredentials,
                 out string alwaysRefreshCredentials) && alwaysRefreshCredentials.ToBooleanyOrDefault(false))
             {
                 _context.Trace.WriteLine($"Ignore stored credentials");
@@ -110,14 +110,15 @@ namespace Atlassian.Bitbucket
 
             if (credentials == null)
             {
-                _context.Trace.WriteLine($"    Found none");
+                _context.Trace.WriteLine($"No stored credentials found");
                 return null;
             }
 
-            _context.Trace.WriteLineSecrets($"    Found credentials: {credentials.Account}/{{0}}", new object[] {credentials.Password});
-            
-            //check credentials are still valid
-            if (!await ValidateCredentialsWork(input, credentials, GetSupportedAuthenticationModes(targetUri))) {
+            _context.Trace.WriteLineSecrets($"Found stored credentials: {credentials.Account}/{{0}}", new object[] { credentials.Password });
+
+            // Check credentials are still valid
+            if (!await ValidateCredentialsWork(input, credentials, GetSupportedAuthenticationModes(targetUri)))
+            {
                 return null;
             }
 
@@ -139,7 +140,7 @@ namespace Atlassian.Bitbucket
             ICredential refreshToken = SupportsOAuth(authModes) ? _context.CredentialStore.Get(refreshTokenService, input.UserName) : null;
             if (refreshToken is null)
             {
-                _context.Trace.WriteLine($"    Found none");
+                _context.Trace.WriteLine($"No stored refresh token found");
                 // There is no refresh token either because this is a non-2FA enabled account (where OAuth is not
                 // required), or because we previously erased the RT.
 
@@ -156,7 +157,7 @@ namespace Atlassian.Bitbucket
                     {
                         return basicCredentials;
                     }
-                    
+
                     // Fall through to the start of the interactive OAuth authentication flow
                 }
 
@@ -178,7 +179,7 @@ namespace Atlassian.Bitbucket
             }
             else
             {
-                _context.Trace.WriteLine($"    Found refresh token: {refreshToken} ");
+                _context.Trace.WriteLineSecrets($"Found stored refresh token: {{0}}", new object[] { refreshToken });
 
                 // It's very likely that any access token expired between the last time we used/stored it.
                 // To ensure the AT is as 'fresh' as it can be, always first try to use the refresh token
@@ -379,7 +380,7 @@ namespace Atlassian.Bitbucket
 
         private async Task<bool> RequiresTwoFactorAuthenticationAsync(ICredential credentials, AuthenticationModes authModes)
         {
-            _context.Trace.WriteLineSecrets($"Check if 2FA si required for credentials ({credentials.Account}/{{0}}) {authModes} ...", new object[] {credentials.Password});
+            _context.Trace.WriteLineSecrets($"Check if 2FA si required for credentials ({credentials.Account}/{{0}}) {authModes} ...", new object[] { credentials.Password });
 
             if (!SupportsOAuth(authModes))
             {
@@ -407,7 +408,7 @@ namespace Atlassian.Bitbucket
             }
         }
 
-        private async Task<bool> ValidateCredentialsWork(InputArguments input, ICredential credentials, AuthenticationModes authModes) 
+        private async Task<bool> ValidateCredentialsWork(InputArguments input, ICredential credentials, AuthenticationModes authModes)
         {
             if (credentials == null)
             {
@@ -419,7 +420,7 @@ namespace Atlassian.Bitbucket
             // This would be more efficient than having to make REST API calls to check.
 
             var targetUri = input.GetRemoteUri();
-            _context.Trace.WriteLineSecrets($"Validate credentials ({credentials.Account}/{{0}}) are fresh for {targetUri} ...", new object[] {credentials.Password});
+            _context.Trace.WriteLineSecrets($"Validate credentials ({credentials.Account}/{{0}}) are fresh for {targetUri} ...", new object[] { credentials.Password });
 
             if (!IsBitbucketOrg(targetUri))
             {
@@ -440,7 +441,7 @@ namespace Atlassian.Bitbucket
                     _context.Trace.WriteLine("Validated existing credentials using OAuth");
                     return true;
                 }
-                catch(Exception)
+                catch (Exception)
                 {
                     _context.Trace.WriteLine("Failed to validate existing credentials using OAuth");
                 }
@@ -454,7 +455,7 @@ namespace Atlassian.Bitbucket
                     _context.Trace.WriteLine("Validated existing credentials using BasicAuth");
                     return true;
                 }
-                catch(Exception)
+                catch (Exception)
                 {
                     _context.Trace.WriteLine("Failed to validate existing credentials using Basic Auth");
                     return false;
@@ -475,7 +476,7 @@ namespace Atlassian.Bitbucket
 
             // The refresh token key never includes the path component.
             // Instead we use the path component to specify this is the "refresh_token".
-            Uri uri = new UriBuilder(baseUri) {Path = "/refresh_token"}.Uri;
+            Uri uri = new UriBuilder(baseUri) { Path = "/refresh_token" }.Uri;
 
             return uri.AbsoluteUri.TrimEnd('/');
         }

--- a/src/shared/GitHub.Tests/GitHubRestApiTests.cs
+++ b/src/shared/GitHub.Tests/GitHubRestApiTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using GitCredentialManager.Tests;
 using GitCredentialManager.Tests.Objects;
 using Xunit;
 
@@ -73,7 +74,7 @@ namespace GitHub.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
             {
-                AssertBasicAuth(request, testUserName, testPassword);
+                RestTestUtilities.AssertBasicAuth(request, testUserName, testPassword);
                 AssertAuthCode(request, testAuthCode);
                 return httpResponse;
             });
@@ -112,7 +113,7 @@ namespace GitHub.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
             {
-                AssertBasicAuth(request, testUserName, testPassword);
+                RestTestUtilities.AssertBasicAuth(request, testUserName, testPassword);
                 AssertAuthCode(request, testAuthCode);
                 return httpResponse;
             });
@@ -150,7 +151,7 @@ namespace GitHub.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
             {
-                AssertBasicAuth(request, testUserName, testPassword);
+                RestTestUtilities.AssertBasicAuth(request, testUserName, testPassword);
                 AssertAuthCode(request, testAuthCode);
                 return httpResponse;
             });
@@ -184,7 +185,7 @@ namespace GitHub.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
             {
-                AssertBasicAuth(request, testUserName, testPassword);
+                RestTestUtilities.AssertBasicAuth(request, testUserName, testPassword);
                 AssertAuthCode(request, null);
                 return httpResponse;
             });
@@ -216,7 +217,7 @@ namespace GitHub.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
             {
-                AssertBasicAuth(request, testUserName, testPassword);
+                RestTestUtilities.AssertBasicAuth(request, testUserName, testPassword);
                 AssertAuthCode(request, null);
                 return httpResponse;
             });
@@ -250,7 +251,7 @@ namespace GitHub.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
             {
-                AssertBasicAuth(request, testUserName, testOAuthToken);
+                RestTestUtilities.AssertBasicAuth(request, testUserName, testOAuthToken);
                 AssertAuthCode(request, null);
                 return httpResponse;
             });
@@ -287,7 +288,7 @@ namespace GitHub.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
             {
-                AssertBasicAuth(request, testUserName, testPassword);
+                RestTestUtilities.AssertBasicAuth(request, testUserName, testPassword);
                 AssertAuthCode(request, testAuthCode);
                 return httpResponse;
             });
@@ -322,7 +323,7 @@ namespace GitHub.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
             {
-                AssertBasicAuth(request, testUserName, testPassword);
+                RestTestUtilities.AssertBasicAuth(request, testUserName, testPassword);
                 AssertAuthCode(request, testAuthCode);
                 return httpResponse;
             });
@@ -359,7 +360,7 @@ namespace GitHub.Tests
             var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
             httpHandler.Setup(HttpMethod.Post, expectedRequestUri, request =>
             {
-                AssertBasicAuth(request, testUserName, testPassword);
+                RestTestUtilities.AssertBasicAuth(request, testUserName, testPassword);
                 AssertAuthCode(request, testAuthCode);
                 return httpResponse;
             });
@@ -374,16 +375,6 @@ namespace GitHub.Tests
         }
 
         #region Helpers
-
-        private static void AssertBasicAuth(HttpRequestMessage request, string userName, string password)
-        {
-            string expectedBasicValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{userName}:{password}"));
-
-            AuthenticationHeaderValue authHeader = request.Headers.Authorization;
-            Assert.NotNull(authHeader);
-            Assert.Equal("Basic", authHeader.Scheme);
-            Assert.Equal(expectedBasicValue, authHeader.Parameter);
-        }
 
         private void AssertAuthCode(HttpRequestMessage request, string authCode)
         {

--- a/src/shared/TestInfrastructure/RestTestUtilities.cs
+++ b/src/shared/TestInfrastructure/RestTestUtilities.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Xunit;
+
+namespace GitCredentialManager.Tests
+{
+    public static class RestTestUtilities
+    {
+        public static void AssertBasicAuth(HttpRequestMessage request, string userName, string password)
+        {
+            string expectedBasicValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{userName}:{password}"));
+
+            AuthenticationHeaderValue authHeader = request.Headers.Authorization;
+            Assert.NotNull(authHeader);
+            Assert.Equal("Basic", authHeader.Scheme);
+            Assert.Equal(expectedBasicValue, authHeader.Parameter);
+        }
+
+        public static void AssertBearerAuth(HttpRequestMessage request, string token)
+        {
+            AuthenticationHeaderValue authHeader = request.Headers.Authorization;
+            Assert.NotNull(authHeader);
+            Assert.Equal("Bearer", authHeader.Scheme);
+            Assert.Equal(token, authHeader.Parameter);
+        }
+    }
+}


### PR DESCRIPTION
### Problem

The current implementation of OAuth2 support for Bitbucket.org in GCM assumes any stored access_token is likely to have expired.

This is based on the _outdated_ fact that Bitbucket.org access_tokens expire after 1 hour and the assumption that users are running remote Git commands at a frequency less than once per 1 hr.

In more detail the current process relies on using a much longer living refresh_token to refresh the access_token before returning the new value to Git. This effectively means

- the access_token returned to Git is _never_ the stored version
- for Bitbucket.org/OAuth2 GCM will run an OAuth2 refresh flow for every GET request

This means expired access_tokens are _never_ returned to Git and therefore the Git process should _never_ fail due to an expired access_token.

This overhead in GCM, running the refresh flow, should be more efficient than allowing Git to GET expired credentials from GCM, try to use the, fail, request ERASE from GCM, then repeat with a fresh GCM to get fresh credentials when the user is running remote  Git commands at a frequency less than once per 1 hr.


But ...

If the user is running remote Git commands at a frequency of more than once per 1hr they are incurring the OAuth refresh flow overhead everytime when they already have a valid access_token.

And ...

Bitbucket.org has revised the lifetime of access_tokens, increasing it from 1hr to 2 hrs. https://community.developer.atlassian.com/t/oauth2-token-lifetime-expiration-clarification/22136

This changes the performance balance. its now more likely GCM is ignoring valid access_tokens and incurring the OAuth2 refresh flow overhead 

### Solution

Flip the assumption around. 

Now assume that stored access_tokens are possibly still valid, verify if they are still valid and if they are return them directly to Git.

GCM does not store lifespan metadata about access_tokens, so there is no simple check to determine if they have expired, as such it is necessary to do. simple REST API call to Bitbucket.org using the access_token for authentication.

If that works, the access_token is assumed to be valid and is returned to Git.

If that fails GCM will try to run the OAuth refresh flow and generate and store a new access_token and return it to Git.

If that fails GCM will delete the refresh_token and return nothing to Git.Git's process will fail and when Git next requests to GET the credentials a new interactive process will be run by GCM to generate new credentials.

There will still be an overhead due to the verification of stored access_tokens but this requires fewer HTTP calls than the full refresh flow so will be quicker.

This verification is only applied to Bitbucket.org credentials, not to Bitbucket DC credentials.

It is possible that if the user is carrying our remote Git commands less frequently than once every 2 hours that it is better to keep the old process, of always running the OAuth refresh flow, in this case the configuration options `GCM_BITBUCKET_ALWAYS_REFRESH_CREDENTIALS`/`credential.bitbucketAlwaysRefreshCredentials` can be used to enable that process. **Be aware** for Basic Auth this means the user has to re-enter credentials everytime.


### Testing

I'm running this manually at the moment.

I've refactored some code and made use of the new code coverage tools to significantly increase the levels of test coverage for Bitbucket code.