### PR TITLE
Show GitHub terminal prompts when no GUI session

### DIFF
--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -79,7 +79,7 @@ namespace GitHub
                 throw new ArgumentException(@$"Must specify at least one {nameof(AuthenticationModes)}", nameof(modes));
             }
 
-            if (TryFindHelperExecutablePath(out string helperPath))
+            if (Context.SessionManager.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
             {
                 var promptArgs = new StringBuilder("prompt");
                 if (modes == AuthenticationModes.All)
@@ -207,7 +207,7 @@ namespace GitHub
         {
             ThrowIfUserInteractionDisabled();
 
-            if (TryFindHelperExecutablePath(out string helperPath))
+            if (Context.SessionManager.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
             {
                 var args = new StringBuilder("2fa");
                 if (isSms) args.Append(" --sms");


### PR DESCRIPTION
Show the terminal/TTY based prompts when there is no desktop/GUI sessions present for GitHub.

Currently the Bitbucket and Microsoft auth stacks correctly detect the lack of a desktop session and use terminal prompts - GitHub does not.

Without this change, SSH-ing in to a machine we'd still try and show a UI prompt where there is no way to interact with it!

Fixes #453 