### PR TITLE
Fix Debian package build script copy command

### DIFF
--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -176,13 +176,9 @@ EOF
 # Copy all binaries and shared libraries to target installation location
 cp -R "$PAYLOAD"/* "$INSTALL_TO" || exit 1
 
-# Create symlinks
+# Create symlink
 ln -s -r "$INSTALL_TO/git-credential-manager-core" \
     "$LINK_TO/git-credential-manager-core" || exit 1
-ln -s -r "$INSTALL_TO/Atlassian.Bitbucket.UI" \
-    "$LINK_TO/Atlassian.Bitbucket.UI" || exit 1
-ln -s -r "$INSTALL_TO/GitHub.UI" \
-    "$LINK_TO/GitHub.UI" || exit 1
 
 dpkg-deb --build "$DEBROOT" "$DEBPKG" || exit 1
 

--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -174,7 +174,7 @@ Description: Cross Platform Git Credential Manager Core command line utility.
 EOF
 
 # Copy all binaries and shared libraries to target installation location
-cp -R "$PAYLOAD" "$INSTALL_TO" || exit 1
+cp -R "$PAYLOAD"/* "$INSTALL_TO" || exit 1
 
 # Create symlinks
 ln -s -r "$INSTALL_TO/git-credential-manager-core" \


### PR DESCRIPTION
The Debian package build script incorrectly copies the containing directory to the destination tree rather than just the contents recursively. We also create extra symlinks for the UI helpers which isn't needed.

This means we end up with:

```text
usr
└── local
    ├── bin
*-> │   ├── Atlassian.Bitbucket.UI -> ../share/gcm-core/Atlassian.Bitbucket.UI
*-> │   ├── git-credential-manager-core -> ../share/gcm-core/git-credential-manager-core
    │   └── GitHub.UI -> ../share/gcm-core/GitHub.UI
    └── share
        └── gcm-core
 ** --->    └── Release
                ├── Atlassian.Bitbucket.UI
                ├── git-credential-manager-core
                ├── GitHub.UI
                ├── libHarfBuzzSharp.so
                ├── libSkiaSharp.so
                └── NOTICE
```

..rather than:

```text
usr
└── local
    ├── bin
    │   └── git-credential-manager-core -> ../share/gcm-core/git-credential-manager-core
    └── share
        └── gcm-core
            ├── Atlassian.Bitbucket.UI
            ├── git-credential-manager-core
            ├── GitHub.UI
            ├── libHarfBuzzSharp.so
            ├── libSkiaSharp.so
            └── NOTICE
```

Since the symlinks are wrong, the installation is broken.