### PR TITLE
Remove 'core' from docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/auth-problem.md
+++ b/.github/ISSUE_TEMPLATE/auth-problem.md
@@ -6,7 +6,7 @@ labels: 'auth-issue'
 assignees: ''
 ---
 
-**Which version of GCM Core are you using?**
+**Which version of GCM are you using?**
 
 From a terminal, run `git-credential-manager-core --version` and paste the output.
 

--- a/.github/ISSUE_TEMPLATE/experimental.md
+++ b/.github/ISSUE_TEMPLATE/experimental.md
@@ -6,7 +6,7 @@ labels: 'experimental'
 assignees: ''
 ---
 
-**Which version of GCM Core are you using?**
+**Which version of GCM are you using?**
 
 From a terminal, run `git-credential-manager-core --version` and paste the output.
 

--- a/.github/ISSUE_TEMPLATE/feature-req.md
+++ b/.github/ISSUE_TEMPLATE/feature-req.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: A suggestion for a new feature in Git Credential Manager Core.
+about: A suggestion for a new feature in Git Credential Manager.
 title: ''
 labels: 'enhancement'
 assignees: ''

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,4 @@
-name: GCM-Core
+name: GCM
 
 on:
   workflow_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 ## Contributing
 
-[issue]: https://github.com/microsoft/Git-Credential-Manager-Core/issues 
-[fork]: https://github.com/microsoft/Git-Credential-Manager-Core/fork
-[pr]: https://github.com/microsoft/Git-Credential-Manager-Core/compare
+[issue]: https://github.com/GitCredentialManager/git-credential-manager/issues 
+[fork]: https://github.com/GitCredentialManager/git-credential-manager/fork
+[pr]: https://github.com/GitCredentialManager/git-credential-manager/compare
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Git Credential Manager Core
+Git Credential Manager
 Copyright © GitHub, Inc. and contributors
 
 MIT License

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
 NOTICES AND INFORMATION
 Do Not Translate or Localize
 
-This repository for Git Credential Manager Core includes material from the
+This repository for Git Credential Manager includes material from the
 projects listed below.
 
 --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Git Credential Manager
 
-[![Build Status](https://github.com/microsoft/Git-Credential-Manager-Core/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/microsoft/Git-Credential-Manager-Core/actions/workflows/continuous-integration.yml)
+[![Build Status](https://github.com/GitCredentialManager/git-credential-manager/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/GitCredentialManager/git-credential-manager/actions/workflows/continuous-integration.yml)
 
 ---
 
-[Git Credential Manager](https://github.com/microsoft/Git-Credential-Manager-Core) (GCM) is a secure Git credential helper built on [.NET](https://dotnet.microsoft.com) that runs on Windows, macOS, and Linux.
+[Git Credential Manager](https://github.com/GitCredentialManager/git-credential-manager) (GCM) is a secure Git credential helper built on [.NET](https://dotnet.microsoft.com) that runs on Windows, macOS, and Linux.
 
 Compared to Git's [built-in credential helpers]((https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage)) (Windows: wincred, macOS: osxkeychain, Linux: gnome-keyring/libsecret) which provides single-factor authentication support working on any HTTP-enabled Git repository, GCM provides multi-factor authentication support for [Azure DevOps](https://dev.azure.com/), Azure DevOps Server (formerly Team Foundation Server), GitHub, and Bitbucket.
 
@@ -72,7 +72,7 @@ brew uninstall --cask git-credential-manager-core
 
 ### macOS Package
 
-We also provide a [.pkg installer](https://github.com/microsoft/Git-Credential-Manager-Core/releases/latest) with each release. To install, double-click the installation package and follow the instructions presented.
+We also provide a [.pkg installer](https://github.com/GitCredentialManager/git-credential-manager/releases/latest) with each release. To install, double-click the installation package and follow the instructions presented.
 
 #### Uninstall
 
@@ -90,7 +90,7 @@ sudo /usr/local/share/gcm-core/uninstall.sh
 
 #### Ubuntu/Debian distributions
 
-Download the latest [.deb package](https://github.com/microsoft/Git-Credential-Manager-Core/releases/latest), and run the following:
+Download the latest [.deb package](https://github.com/GitCredentialManager/git-credential-manager/releases/latest), and run the following:
 
 ```shell
 sudo dpkg -i <path-to-package>
@@ -99,7 +99,7 @@ git-credential-manager-core configure
 
 #### Other distributions
 
-Download the latest [tarball](https://github.com/microsoft/Git-Credential-Manager-Core/releases/latest), and run the following:
+Download the latest [tarball](https://github.com/GitCredentialManager/git-credential-manager/releases/latest), and run the following:
 
 ```shell
 tar -xvf <path-to-tarball> -C /usr/local/bin
@@ -118,7 +118,7 @@ GCM is included with [Git for Windows](https://gitforwindows.org/), and the late
 
 #### Standalone installation
 
-You can also download the [latest installer](https://github.com/microsoft/Git-Credential-Manager-Core/releases/latest) for Windows to install GCM standalone.
+You can also download the [latest installer](https://github.com/GitCredentialManager/git-credential-manager/releases/latest) for Windows to install GCM standalone.
 
 **:warning: Important :warning:**
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ tar -xvf <path-to-tarball> -C /usr/local/bin
 git-credential-manager-core configure
 ```
 
-**Note:** all Linux distributions [require additional configuration](https://aka.ms/gcmcore-credstores) to use GCM.
+**Note:** all Linux distributions [require additional configuration](https://aka.ms/gcm/credstores) to use GCM.
 
 ---
 
@@ -180,7 +180,7 @@ Read full command line usage [here](docs/usage.md).
 
 ### Configuring a proxy
 
-See detailed information [here](https://aka.ms/gcmcore-httpproxy).
+See detailed information [here](https://aka.ms/gcm/httpproxy).
 
 ## Additional Resources
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# Git Credential Manager Core
+# Git Credential Manager
 
 [![Build Status](https://github.com/microsoft/Git-Credential-Manager-Core/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/microsoft/Git-Credential-Manager-Core/actions/workflows/continuous-integration.yml)
 
 ---
 
-[Git Credential Manager Core](https://github.com/microsoft/Git-Credential-Manager-Core) (GCM Core) is a secure Git credential helper built on [.NET](https://dotnet.microsoft.com) that runs on Windows, macOS, and Linux.
+[Git Credential Manager](https://github.com/microsoft/Git-Credential-Manager-Core) (GCM) is a secure Git credential helper built on [.NET](https://dotnet.microsoft.com) that runs on Windows, macOS, and Linux.
 
-Compared to Git's [built-in credential helpers]((https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage)) (Windows: wincred, macOS: osxkeychain, Linux: gnome-keyring/libsecret) which provides single-factor authentication support working on any HTTP-enabled Git repository, GCM Core provides multi-factor authentication support for [Azure DevOps](https://dev.azure.com/), Azure DevOps Server (formerly Team Foundation Server), GitHub, and Bitbucket.
+Compared to Git's [built-in credential helpers]((https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage)) (Windows: wincred, macOS: osxkeychain, Linux: gnome-keyring/libsecret) which provides single-factor authentication support working on any HTTP-enabled Git repository, GCM provides multi-factor authentication support for [Azure DevOps](https://dev.azure.com/), Azure DevOps Server (formerly Team Foundation Server), GitHub, and Bitbucket.
 
-Git Credential Manager Core (GCM Core) replaces the .NET Framework-based [Git Credential Manager for Windows](https://github.com/microsoft/Git-Credential-Manager-for-Windows) (GCM), and the Java-based [Git Credential Manager for Mac and Linux](https://github.com/microsoft/Git-Credential-Manager-for-Mac-and-Linux) (Java GCM), providing a consistent authentication experience across all platforms.
+Git Credential Manager (GCM) replaces the .NET Framework-based [Git Credential Manager for Windows](https://github.com/microsoft/Git-Credential-Manager-for-Windows) (GCM), and the Java-based [Git Credential Manager for Mac and Linux](https://github.com/microsoft/Git-Credential-Manager-for-Mac-and-Linux) (Java GCM), providing a consistent authentication experience across all platforms.
 
 ## Current status
 
-Git Credential Manager Core is currently available for Windows, macOS, and Linux. GCM only works with HTTP(S) remotes; you can still use Git with SSH:
+Git Credential Manager is currently available for Windows, macOS, and Linux. GCM only works with HTTP(S) remotes; you can still use Git with SSH:
 
 - [Azure DevOps SSH](https://docs.microsoft.com/en-us/azure/devops/repos/git/use-ssh-keys-to-authenticate?view=azure-devops)
 - [GitHub SSH](https://help.github.com/en/articles/connecting-to-github-with-ssh)
@@ -58,7 +58,7 @@ brew upgrade git-credential-manager-core
 
 #### Git Credential Manager for Mac and Linux (Java-based GCM)
 
-If you have an existing installation of the 'Java GCM' on macOS and you have installed this using Homebrew, this installation will be unlinked (`brew unlink git-credential-manager`) when GCM Core is installed.
+If you have an existing installation of the 'Java GCM' on macOS and you have installed this using Homebrew, this installation will be unlinked (`brew unlink git-credential-manager`) when GCM is installed.
 
 #### Uninstall
 
@@ -106,23 +106,23 @@ tar -xvf <path-to-tarball> -C /usr/local/bin
 git-credential-manager-core configure
 ```
 
-**Note:** all Linux distributions [require additional configuration](https://aka.ms/gcmcore-credstores) to use GCM Core.
+**Note:** all Linux distributions [require additional configuration](https://aka.ms/gcmcore-credstores) to use GCM.
 
 ---
 
 ### Windows
 
-GCM Core is included with [Git for Windows](https://gitforwindows.org/), and the latest version is included in each new Git for Windows release. This is the preferred way to install GCM Core on Windows. During installation you will be asked to select a credential helper, with GCM Core being set as the default.
+GCM is included with [Git for Windows](https://gitforwindows.org/), and the latest version is included in each new Git for Windows release. This is the preferred way to install GCM on Windows. During installation you will be asked to select a credential helper, with GCM being set as the default.
 
 ![image](https://user-images.githubusercontent.com/5658207/140082529-1ac133c1-0922-4a24-af03-067e27b3988b.png)
 
 #### Standalone installation
 
-You can also download the [latest installer](https://github.com/microsoft/Git-Credential-Manager-Core/releases/latest) for Windows to install GCM Core standalone.
+You can also download the [latest installer](https://github.com/microsoft/Git-Credential-Manager-Core/releases/latest) for Windows to install GCM standalone.
 
 **:warning: Important :warning:**
 
-Installing GCM Core as a standalone package on Windows will forcibly override the version of GCM Core that is bundled with Git for Windows, **even if the version bundled with Git for Windows is a later version**.
+Installing GCM as a standalone package on Windows will forcibly override the version of GCM that is bundled with Git for Windows, **even if the version bundled with Git for Windows is a later version**.
 
 There are two flavors of standalone installation on Windows:
 
@@ -138,23 +138,23 @@ To install, double-click the desired installation package and follow the instruc
 
 #### Uninstall (Windows 10)
 
-To uninstall, open the Settings app and navigate to the Apps section. Select "Git Credential Manager Core" and click "Uninstall".
+To uninstall, open the Settings app and navigate to the Apps section. Select "Git Credential Manager" and click "Uninstall".
 
 #### Uninstall (Windows 7-8.1)
 
-To uninstall, open Control Panel and navigate to the Programs and Features screen. Select "Git Credential Manager Core" and click "Remove".
+To uninstall, open Control Panel and navigate to the Programs and Features screen. Select "Git Credential Manager" and click "Remove".
 
 #### Windows Subsystem for Linux (WSL)
 
-Git Credential Manager Core can be used with the [Windows Subsystem for Linux
+Git Credential Manager can be used with the [Windows Subsystem for Linux
 (WSL)](https://aka.ms/wsl) to enable secure authentication of your remote Git
 repositories from inside of WSL.
 
-[Please see the GCM Core on WSL docs](docs/wsl.md) for more information.
+[Please see the GCM on WSL docs](docs/wsl.md) for more information.
 
 ## Supported Git versions
 
-Git Credential Manager Core tries to be compatible with the broadest set of Git
+Git Credential Manager tries to be compatible with the broadest set of Git
 versions (within reason). However there are some know problematic releases of
 Git that are not compatible.
 
@@ -170,11 +170,11 @@ Git that are not compatible.
 
 ## How to use
 
-Once it's installed and configured, Git Credential Manager Core is called implicitly by Git.
-You don't have to do anything special, and GCM Core isn't intended to be called directly by the user.
+Once it's installed and configured, Git Credential Manager is called implicitly by Git.
+You don't have to do anything special, and GCM isn't intended to be called directly by the user.
 For example, when pushing (`git push`) to [Azure DevOps](https://dev.azure.com), [Bitbucket](https://bitbucket.org), or [GitHub](https://github.com), a window will automatically open and walk you through the sign-in process.
 (This process will look slightly different for each Git host, and even in some cases, whether you've connected to an on-premises or cloud-hosted Git host.)
-Later Git commands in the same repository will re-use existing credentials or tokens that GCM Core has stored for as long as they're valid.
+Later Git commands in the same repository will re-use existing credentials or tokens that GCM has stored for as long as they're valid.
 
 Read full command line usage [here](docs/usage.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@
 +--------------------------------------+  +------------------------------------+
 ```
 
-Git Credential Manager Core (GCM Core) is built to be Git host and platform/OS
+Git Credential Manager (GCM) is built to be Git host and platform/OS
 agonstic. Most of the shared logic (command execution, the abstract platform
 subsystems, etc) can be found in the `Core` class
 library (C#). The library targets .NET Standard as well as .NET Framework.
@@ -55,7 +55,7 @@ library (C#). The library targets .NET Standard as well as .NET Framework.
 > See [this](https://github.com/microsoft/Git-Credential-Manager-Core/issues/113)
 > issue for more information.
 
-The entry-point for GCM Core can be found in the `Git-Credential-Manager`
+The entry-point for GCM can be found in the `Git-Credential-Manager`
 project, a console application that targets both .NET and .NET Framework.
 This project emits the `git-credential-manager-core(.exe)` executable, and
 contains very little code - registration of all supported host providers and
@@ -88,14 +88,14 @@ issue for up-to-date progress on this effort.
 
 For authentication using Microsoft Accounts or Azure Active Directory, things
 are a little different. The `MicrosoftAuthentication` component is present in
-the core `Core` assembly, rather than bundled with a
+the `Core` core assembly, rather than bundled with a
 specific host provider. This was done to allow any service that may wish to in
 the future integrate with Microsoft Accounts or Azure Active Directory can make
 use of this reusable authentication component.
 
 ## Asynchronous programming
 
-GCM Core makes use of the `async`/`await` model of .NET and C# in almost all
+GCM makes use of the `async`/`await` model of .NET and C# in almost all
 parts of the codebase where appropriate as usually requests end up going to the
 network at some point.
 
@@ -142,10 +142,10 @@ network at some point.
                              +---------------+
 ```
 
-Git Credential Manager Core maintains a set of known commands including
+Git Credential Manager maintains a set of known commands including
 `Get|Store|EraseCommand`, as well as commands for install and help/usage.
 
-GCM Core also maintains a set of known, registered host providers that implement
+GCM also maintains a set of known, registered host providers that implement
 the `IHostProvider` interface. Providers register themselves by adding an
 instance of the provider to the `Application` object via the `RegisterProvider`
 method [in `Core.Program`](../src/shared/Git-Credential-Manager/Program.cs).
@@ -154,7 +154,7 @@ HTTP-based remotes as a catch-all, and provide basic username/password auth and
 detect the presence of Windows Integrated Authentication (Kerberos, NTLM,
 Negotiate) support (1).
 
-For each invocation of GCM Core, the first argument on the command-line is
+For each invocation of GCM, the first argument on the command-line is
 matched against the known commands and if there is a successful match, the input
 from Git (over standard input) is deserialized and the command is executed (2).
 
@@ -174,7 +174,7 @@ context to complete the requested operation (5).
 Once a credential has been created, retrieved, stored or erased, the host
 provider returns the credential (for `get` operations only) to the calling
 command (6). The credential is then serialized and returned to Git over standard
-output (7) and GCM Core terminates with a successful exit code.
+output (7) and GCM terminates with a successful exit code.
 
 ## Host provider
 
@@ -247,7 +247,7 @@ systems and platforms.
 Component|Description
 -|-
 CredentialStore|A secure operating system controlled location for storing and retrieving `ICredential` objects.
-Settings|Abstraction over all GCM Core settings.
+Settings|Abstraction over all GCM settings.
 Streams|Abstraction over standard input, output and error streams connected to the parent process (typically Git).
 Terminal|Provides interactions with an attached terminal, if it exists.
 SessionManager|Provides information about the current user session.
@@ -260,7 +260,7 @@ SystemPrompts|Provides services for showing system/OS native credential prompts.
 
 ## Error handling and tracing
 
-GCM Core operates a 'fail fast' approach to unrecoverable errors. This usually
+GCM operates a 'fail fast' approach to unrecoverable errors. This usually
 means throwing an `Exception` which will propagate up to the entry-point and be
 caught, a non-zero exit code returned, and the error message printed with the
 "fatal:" prefix. For errors originating from interop/native code, you should
@@ -276,4 +276,4 @@ operation/authentication.
 
 The `ITrace` component can be found on the `ICommandContext` object or passed in
 directly to some constructors. Verbose and diagnostic information is be written
-to the trace object in most places of GCM Core.
+to the trace object in most places of GCM.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ library (C#). The library targets .NET Standard as well as .NET Framework.
 > our own browser pop-up handling code on .NET meaning both Windows and
 > Mac. We haven't yet gotten around to exploring this.
 >
-> See [this](https://github.com/microsoft/Git-Credential-Manager-Core/issues/113)
+> See [this](https://github.com/GitCredentialManager/git-credential-manager/issues/113)
 > issue for more information.
 
 The entry-point for GCM can be found in the `Git-Credential-Manager`
@@ -81,7 +81,7 @@ helpers on Windows.
 ### Cross-platform UI
 
 We hope to be able to migrate the WPF/Windows only helpers to [Avalonia](https://avaloniaui.net/)
-in order to gain cross-platform graphical user interface support. See [this](https://github.com/microsoft/Git-Credential-Manager-Core/issues/136)
+in order to gain cross-platform graphical user interface support. See [this](https://github.com/GitCredentialManager/git-credential-manager/issues/136)
 issue for up-to-date progress on this effort.
 
 ### Microsoft authentication

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,17 +1,17 @@
 # Configuration options
 
-[Git Credential Manager Core](usage.md) works out of the box for most users.
+[Git Credential Manager](usage.md) works out of the box for most users.
 
-Git Credential Manager Core (GCM Core) can be configured using Git's configuration files, and follows all of the same rules Git does when consuming the files.
+Git Credential Manager (GCM) can be configured using Git's configuration files, and follows all of the same rules Git does when consuming the files.
 
-Global configuration settings override system configuration settings, and local configuration settings override global settings; and because the configuration details exist within Git's configuration files you can use Git's `git config` utility to set, unset, and alter the setting values. All of GCM Core's configuration settings begin with the term `credential`.
+Global configuration settings override system configuration settings, and local configuration settings override global settings; and because the configuration details exist within Git's configuration files you can use Git's `git config` utility to set, unset, and alter the setting values. All of GCM's configuration settings begin with the term `credential`.
 
-GCM Core honors several levels of settings, in addition to the standard local \> global \> system tiering Git uses.
+GCM honors several levels of settings, in addition to the standard local \> global \> system tiering Git uses.
 URL-specific settings or overrides can be applied to any value in the `credential` namespace with the syntax below.
 
-Additionally, GCM Core respects several GCM-specific [environment variables](environment.md) **which take precedence over configuration options**. System administrators may also configure [default values](enterprise-config.md) for many settings used by GCM Core.
+Additionally, GCM respects several GCM-specific [environment variables](environment.md) **which take precedence over configuration options**. System administrators may also configure [default values](enterprise-config.md) for many settings used by GCM.
 
-GCM Core will only be used by Git if it is installed and configured. Use `git config --global credential.helper manager-core` to assign GCM Core as your credential helper. Use `git config credential.helper` to see the current configuration.
+GCM will only be used by Git if it is installed and configured. Use `git config --global credential.helper manager-core` to assign GCM as your credential helper. Use `git config credential.helper` to see the current configuration.
 
 **Example:**
 
@@ -19,15 +19,15 @@ GCM Core will only be used by Git if it is installed and configured. Use `git co
 
 In the examples above, the `credential.namespace` setting would affect any remote repository; the `credential.visualstudio.com.namespace` would affect any remote repository in the domain, and/or any subdomain (including `www.`) of, 'visualstudio.com'; where as the `credential.microsoft.visualstudio.com.namespace` setting would only be applied to remote repositories hosted at 'microsoft.visualstudio.com'.
 
-For the complete list of settings GCM Core understands, see the list below.
+For the complete list of settings GCM understands, see the list below.
 
 ## Available settings
 
 ### credential.interactive
 
-Permit or disable GCM Core from interacting with the user (showing GUI or TTY prompts). If interaction is required but has been disabled, an error is returned.
+Permit or disable GCM from interacting with the user (showing GUI or TTY prompts). If interaction is required but has been disabled, an error is returned.
 
-This can be helpful when using GCM Core in headless and unattended environments, such as build servers, where it would be preferable to fail than to hang indefinitely waiting for a non-existent user.
+This can be helpful when using GCM in headless and unattended environments, such as build servers, where it would be preferable to fail than to hang indefinitely waiting for a non-existent user.
 
 To disable interactivity set this to `false` or `0`.
 
@@ -156,7 +156,7 @@ git config --global credential.tfsonprem123.allowWindowsAuth false
 >
 > Click [here](https://aka.ms/gcmcore-httpproxy) for more information.
 
-Configure GCM Core to use the a proxy for network operations.
+Configure GCM to use the a proxy for network operations.
 
 **Note:** Git itself does _not_ respect this setting; this affects GCM _only_.
 
@@ -375,11 +375,11 @@ git config --global credential.msauthUseBroker true
 
 ### credential.useHttpPath
 
-Tells Git to pass the entire repository URL, rather than just the hostname, when calling out to a credential provider. (This setting [comes from Git itself](https://git-scm.com/docs/gitcredentials/#Documentation/gitcredentials.txt-useHttpPath), not GCM Core.)
+Tells Git to pass the entire repository URL, rather than just the hostname, when calling out to a credential provider. (This setting [comes from Git itself](https://git-scm.com/docs/gitcredentials/#Documentation/gitcredentials.txt-useHttpPath), not GCM.)
 
 Defaults to `false`.
 
-**Note:** GCM Core sets this value to `true` for `dev.azure.com` (Azure Repos) hosts after installation by default.
+**Note:** GCM sets this value to `true` for `dev.azure.com` (Azure Repos) hosts after installation by default.
 
 This is because `dev.azure.com` alone is not enough information to determine the correct Azure authentication authority - we require a part of the path. The fallout of this is that for `dev.azure.com` remote URLs we do not support storing credentials against the full-path. We always store against the `dev.azure.com/org-name` stub.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,7 +84,7 @@ git config --global credential.ghe.contoso.com.provider github
 
 > This setting is deprecated and should be replaced by `credential.provider` with the corresponding provider ID value.
 >
-> Click [here](https://aka.ms/gcmcore-authority) for more information.
+> Click [here](https://aka.ms/gcm/authority) for more information.
 
 Select the host provider to use when authenticating by which authority is supported by the providers.
 
@@ -154,7 +154,7 @@ git config --global credential.tfsonprem123.allowWindowsAuth false
 
 > This setting is deprecated and should be replaced by the [standard `http.proxy` Git configuration option](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpproxy).
 >
-> Click [here](https://aka.ms/gcmcore-httpproxy) for more information.
+> Click [here](https://aka.ms/gcm/httpproxy) for more information.
 
 Configure GCM to use the a proxy for network operations.
 

--- a/docs/credstores.md
+++ b/docs/credstores.md
@@ -1,6 +1,6 @@
 # Credential stores
 
-There are several options for storing credentials that GCM Core supports:
+There are several options for storing credentials that GCM supports:
 
 - Windows Credential Manager
 - DPAPI protected files
@@ -157,12 +157,12 @@ you must ensure you have configured the GPG Agent (`gpg-agent`) with a suitable
 pin-entry program for the terminal such as `pinentry-tty` or `pinentry-curses`.
 
 If you are connecting to your system via SSH, then the `SSH_TTY` variable should
-automatically be set. GCM Core will pass the value of `SSH_TTY` to GPG/GPG Agent
+automatically be set. GCM will pass the value of `SSH_TTY` to GPG/GPG Agent
 as the TTY device to use for prompting for a passphrase.
 
 If you are not connecting via SSH, or otherwise do not have the `SSH_TTY`
 environment variable set, you must set the `GPG_TTY` environment variable before
-running GCM Core. The easiest way to do this is by adding the following to your
+running GCM. The easiest way to do this is by adding the following to your
 profile (`~/.bashrc`, `~/.profile` etc):
 
 ```shell

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,7 +3,7 @@
 Start by cloning this repository:
 
 ```shell
-git clone https://github.com/microsoft/Git-Credential-Manager-Core
+git clone https://github.com/GitCredentialManager/git-credential-manager
 ```
 
 You also need the latest version of the .NET SDK which can be downloaded and installed from [here](https://dotnet.microsoft.com/).

--- a/docs/development.md
+++ b/docs/development.md
@@ -58,7 +58,7 @@ The flat binaries can also be found in `out/linux/Packaging.Linux/payload/Debug`
 
 To debug from inside an IDE you'll want to set `Git-Credential-Manager` as the startup project, and specify one of `get`, `store`, or `erase` as a program argument.
 
-To simulate Git interacting with GCM Core, when you start from your IDE of choice, you'll need to enter the following [information over standard input](https://git-scm.com/docs/git-credential#IOFMT):
+To simulate Git interacting with GCM, when you start from your IDE of choice, you'll need to enter the following [information over standard input](https://git-scm.com/docs/git-credential#IOFMT):
 
 ```text
 protocol=http<LF>
@@ -80,13 +80,13 @@ For more information about how Git interacts with credential helpers, please rea
 
 ### Attaching to a running process
 
-If you want to debug an already running GCM Core process, set the `GCM_DEBUG` environment variable to `1` or `true`. The process will wait on launch for a debugger to attach before continuing.
+If you want to debug an already running GCM process, set the `GCM_DEBUG` environment variable to `1` or `true`. The process will wait on launch for a debugger to attach before continuing.
 
-This is useful when debugging interactions between GCM Core and Git, and you want Git to be the one launching us.
+This is useful when debugging interactions between GCM and Git, and you want Git to be the one launching us.
 
 ### Collect trace output
 
-If you want to debug a release build or installation of GCM Core, you can set the `GCM_TRACE` environment variable to `1` to print trace information to standard error, or to an absolute file path to write trace information to a file.
+If you want to debug a release build or installation of GCM, you can set the `GCM_TRACE` environment variable to `1` to print trace information to standard error, or to an absolute file path to write trace information to a file.
 
 For example:
 

--- a/docs/enterprise-config.md
+++ b/docs/enterprise-config.md
@@ -1,6 +1,6 @@
 # Enterprise configuration defaults
 
-Git Credential Manager Core (GCM Core) can be configured using multiple
+Git Credential Manager (GCM) can be configured using multiple
 different mechanisms. In order of preference, those mechanisms are:
 
 1. [Environment variables](environment.md)
@@ -42,12 +42,12 @@ HKEY_LOCAL_MACHINE\SOFTWARE\GitCredentialManager\Configuration
 HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\GitCredentialManager\Configuration
 ```
 
-> GCM Core is a 32-bit executable on Windows. When running on a 64-bit
+> GCM is a 32-bit executable on Windows. When running on a 64-bit
 installation of Windows registry access is transparently redirected to the
 `WOW6432Node` node.
 
 By using the Windows Registry, system administrators can use Group Policy to
-easily set defaults for GCM Core's settings.
+easily set defaults for GCM's settings.
 
 The names and possible values of all settings under this key are the same as
 those of the [Git configuration](configuration.md) settings.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -197,7 +197,7 @@ export GCM_PROVIDER=github
 
 > This setting is deprecated and should be replaced by `GCM_PROVIDER` with the corresponding provider ID value.
 >
-> Click [here](https://aka.ms/gcmcore-authority) for more information.
+> Click [here](https://aka.ms/gcm/authority) for more information.
 
 Select the host provider to use when authenticating by which authority is supported by the providers.
 
@@ -290,7 +290,7 @@ export GCM_ALLOW_WINDOWSAUTH=0
 
 > This setting is deprecated and should be replaced by the [standard `http.proxy` Git configuration option](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpproxy).
 >
-> Click [here](https://aka.ms/gcmcore-httpproxy) for more information.
+> Click [here](https://aka.ms/gcm/httpproxy) for more information.
 
 Configure GCM to use the a proxy for network operations.
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,10 +1,10 @@
 # Environment variables
 
-[Git Credential Manager Core](usage.md) works out of the box for most users. Configuration options are available to customize or tweak behavior.
+[Git Credential Manager](usage.md) works out of the box for most users. Configuration options are available to customize or tweak behavior.
 
-Git Credential Manager Core (GCM Core) can be configured using environment variables. **Environment variables take precedence over [configuration](configuration.md) options and enterprise system administrator [default values](enterprise-config.md)**.
+Git Credential Manager (GCM) can be configured using environment variables. **Environment variables take precedence over [configuration](configuration.md) options and enterprise system administrator [default values](enterprise-config.md)**.
 
-For the complete list of environment variables GCM Core understands, see the list below.
+For the complete list of environment variables GCM understands, see the list below.
 
 ## Available settings
 
@@ -99,7 +99,7 @@ _No configuration equivalent._
 
 ### GCM_DEBUG
 
-Pauses execution of GCM Core at launch to wait for a debugger to be attached.
+Pauses execution of GCM at launch to wait for a debugger to be attached.
 
 #### Example
 
@@ -123,9 +123,9 @@ _No configuration equivalent._
 
 ### GCM_INTERACTIVE
 
-Permit or disable GCM Core from interacting with the user (showing GUI or TTY prompts). If interaction is required but has been disabled, an error is returned.
+Permit or disable GCM from interacting with the user (showing GUI or TTY prompts). If interaction is required but has been disabled, an error is returned.
 
-This can be helpful when using GCM Core in headless and unattended environments, such as build servers, where it would be preferable to fail than to hang indefinitely waiting for a non-existent user.
+This can be helpful when using GCM in headless and unattended environments, such as build servers, where it would be preferable to fail than to hang indefinitely waiting for a non-existent user.
 
 To disable interactivity set this to `false` or `0`.
 
@@ -292,7 +292,7 @@ export GCM_ALLOW_WINDOWSAUTH=0
 >
 > Click [here](https://aka.ms/gcmcore-httpproxy) for more information.
 
-Configure GCM Core to use the a proxy for network operations.
+Configure GCM to use the a proxy for network operations.
 
 **Note:** Git itself does _not_ respect this setting; this affects GCM _only_.
 
@@ -502,7 +502,7 @@ SETX GCM_DPAPI_STORE_PATH=D:\credentials
 
 Specify the path (_including_ the executable name) to the version of `gpg` used by `pass` (`gpg2` if present, otherwise `gpg`). This is primarily meant to allow manual resolution of the conflict that occurs on legacy Linux systems with parallel installs of `gpg` and `gpg2`.
 
-If not specified, GCM Core defaults to using the version of `gpg2` on the `$PATH`, falling back on `gpg` if `gpg2` is not found.
+If not specified, GCM defaults to using the version of `gpg2` on the `$PATH`, falling back on `gpg` if `gpg2` is not found.
 
 ##### macOS/Linux
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,13 +16,13 @@ Please follow these steps to diagnose or resolve the problem:
 
 ### Q: I got an error saying unsecure HTTP is not supported.
 
-To keep your data secure, Git Credential Manager Core will not send credentials for Azure Repos, Azure DevOps Server (TFS), GitHub, and Bitbucket, over HTTP connections that are not secured using TLS (HTTPS).
+To keep your data secure, Git Credential Manager will not send credentials for Azure Repos, Azure DevOps Server (TFS), GitHub, and Bitbucket, over HTTP connections that are not secured using TLS (HTTPS).
 
 Please make sure your remote URLs use "https://" rather than "http://".
 
 ### Q: I got an authentication error and I am behind a network proxy.
 
-You probably need to configure Git and GCM Core to use a proxy. Please see detailed information [here](https://aka.ms/gcmcore-httpproxy).
+You probably need to configure Git and GCM to use a proxy. Please see detailed information [here](https://aka.ms/gcmcore-httpproxy).
 
 ### Q: I'm getting errors about picking a credential store on Linux.
 
@@ -35,19 +35,19 @@ On Linux you must [select and configure a credential store](https://aka.ms/gcmco
 Git Credential Manager for Windows (GCM Windows) is a .NET Framework-based Git credential helper which runs on Windows.
 Likewise the Git Credential Manager for Mac and Linux (Java GCM) is a Java-based Git credential helper that runs only on macOS and Linux. Although both of these projects aim to solve the same problem (providing seamless multi-factor HTTPS authentication with Git), they are based on different codebases and languages which is becoming hard to manage to ensure feature parity.
 
-Git Credential Manager Core (GCM Core; this project) aims to replace both GCM Windows and Java GCM with a unified codebase which should be easier to maintain and enhance in the future.
+Git Credential Manager (GCM; this project) aims to replace both GCM Windows and Java GCM with a unified codebase which should be easier to maintain and enhance in the future.
 
 ### Q: Does this mean GCM for Windows (.NET Framework-based) is deprecated?
 
-Yes. Git Credential Manager for Windows (GCM Windows) is no longer receiving updates and fixes. All development effort has now been directed to GCM Core. GCM Core is available as an credential helper option in Git for Windows 2.28, and will be made the default helper in 2.29.
+Yes. Git Credential Manager for Windows (GCM Windows) is no longer receiving updates and fixes. All development effort has now been directed to GCM. GCM is available as an credential helper option in Git for Windows 2.28, and will be made the default helper in 2.29.
 
 ### Q: Does this mean the Java-based GCM for Mac/Linux is deprecated?
 
-Yes. Usage of Git Credential Manager for Mac and Linux (Java GCM) should be replaced with GCM Core or SSH keys. If you wish to install GCM Core on macOS or Linux, please follow the [download and installation instructions](../README.md#download-and-install).
+Yes. Usage of Git Credential Manager for Mac and Linux (Java GCM) should be replaced with GCM or SSH keys. If you wish to install GCM on macOS or Linux, please follow the [download and installation instructions](../README.md#download-and-install).
 
 ### Q: I want to use SSH
 
-GCM Core is only useful for HTTP(S)-based remotes. Git supports SSH out-of-the box so you shouldn't need to install anything else.
+GCM is only useful for HTTP(S)-based remotes. Git supports SSH out-of-the box so you shouldn't need to install anything else.
 
 To use SSH please follow the below links:
 
@@ -63,22 +63,22 @@ No, neither are "preferred". SSH isn't going away, and is supported "natively" i
 
 GCM Windows was not designed with a cross-platform architecture.
 
-### What level of support does GCM Core have?
+### What level of support does GCM have?
 
 Support will be best-effort. We would really appreciate your feedback to make this a great experience across each platform we support. 
 
-### Q: Why does GCM Core not support operating system/distribution 'X', or Git hosting provider 'Y'?
+### Q: Why does GCM not support operating system/distribution 'X', or Git hosting provider 'Y'?
 
 The likely answer is we haven't gotten around to that yet! 🙂
 
 We are working on ensuring support for the Windows, macOS, and Ubuntu operating system, as well as the following Git hosting providers: Azure Repos, Azure DevOps Server (TFS), GitHub, and Bitbucket.
 
-We are happy to accept proposals and/or contributions to enable GCM Core to run on other platforms and Git host providers. Thank you!
+We are happy to accept proposals and/or contributions to enable GCM to run on other platforms and Git host providers. Thank you!
 
 ## Technical
 
 ### Why is the `credential.useHttpPath` setting required for `dev.azure.com`?
 
-Due to the design of Git and credential helpers such as GCM Core, we need this setting to make Git use the full remote URL (including the path component) when communicating with GCM. The new `dev.azure.com` format of Azure DevOps URLs means the account name is now part of the path component (for example: `https://dev.azure.com/contoso/...`). The Azure DevOps account name is required in order to resolve the correct authority for authentication (which Azure AD tenant backs this account, or if it is backed by Microsoft personal accounts).
+Due to the design of Git and credential helpers such as GCM, we need this setting to make Git use the full remote URL (including the path component) when communicating with GCM. The new `dev.azure.com` format of Azure DevOps URLs means the account name is now part of the path component (for example: `https://dev.azure.com/contoso/...`). The Azure DevOps account name is required in order to resolve the correct authority for authentication (which Azure AD tenant backs this account, or if it is backed by Microsoft personal accounts).
 
-In the older GCM for Windows product, the solution to the same problem was a "hack". GCM for Windows would walk the process tree looking for the `git-remote-https.exe` process, and attempt to read/parse the process environment block looking for the command line arguments (that contained the full remote URL). This is fragile and not a cross-platform solution, hense the need for the `credential.useHttpPath` setting with GCM Core.
+In the older GCM for Windows product, the solution to the same problem was a "hack". GCM for Windows would walk the process tree looking for the `git-remote-https.exe` process, and attempt to read/parse the process environment block looking for the command line arguments (that contained the full remote URL). This is fragile and not a cross-platform solution, hense the need for the `credential.useHttpPath` setting with GCM.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,7 +12,7 @@ Please follow these steps to diagnose or resolve the problem:
 
 1. Set the environment variable `GCM_TRACE` and run the Git operation again. Find instructions [here](environment.md#GCM_TRACE).
 
-1. If all else fails, create an issue [here](https://github.com/Microsoft/Git-Credential-Manager-Core/issues/create), making sure to include the trace log.
+1. If all else fails, create an issue [here](https://github.com/GitCredentialManager/git-credential-manager/issues/create), making sure to include the trace log.
 
 ### Q: I got an error saying unsecure HTTP is not supported.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,11 +22,11 @@ Please make sure your remote URLs use "https://" rather than "http://".
 
 ### Q: I got an authentication error and I am behind a network proxy.
 
-You probably need to configure Git and GCM to use a proxy. Please see detailed information [here](https://aka.ms/gcmcore-httpproxy).
+You probably need to configure Git and GCM to use a proxy. Please see detailed information [here](https://aka.ms/gcm/httpproxy).
 
 ### Q: I'm getting errors about picking a credential store on Linux.
 
-On Linux you must [select and configure a credential store](https://aka.ms/gcmcore-credstores), as due to the varied nature of distributions and installations, we cannot guarantee a suitable storage solution is available.
+On Linux you must [select and configure a credential store](https://aka.ms/gcm/credstores), as due to the varied nature of distributions and installations, we cannot guarantee a suitable storage solution is available.
 
 ## About the project
 

--- a/docs/github-apideprecation.md
+++ b/docs/github-apideprecation.md
@@ -7,7 +7,7 @@ call their APIs, and in the future, use Git itself.
 
 This means Git credential helpers such as [Git Credential Manager (GCM) for
 Windows](https://github.com/microsoft/Git-Credential-Manager-for-Windows), and
-old versions of [GCM Core](https://aka.ms/gcmcore) that offer username/password
+old versions of [GCM](https://aka.ms/gcmcore) that offer username/password
 flows **will not be able to create new access tokens** for accessing Git
 repositories.
 
@@ -19,7 +19,7 @@ Windows, they will continue to work until they expire or are revoked/deleted.
 ### Windows command-line users
 
 The best thing to do right now is upgrade to the latest Git for Windows (at
-least version 2.29), which includes a version of Git Credential Manager Core that
+least version 2.29), which includes a version of Git Credential Manager that
 uses supported OAuth token-based authentication.
 
 [Download the latest Git for Windows ⬇️](https://git-scm.com/download/win)
@@ -27,7 +27,7 @@ uses supported OAuth token-based authentication.
 ### Visual Studio users
 
 Please update to the latest supported release of Visual Studio, that includes
-GCM Core and support for OAuth token-based authentication.
+GCM and support for OAuth token-based authentication.
 
 - [Visual Studio 2019 ⬇️](https://docs.microsoft.com/en-us/visualstudio/install/update-visual-studio?view=vs-2019)
 - [Visual Studio 2017 ⬇️](https://docs.microsoft.com/en-us/visualstudio/install/update-visual-studio?view=vs-2017)
@@ -36,21 +36,21 @@ GCM Core and support for OAuth token-based authentication.
 
 If you are using SSH this change does **not** affect you.
 
-If you are using an older version of Git Credential Manager Core (before
+If you are using an older version of Git Credential Manager (before
 2.0.124-beta) please upgrade to the latest version following [these
 instructions](https://github.com/microsoft/Git-Credential-Manager-Core#download-and-install).
 
 ## What if I cannot upgrade Git for Windows?
 
 If you are unable to upgrade Git for Windows, you can manually install Git
-Credential Manager Core as a standalone install. This will override the older,
+Credential Manager as a standalone install. This will override the older,
 GCM for Windows bundled with the Git for Windows installation.
 
-[Download Git Credential Manager Core standalone ⬇️](https://aka.ms/gcmcore-latest)
+[Download Git Credential Manager standalone ⬇️](https://aka.ms/gcmcore-latest)
 
-## What if I cannot use Git Credential Manager Core?
+## What if I cannot use Git Credential Manager?
 
-If you are unable to use Git Credential Manager Core due to a bug or
+If you are unable to use Git Credential Manager due to a bug or
 compatibility issue we'd [like to know why](https://github.com/microsoft/Git-Credential-Manager-Core/issues/new/choose)!
 
 ## Help! I cannot make any changes to my Windows machine without an Administrator!

--- a/docs/github-apideprecation.md
+++ b/docs/github-apideprecation.md
@@ -7,7 +7,7 @@ call their APIs, and in the future, use Git itself.
 
 This means Git credential helpers such as [Git Credential Manager (GCM) for
 Windows](https://github.com/microsoft/Git-Credential-Manager-for-Windows), and
-old versions of [GCM](https://aka.ms/gcmcore) that offer username/password
+old versions of [GCM](https://aka.ms/gcm) that offer username/password
 flows **will not be able to create new access tokens** for accessing Git
 repositories.
 
@@ -46,7 +46,7 @@ If you are unable to upgrade Git for Windows, you can manually install Git
 Credential Manager as a standalone install. This will override the older,
 GCM for Windows bundled with the Git for Windows installation.
 
-[Download Git Credential Manager standalone ⬇️](https://aka.ms/gcmcore-latest)
+[Download Git Credential Manager standalone ⬇️](https://aka.ms/gcm/latest)
 
 ## What if I cannot use Git Credential Manager?
 
@@ -57,7 +57,7 @@ compatibility issue we'd [like to know why](https://github.com/GitCredentialMana
 
 If you do not have permission to change your installation (for example in a
 corporate environment) you can use the per-user installer. Check out the [latest
-release](https://aka.ms/gcmcore-latest) and download the `gcmcoreuser-win-*.exe`
+release](https://aka.ms/gcm/latest) and download the `gcmcoreuser-win-*.exe`
 executable.
 
 ### Help! I still cannot or don't want to install anything!

--- a/docs/github-apideprecation.md
+++ b/docs/github-apideprecation.md
@@ -38,7 +38,7 @@ If you are using SSH this change does **not** affect you.
 
 If you are using an older version of Git Credential Manager (before
 2.0.124-beta) please upgrade to the latest version following [these
-instructions](https://github.com/microsoft/Git-Credential-Manager-Core#download-and-install).
+instructions](https://github.com/GitCredentialManager/git-credential-manager#download-and-install).
 
 ## What if I cannot upgrade Git for Windows?
 
@@ -51,7 +51,7 @@ GCM for Windows bundled with the Git for Windows installation.
 ## What if I cannot use Git Credential Manager?
 
 If you are unable to use Git Credential Manager due to a bug or
-compatibility issue we'd [like to know why](https://github.com/microsoft/Git-Credential-Manager-Core/issues/new/choose)!
+compatibility issue we'd [like to know why](https://github.com/GitCredentialManager/git-credential-manager/issues/new/choose)!
 
 ## Help! I cannot make any changes to my Windows machine without an Administrator!
 

--- a/docs/hostprovider.md
+++ b/docs/hostprovider.md
@@ -50,7 +50,7 @@ Git Credential Manager (GCM) is a host and platform agnostic Git
 credential helper application. Support for authenticating to any Git hosting
 service can be added to GCM by creating a custom "host provider" and
 registering it within the product. Host providers can be submitted via a pull
-request on GitHub at <https://github.com/microsoft/Git-Credential-Manager-Core>.
+request on GitHub at <https://github.com/GitCredentialManager/git-credential-manager>.
 
 This document outlines the required and expected behaviour of a host provider,
 and what is required to implement and register one.

--- a/docs/hostprovider.md
+++ b/docs/hostprovider.md
@@ -1,4 +1,4 @@
-# Git Credential Manager Core Host Provider
+# Git Credential Manager Host Provider
 
 Property|Value
 -|-
@@ -15,7 +15,7 @@ Last updated|2021-01-08
 
 ## Abstract
 
-Git Credential Manger Core, the cross-platform and cross-host Git credential
+Git Credential Manger, the cross-platform and cross-host Git credential
 helper, can be extended to support any Git hosting service allowing seamless
 authentication to secured Git repositories by implementing and registering a
 "host provider".
@@ -46,9 +46,9 @@ authentication to secured Git repositories by implementing and registering a
 
 ## 1. Introduction
 
-Git Credential Manager Core (GCM Core) is a host and platform agnostic Git
+Git Credential Manager (GCM) is a host and platform agnostic Git
 credential helper application. Support for authenticating to any Git hosting
-service can be added to GCM Core by creating a custom "host provider" and
+service can be added to GCM by creating a custom "host provider" and
 registering it within the product. Host providers can be submitted via a pull
 request on GitHub at <https://github.com/microsoft/Git-Credential-Manager-Core>.
 
@@ -67,7 +67,7 @@ specification are to be interpreted as described in
 Throughout this document you may see multiple abbreviations of product names and
 security or credential objects.
 
-"Git Credential Manager Core" is abbreviated to "GCM Core". "Git Credential
+"Git Credential Manager" is abbreviated to "GCM". "Git Credential
 Manager for Windows" is abbreviated to "GCM for Windows" or "GCM Windows".
 "Git Credential Manager for Mac & Linux" is abbreviated to "GCM for
 Mac/Linux" or "GCM Mac/Linux".
@@ -78,7 +78,7 @@ abbreviated to "PATs".
 
 ## 2. Implementation
 
-Writing and adding a host provider to GCM Core requires two main actions:
+Writing and adding a host provider to GCM requires two main actions:
 implementing the `IHostProvider` interface, and registering an instance of the
 provider with the application via the host provider registry.
 
@@ -109,15 +109,15 @@ authorities that the provider supports authentication against.
 ### 2.1. Registration
 
 Host providers must provide an instance of their `IHostProvider` type to the
-GCM Core application host provider registry to be considered for handling
+GCM application host provider registry to be considered for handling
 requests.
 
-The main GCM Core `Application` object has one principal registry which you can
+The main GCM `Application` object has one principal registry which you can
 register providers with by calling the `RegisterProvider` method.
 
 #### 2.1.2. Ordering
 
-The default host provider registry in GCM Core has multiple priority levels that
+The default host provider registry in GCM has multiple priority levels that
 host providers can be registered at: High, Normal, and Low.
 
 For each priority level (starting with High, then Normal, then Low), the
@@ -333,14 +333,14 @@ terminal/TTY or text-based authentication mechanism alongside any graphical
 interface provided by a helper.
 
 In order to achieve this host providers MUST introduce an out-of-process
-"helper" executable that can be invoked from the main GCM Core process. This
+"helper" executable that can be invoked from the main GCM process. This
 allows the "helper" executable full implementation freedom of runtime, language,
 etc.
 
 Communications between the main and helper processes MAY use any IPC mechanism
 available. It is RECOMMENDED implementors use standard input/output streams or
 file descriptors to send and receive data as this is consistent with how Git and
-GCM Core communicate. UNIX sockets or Windows Named Pipes MAY also be used when
+GCM communicate. UNIX sockets or Windows Named Pipes MAY also be used when
 an ongoing back-and-forth communication is required.
 
 ### 3.1. Discovery

--- a/docs/netconfig.md
+++ b/docs/netconfig.md
@@ -1,6 +1,6 @@
 # Network and HTTP configuration
 
-Git Credential Manager Core's network and HTTP(S) behavior can be configured in a few different ways via [environment variables](environment.md) and [configuration options](configuration.md).
+Git Credential Manager's network and HTTP(S) behavior can be configured in a few different ways via [environment variables](environment.md) and [configuration options](configuration.md).
 
 ## HTTP Proxy
 
@@ -44,7 +44,7 @@ For example, a space character would be encoded with `%20`.
 
 ### Other proxy options
 
-GCM Core supports other ways of configuring a proxy for convenience and compatibility.
+GCM supports other ways of configuring a proxy for convenience and compatibility.
 
 1. GCM-specific configuration options (_**only** respected by GCM; **deprecated**_):
    - `credential.httpProxy`
@@ -62,7 +62,7 @@ uppercase variants.
 consistent with how libcurl (and therefore Git) operates.
 
 The `http_proxy` variable exists only in the lowercase variant and libcurl does
-_not_ consider any uppercase form. _GCM Core also reflects this behavior._
+_not_ consider any uppercase form. _GCM also reflects this behavior._
 
 See <https://everything.curl.dev/usingcurl/proxies#proxy-environment-variables>
 for more information.
@@ -70,7 +70,7 @@ for more information.
 ### Bypassing addresses
 
 In some circumstances you may wish to bypass a configured proxy for specific
-addresses. GCM Core supports the cURL environment variable `no_proxy` (and
+addresses. GCM supports the cURL environment variable `no_proxy` (and
 `NO_PROXY`) for this scenario, as does Git itself.
 
 Like with the [other cURL proxy environment variables](#other-proxy-options),
@@ -79,7 +79,7 @@ the lowercase variant will take precedence over the uppercase form.
 This environment variable should contain a comma (`,`) or space (` `) separated
 list of host names that should not be proxied (should connect directly).
 
-GCM Core attempts to match [libcurl's behaviour](https://curl.se/libcurl/c/CURLOPT_NOPROXY.html),
+GCM attempts to match [libcurl's behaviour](https://curl.se/libcurl/c/CURLOPT_NOPROXY.html),
 which is briefly summarized here:
 
 - a value of `*` disables proxying for all hosts;

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,9 +1,9 @@
 # Command-line usage
 
-After installation, Git will use Git Credential Manager Core and you will only need to interact with any authentication dialogs asking for credentials.
-GCM Core stays invisible as much as possible, so ideally you’ll forget that you’re depending on GCM at all.
+After installation, Git will use Git Credential Manager and you will only need to interact with any authentication dialogs asking for credentials.
+GCM stays invisible as much as possible, so ideally you’ll forget that you’re depending on GCM at all.
 
-Assuming GCM Core has been installed, use your favorite terminal to execute the following commands to interact directly with GCM.
+Assuming GCM has been installed, use your favorite terminal to execute the following commands to interact directly with GCM.
 
 ```shell
 git credential-manager-core [<command> [<args>]]
@@ -27,7 +27,7 @@ Read the [Git manual](https://git-scm.com/docs/gitcredentials#_custom_helpers) a
 
 ### configure/unconfigure
 
-Set your user-level Git configuration (`~/.gitconfig`) to use GCM Core. If you pass
+Set your user-level Git configuration (`~/.gitconfig`) to use GCM. If you pass
 `--system` to these commands, they act on the system-level Git configuration
 (`/etc/gitconfig`) instead.
 

--- a/docs/windows-broker.md
+++ b/docs/windows-broker.md
@@ -103,7 +103,7 @@ If GCM can't modify the process's COM security settings, GCM prints a warning me
 ```text
 warning: broker initialization failed
 Failed to set COM process security to allow Windows broker from an elevated process (0x80010119).
-See https://aka.ms/gcmcore-wamadmin for more information.
+See https://aka.ms/gcm/wamadmin for more information.
 ```
 
 ### Possible solutions

--- a/docs/windows-broker.md
+++ b/docs/windows-broker.md
@@ -1,6 +1,6 @@
 # Web Account Manager integration
 
-Git Credential Manager (GCM) Core knows how to integrate with the [Web Account Manager (WAM)](https://docs.microsoft.com/azure/active-directory/devices/concept-primary-refresh-token#key-terminology-and-components) feature of Windows.
+Git Credential Manager (GCM) knows how to integrate with the [Web Account Manager (WAM)](https://docs.microsoft.com/azure/active-directory/devices/concept-primary-refresh-token#key-terminology-and-components) feature of Windows.
 GCM uses WAM to store credentials for Azure DevOps.
 Authentication requests are said to be "brokered" to the operating system.
 Currently, GCM will share authentication state with a few other Microsoft developer tools like Visual Studio and the Azure CLI, meaning fewer authentication prompts.
@@ -19,7 +19,7 @@ You can opt-in to WAM support by setting the environment variable [`GCM_MSAUTH_U
 
 ## Features
 
-When you turn on WAM support, GCM Core can cooperate with Windows and with other WAM-enabled software on your machine.
+When you turn on WAM support, GCM can cooperate with Windows and with other WAM-enabled software on your machine.
 This means a more seamless experience, fewer multi-factor authentication prompts, and the ability to use additional authentication technologies like smart cards and Windows Hello.
 These convenience and security features make a good case for enabling WAM.
 
@@ -27,7 +27,7 @@ These convenience and security features make a good case for enabling WAM.
 
 The WAM and Windows identity systems are complex, addressing a very broad range of customer use cases.
 What works for a solo home user may not be adequate for a corporate-managed fleet of 100,000 devices and vice versa.
-The GCM Core team isn't responsible for the user experience or choices made by WAM, but by integrating with WAM, we inherit some of those choices.
+The GCM team isn't responsible for the user experience or choices made by WAM, but by integrating with WAM, we inherit some of those choices.
 Therefore, we want you to be aware of some defaults and experiences if you choose to use WAM integration.
 
 ### For work or school accounts (Azure AD-backed identities)

--- a/docs/windows-broker.md
+++ b/docs/windows-broker.md
@@ -15,7 +15,7 @@ It doesn't impact authentication with GitHub, Bitbucket, or any other Git host.
 
 ## How to enable
 
-You can opt-in to WAM support by setting the environment variable [`GCM_MSAUTH_USEBROKER`](https://github.com/microsoft/Git-Credential-Manager-Core/blob/main/docs/environment.md#gcm_msauth_usebroker-experimental) or setting the Git configuration value [`credential.msauthUseBroker`](https://github.com/microsoft/Git-Credential-Manager-Core/blob/main/docs/configuration.md#credentialmsauthusebroker-experimental).
+You can opt-in to WAM support by setting the environment variable [`GCM_MSAUTH_USEBROKER`](https://github.com/GitCredentialManager/git-credential-manager/blob/main/docs/environment.md#gcm_msauth_usebroker-experimental) or setting the Git configuration value [`credential.msauthUseBroker`](https://github.com/GitCredentialManager/git-credential-manager/blob/main/docs/configuration.md#credentialmsauthusebroker-experimental).
 
 ## Features
 

--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -1,6 +1,6 @@
 # Windows Subsystem for Linux (WSL)
 
-GCM Core can be used with the
+GCM can be used with the
 [Windows Subsystem for Linux (WSL)](https://aka.ms/wsl), both WSL1 and WSL2, by
 following these instructions.
 
@@ -34,7 +34,7 @@ git config --global credential.https://dev.azure.com.useHttpPath true
 
 ## Configuring WSL without Git for Windows
 
-If you wish to use GCM Core inside of WSL _without installing Git for Windows_
+If you wish to use GCM inside of WSL _without installing Git for Windows_
 you must complete additional configuration so that GCM can callback to Git
 inside of your WSL installation.
 

--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -38,7 +38,7 @@ If you wish to use GCM inside of WSL _without installing Git for Windows_
 you must complete additional configuration so that GCM can callback to Git
 inside of your WSL installation.
 
-Start by installing the [latest GCM ⬇️](https://aka.ms/gcmcore-latest)
+Start by installing the [latest GCM ⬇️](https://aka.ms/gcm/latest)
 
 _Inside your WSL installation_, run the following command to set GCM as the Git
 credential helper:

--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -166,9 +166,9 @@ Section: vcs
 Priority: optional
 Architecture: $ARCH
 Depends:
-Maintainer: GCM-Core <gitfundamentals@github.com>
-Description: Cross Platform Git Credential Manager Core command line utility.
- GCM Core supports authentication with a number of Git hosting providers
+Maintainer: GCM <gitfundamentals@github.com>
+Description: Cross Platform Git Credential Manager command line utility.
+ GCM supports authentication with a number of Git hosting providers
  including GitHub, BitBucket, and Azure DevOps.
  For more information see https://aka.ms/gcmcore
 EOF

--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -170,7 +170,7 @@ Maintainer: GCM <gitfundamentals@github.com>
 Description: Cross Platform Git Credential Manager command line utility.
  GCM supports authentication with a number of Git hosting providers
  including GitHub, BitBucket, and Azure DevOps.
- For more information see https://aka.ms/gcmcore
+ For more information see https://aka.ms/gcm
 EOF
 
 # Copy all binaries and shared libraries to target installation location

--- a/src/osx/Installer.Mac/distribution.xml
+++ b/src/osx/Installer.Mac/distribution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <installer-gui-script minSpecVersion="1">
-    <title>Git Credential Manager Core</title>
+    <title>Git Credential Manager</title>
     <background file="background.png" mime-type="image/png" alignment="bottomleft" scaling="tofit" />
     <options customize="never" />
     <welcome file="welcome.html" mime-type="text/html" />
@@ -15,7 +15,7 @@
     <choices-outline>
         <line choice="default" />
     </choices-outline>
-    <choice id="default" visible="true" enabled="false" title="Git Credential Manager Core" description="Git Credential Manager core application.">
+    <choice id="default" visible="true" enabled="false" title="Git Credential Manager" description="Git Credential Manager application.">
         <pkg-ref id="gcmcore">com.microsoft.gitcredentialmanager.component.pkg</pkg-ref>
     </choice>
 </installer-gui-script>

--- a/src/osx/Installer.Mac/resources/en.lproj/conclusion.html
+++ b/src/osx/Installer.Mac/resources/en.lproj/conclusion.html
@@ -33,8 +33,8 @@
         <div class="section">
             <h2>Resources</h3>
             <ul>
-                <li><a href="https://aka.ms/gcmcore">Project homepage</a></li>
-                <li><a href="https://aka.ms/gcmcore-config">Configuration options</a></li>
+                <li><a href="https://aka.ms/gcm">Project homepage</a></li>
+                <li><a href="https://aka.ms/gcm/config">Configuration options</a></li>
             </ul>
         </div>
     </body>

--- a/src/osx/Installer.Mac/resources/en.lproj/conclusion.html
+++ b/src/osx/Installer.Mac/resources/en.lproj/conclusion.html
@@ -11,23 +11,23 @@
     </head>
     <body>
         <div class="section">
-            <p>Git Credential Manager Core was installed in <a href="file:///usr/local/share/gcm-core"><code>/usr/local/share/gcm-core</code></a> and configured for the current user.</p>
+            <p>Git Credential Manager was installed in <a href="file:///usr/local/share/gcm-core"><code>/usr/local/share/gcm-core</code></a> and configured for the current user.</p>
         </div>
         <div class="section">
             <h2>Other users</h2>
             <p>
-                GCM Core has already been automatically configured for use by the current user with Git.
-                If other users wish to use GCM Core, have them run the following command to update their global Git configuration (<code>~/.gitconfig</code>):
+                GCM has already been automatically configured for use by the current user with Git.
+                If other users wish to use GCM, have them run the following command to update their global Git configuration (<code>~/.gitconfig</code>):
             </p>
             <p class="mono">$ git-credential-manager-core configure</p>
             <p>
-                To configure GCM Core for all users, run the following command to update the system Git configuration:
+                To configure GCM for all users, run the following command to update the system Git configuration:
             </p>
             <p class="mono">$ git-credential-manager-core configure --system</p>
         </div>
         <div class="section">
             <h2>Uninstall</h2>
-            <p>If you wish to uninstall GCM Core, run the following script:</p>
+            <p>If you wish to uninstall GCM, run the following script:</p>
             <p class="mono">$ /usr/local/share/gcm-core/uninstall.sh</p>
         </div>
         <div class="section">

--- a/src/osx/Installer.Mac/resources/en.lproj/welcome.html
+++ b/src/osx/Installer.Mac/resources/en.lproj/welcome.html
@@ -10,9 +10,9 @@
     </head>
     <body>
         <div class="section">
-            <h2>Git Credential Manager Core</h2>
+            <h2>Git Credential Manager</h2>
             <p>
-                Git Credential Manager Core is a secure, cross-platform Git credential helper with authentication support for GitHub, Azure Repos, and other popular Git hosting services.
+                Git Credential Manager is a secure, cross-platform Git credential helper with authentication support for GitHub, Azure Repos, and other popular Git hosting services.
             </p>
         </div>
         <div class="section">
@@ -21,7 +21,7 @@
                 If you have the old Java-based <a href="https://github.com/microsoft/Git-Credential-Manager-for-Mac-and-Linux">Git Credential Manager for Mac & Linux</a> installed through Homebrew, it will be unlinked after installation.
             </p>
             <p>
-                Git Credential Manager Core will be configured as the Git credential helper for the current user by updating the global Git configuration file (<code>~/.gitconfig</code>).
+                Git Credential Manager will be configured as the Git credential helper for the current user by updating the global Git configuration file (<code>~/.gitconfig</code>).
             </p>
         </div>
         <div class="section">

--- a/src/osx/Installer.Mac/resources/en.lproj/welcome.html
+++ b/src/osx/Installer.Mac/resources/en.lproj/welcome.html
@@ -27,7 +27,7 @@
         <div class="section">
             <h2>Learn more</h2>
             <ul>
-                <li><a href="https://aka.ms/gcmcore">Project homepage</a></li>
+                <li><a href="https://aka.ms/gcm">Project homepage</a></li>
             </ul>
         </div>
     </body>

--- a/src/shared/Core.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
+++ b/src/shared/Core.Tests/Interop/Posix/GnuPassCredentialStoreTests.cs
@@ -90,7 +90,7 @@ namespace GitCredentialManager.Tests.Interop.Posix
         {
             string homePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             string storePath = Path.Combine(homePath, ".password-store");
-            string userId = "gcmcore-test@example.com";
+            string userId = "gcm-test@example.com";
             string gpgIdPath = Path.Combine(storePath, ".gpg-id");
 
             // Ensure we have a GPG key for use with testing

--- a/src/shared/Core.UI.Avalonia/Controls/AboutWindow.axaml
+++ b/src/shared/Core.UI.Avalonia/Controls/AboutWindow.axaml
@@ -32,7 +32,7 @@
         <Button HorizontalAlignment="Center"
                 Margin="0,5"
                 FontSize="12" Classes="hyperlink"
-                Content="https://aka.ms/gcmcore"
+                Content="https://aka.ms/gcm"
                 Click="ProjectButton_Click"/>
         <TextBlock HorizontalAlignment="Center"
                    Margin="0,10,0,0"

--- a/src/shared/Core.UI.Avalonia/Controls/AboutWindow.axaml.cs
+++ b/src/shared/Core.UI.Avalonia/Controls/AboutWindow.axaml.cs
@@ -23,7 +23,7 @@ namespace GitCredentialManager.UI.Controls
 
         private void ProjectButton_Click(object sender, RoutedEventArgs e)
         {
-            var psi = new ProcessStartInfo("https://aka.ms/gcmcore")
+            var psi = new ProcessStartInfo("https://aka.ms/gcm")
             {
                 UseShellExecute = true
             };

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -148,14 +148,14 @@ namespace GitCredentialManager
 
         public static class HelpUrls
         {
-            public const string GcmProjectUrl          = "https://aka.ms/gcmcore";
-            public const string GcmNewIssue            = "https://aka.ms/gcmcore-bug";
-            public const string GcmAuthorityDeprecated = "https://aka.ms/gcmcore-authority";
-            public const string GcmHttpProxyGuide      = "https://aka.ms/gcmcore-httpproxy";
-            public const string GcmTlsVerification     = "https://aka.ms/gcmcore-tlsverify";
-            public const string GcmCredentialStores    = "https://aka.ms/gcmcore-credstores";
-            public const string GcmWamComSecurity      = "https://aka.ms/gcmcore-wamadmin";
-            public const string GcmAutoDetect          = "https://aka.ms/gcmcore-autodetect";
+            public const string GcmProjectUrl          = "https://aka.ms/gcm";
+            public const string GcmNewIssue            = "https://aka.ms/gcm/bug";
+            public const string GcmAuthorityDeprecated = "https://aka.ms/gcm/authority";
+            public const string GcmHttpProxyGuide      = "https://aka.ms/gcm/httpproxy";
+            public const string GcmTlsVerification     = "https://aka.ms/gcm/tlsverify";
+            public const string GcmCredentialStores    = "https://aka.ms/gcm/credstores";
+            public const string GcmWamComSecurity      = "https://aka.ms/gcm/wamadmin";
+            public const string GcmAutoDetect          = "https://aka.ms/gcm/autodetect";
         }
 
         private static Version _gcmVersion;

--- a/src/shared/Core/Settings.cs
+++ b/src/shared/Core/Settings.cs
@@ -447,7 +447,7 @@ namespace GitCredentialManager
                     /*
                      * COMPAT: In the previous GCM we accepted the values 'auto', 'never', and 'always'.
                      *
-                     * We've slightly changed the behaviour of this setting in GCM Core to essentially
+                     * We've slightly changed the behaviour of this setting in GCM to essentially
                      * remove the 'always' option. The table below outlines the changes:
                      *
                      * -------------------------------------------------------------

--- a/src/shared/Git-Credential-Manager/NOTICE
+++ b/src/shared/Git-Credential-Manager/NOTICE
@@ -1,7 +1,7 @@
 NOTICES AND INFORMATION
 Do Not Translate or Localize
 
-This repository for Git Credential Manager Core includes material from the
+This repository for Git Credential Manager includes material from the
 projects listed below.
 
 --------------------------------------------------------------------------------

--- a/src/shared/GitHub/GitHubConstants.cs
+++ b/src/shared/GitHub/GitHubConstants.cs
@@ -25,7 +25,7 @@ namespace GitHub
         public const string GitHubOptHeader = "X-GitHub-OTP";
 
         /// <summary>
-        /// Minimum GitHub Enterprise Server version that supports OAuth authentication with GCM Core.
+        /// Minimum GitHub Enterprise Server version that supports OAuth authentication with GCM.
         /// </summary>
         public static readonly Version MinimumOnPremOAuthVersion = new Version("3.2");
 

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -145,7 +145,7 @@ namespace GitHub
                     // the PAT permissions manually on the web and then retry the Git operation.
                     // We must store the PAT now so they can resume/repeat the operation with the same,
                     // now SSO authorized, PAT.
-                    // See: https://github.com/microsoft/Git-Credential-Manager-Core/issues/133
+                    // See: https://github.com/GitCredentialManager/git-credential-manager/issues/133
                     Context.CredentialStore.AddOrUpdate(service, patCredential.Account, patCredential.Password);
                     return patCredential;
 

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -461,7 +461,7 @@ namespace Microsoft.AzureRepos
             IGitConfiguration targetConfig = _context.Git.GetConfiguration();
 
             // On Windows, if there is a "manager-core" entry remaining in the system config then we must not clear
-            // the useHttpPath option otherwise this would break the bundled version of GCM Core in Git for Windows.
+            // the useHttpPath option otherwise this would break the bundled version of GCM in Git for Windows.
             if (!PlatformUtils.IsWindows() || target != ConfigurationTarget.System ||
                 targetConfig.GetAll(helperKey).All(x => !string.Equals(x, "manager-core")))
             {

--- a/src/windows/Installer.Windows/Setup.iss
+++ b/src/windows/Installer.Windows/Setup.iss
@@ -36,7 +36,7 @@
 #define GcmPublisherUrl "https://www.github.com"
 #define GcmCopyright "Copyright (c) GitHub, Inc. and contributors"
 #define GcmUrl "https://aka.ms/gcmcore"
-#define GcmReadme "https://github.com/microsoft/Git-Credential-Manager-Core/blob/main/README.md"
+#define GcmReadme "https://github.com/GitCredentialManager/git-credential-manager/blob/main/README.md"
 #define GcmRepoRoot "..\..\.."
 #define GcmAssets GcmRepoRoot + "\assets"
 #define GcmExe "git-credential-manager-core.exe"

--- a/src/windows/Installer.Windows/Setup.iss
+++ b/src/windows/Installer.Windows/Setup.iss
@@ -35,7 +35,7 @@
 #define GcmVersionInfoDescription "Secure, cross-platform Git credential manager."
 #define GcmPublisherUrl "https://www.github.com"
 #define GcmCopyright "Copyright (c) GitHub, Inc. and contributors"
-#define GcmUrl "https://aka.ms/gcmcore"
+#define GcmUrl "https://aka.ms/gcm"
 #define GcmReadme "https://github.com/GitCredentialManager/git-credential-manager/blob/main/README.md"
 #define GcmRepoRoot "..\..\.."
 #define GcmAssets GcmRepoRoot + "\assets"
@@ -139,7 +139,7 @@ begin
 
   #if InstallTarget == "user"
     if not WizardSilent() and IsAdmin() then begin
-      if MsgBox('This User Installer is not meant to be run as an Administrator. If you would like to install Git Credential Manager for all users in this system, download the System Installer instead from https://aka.ms/gcmcore-latest. Are you sure you want to continue?', mbError, MB_OKCANCEL) = IDCANCEL then begin
+      if MsgBox('This User Installer is not meant to be run as an Administrator. If you would like to install Git Credential Manager for all users in this system, download the System Installer instead from https://aka.ms/gcm/latest. Are you sure you want to continue?', mbError, MB_OKCANCEL) = IDCANCEL then begin
         Result := False;
       end;
     end;

--- a/src/windows/Installer.Windows/Setup.iss
+++ b/src/windows/Installer.Windows/Setup.iss
@@ -17,12 +17,12 @@
 
 #if InstallTarget == "user"
   #define GcmAppId "{{aa76d31d-432c-42ee-844c-bc0bc801cef3}}"
-  #define GcmLongName "Git Credential Manager Core (User)"
+  #define GcmLongName "Git Credential Manager (User)"
   #define GcmSetupExe "gcmcoreuser"
   #define GcmConfigureCmdArgs ""
 #elif InstallTarget == "system"
   #define GcmAppId "{{fdfae50a-1bc1-4ead-9228-1e1c275e8d12}}"
-  #define GcmLongName "Git Credential Manager Core"
+  #define GcmLongName "Git Credential Manager"
   #define GcmSetupExe "gcmcore"
   #define GcmConfigureCmdArgs "--system"
 #else
@@ -30,7 +30,7 @@
 #endif
 
 ; Define core properties
-#define GcmShortName "Git Credential Manager Core"
+#define GcmShortName "Git Credential Manager"
 #define GcmPublisher "GitHub"
 #define GcmVersionInfoDescription "Secure, cross-platform Git credential manager."
 #define GcmPublisherUrl "https://www.github.com"
@@ -139,7 +139,7 @@ begin
 
   #if InstallTarget == "user"
     if not WizardSilent() and IsAdmin() then begin
-      if MsgBox('This User Installer is not meant to be run as an Administrator. If you would like to install Git Credential Manager Core for all users in this system, download the System Installer instead from https://aka.ms/gcmcore-latest. Are you sure you want to continue?', mbError, MB_OKCANCEL) = IDCANCEL then begin
+      if MsgBox('This User Installer is not meant to be run as an Administrator. If you would like to install Git Credential Manager for all users in this system, download the System Installer instead from https://aka.ms/gcmcore-latest. Are you sure you want to continue?', mbError, MB_OKCANCEL) = IDCANCEL then begin
         Result := False;
       end;
     end;


### PR DESCRIPTION
New org, new GCM! 🎉  This change updates the docs with:

1. Git Credential Manager Core/GCM Core --> Git Credential Manager/GCM
2. microsoft/Git-Credential-Manager-Core --> GitCredentialManager/git-credential-manager
3. `aka.ms/gcmcore-*` --> `aka.ms/gcm/*`
4. `gcmcore-test@example.com` --> `gcm-test@example.com`