### PR TITLE
updated wsl.md  to refer `git-credential-manager.exe` instead of `git-credential-manager-core.exe`

### DIFF
--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -22,7 +22,7 @@ _Inside your WSL installation_, run the following command to set GCM as the Git
 credential helper:
 
 ```shell
-git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe"
+git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager.exe"
 ```
 
 If you intend to use Azure DevOps you must _also_ set the following Git
@@ -44,7 +44,7 @@ _Inside your WSL installation_, run the following command to set GCM as the Git
 credential helper:
 
 ```shell
-git config --global credential.helper /mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe
+git config --global credential.helper /mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager.exe
 
 # For Azure DevOps support only
 git config --global credential.https://dev.azure.com.useHttpPath true


### PR DESCRIPTION
updated wsl.md  to refer `git-credential-manager.exe` instead of `git-credential-manager-core.exe`