### PR TITLE
Fix bug in Azure Repos binding `list` command

### DIFF
--- a/src/shared/Microsoft.AzureRepos/AzureReposBindingManager.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposBindingManager.cs
@@ -181,7 +181,7 @@ namespace Microsoft.AzureRepos
                     uri.Scheme == AzureDevOpsConstants.UrnScheme && uri.AbsolutePath.StartsWith(orgPrefix))
                 {
                     string entryOrgName = uri.AbsolutePath.Substring(orgPrefix.Length);
-                    if (orgName is null || StringComparer.OrdinalIgnoreCase.Equals(entryOrgName, orgName))
+                    if (string.IsNullOrWhiteSpace(orgName) || StringComparer.OrdinalIgnoreCase.Equals(entryOrgName, orgName))
                     {
                         dict[entryOrgName] = entry.Value;
                     }

--- a/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
+++ b/src/shared/Microsoft.AzureRepos/AzureReposHostProvider.cs
@@ -596,7 +596,7 @@ namespace Microsoft.AzureRepos
                 }
             }
 
-            bool isFiltered = organization != null;
+            bool isFiltered = !string.IsNullOrWhiteSpace(organization);
             string indent = isFiltered ? string.Empty : "  ";
 
             // Get the set of all organization names (organization names are not case sensitive)


### PR DESCRIPTION
There has been a behaviour change in the System.CommandLine library. Previously string arguments that were missing would be null, but now they are the empty string.

Update downlevel use of the `organization` parameter in `BindCmd` to also expect an empty/whitespace string, as well as null.