### PR TITLE
Allow shortcut to perform OAuth from first prompt with Bitbucket

### DIFF
--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketAuthenticationTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketAuthenticationTest.cs
@@ -9,20 +9,99 @@ namespace Atlassian.Bitbucket.Tests
     {
         [Theory]
         [InlineData("jsquire", "password")]
-        public async Task BitbucketAuthentication_GetBasicCredentialsAsync_SucceedsAfterUserInput(string username, string password)
+        public async Task BitbucketAuthentication_GetCredentialsAsync_Basic_SucceedsAfterUserInput(string username, string password)
         {
             var context = new TestCommandContext();
             context.Terminal.Prompts["Username"] = username;
             context.Terminal.SecretPrompts["Password"] = password;
-            System.Uri targetUri = null;
+            Uri targetUri = null;
 
             var bitbucketAuthentication = new BitbucketAuthentication(context);
 
-            var result = await bitbucketAuthentication.GetBasicCredentialsAsync(targetUri, username);
+            var result = await bitbucketAuthentication.GetCredentialsAsync(targetUri, username, AuthenticationModes.Basic);
 
             Assert.NotNull(result);
-            Assert.Equal(username, result.Account);
-            Assert.Equal(password, result.Password);
+            Assert.Equal(AuthenticationModes.Basic, result.AuthenticationMode);
+            Assert.Equal(username, result.Credential.Account);
+            Assert.Equal(password, result.Credential.Password);
+        }
+
+        [Fact]
+        public async Task BitbucketAuthentication_GetCredentialsAsync_OAuth_ReturnsOAuth()
+        {
+            var context = new TestCommandContext();
+            context.SessionManager.IsDesktopSession = true; // Allow OAuth mode
+            Uri targetUri = null;
+
+            var bitbucketAuthentication = new BitbucketAuthentication(context);
+
+            var result = await bitbucketAuthentication.GetCredentialsAsync(targetUri, null, AuthenticationModes.OAuth);
+
+            Assert.NotNull(result);
+            Assert.Equal(AuthenticationModes.OAuth, result.AuthenticationMode);
+            Assert.Null(result.Credential);
+        }
+
+        [Fact]
+        public async Task BitbucketAuthentication_GetCredentialsAsync_All_ShowsMenu_OAuthOption1()
+        {
+            var context = new TestCommandContext();
+            context.SessionManager.IsDesktopSession = true; // Allow OAuth mode
+            context.Terminal.Prompts["option (enter for default)"] = "1";
+            Uri targetUri = null;
+
+            var bitbucketAuthentication = new BitbucketAuthentication(context);
+
+            var result = await bitbucketAuthentication.GetCredentialsAsync(targetUri, null, AuthenticationModes.All);
+
+            Assert.NotNull(result);
+            Assert.Equal(AuthenticationModes.OAuth, result.AuthenticationMode);
+            Assert.Null(result.Credential);
+        }
+
+        [Fact]
+        public async Task BitbucketAuthentication_GetCredentialsAsync_All_ShowsMenu_BasicOption2()
+        {
+            const string username = "jsquire";
+            const string password = "password";
+
+            var context = new TestCommandContext();
+            context.SessionManager.IsDesktopSession = true; // Allow OAuth mode
+            context.Terminal.Prompts["option (enter for default)"] = "2";
+            context.Terminal.Prompts["Username"] = username;
+            context.Terminal.SecretPrompts["Password"] = password;
+            Uri targetUri = null;
+
+            var bitbucketAuthentication = new BitbucketAuthentication(context);
+
+            var result = await bitbucketAuthentication.GetCredentialsAsync(targetUri, null, AuthenticationModes.All);
+
+            Assert.NotNull(result);
+            Assert.Equal(AuthenticationModes.Basic, result.AuthenticationMode);
+            Assert.Equal(username, result.Credential.Account);
+            Assert.Equal(password, result.Credential.Password);
+        }
+
+        [Fact]
+        public async Task BitbucketAuthentication_GetCredentialsAsync_All_NoDesktopSession_BasicOnly()
+        {
+            const string username = "jsquire";
+            const string password = "password";
+
+            var context = new TestCommandContext();
+            context.SessionManager.IsDesktopSession = false; // Disallow OAuth mode
+            context.Terminal.Prompts["Username"] = username;
+            context.Terminal.SecretPrompts["Password"] = password;
+            Uri targetUri = null;
+
+            var bitbucketAuthentication = new BitbucketAuthentication(context);
+
+            var result = await bitbucketAuthentication.GetCredentialsAsync(targetUri, null, AuthenticationModes.All);
+
+            Assert.NotNull(result);
+            Assert.Equal(AuthenticationModes.Basic, result.AuthenticationMode);
+            Assert.Equal(username, result.Credential.Account);
+            Assert.Equal(password, result.Credential.Password);
         }
 
         [Fact]

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -100,7 +100,7 @@ namespace Atlassian.Bitbucket.Tests
             var credential = provider.GetCredentialAsync(input);
 
             //verify bitbucket.org credentials were validated
-            if (BITBUCKET_DOT_ORG_HOST.Equals(host)) 
+            if (BITBUCKET_DOT_ORG_HOST.Equals(host))
             {
                 VerifyValidateBasicAuthCredentialsRan();
             }
@@ -148,7 +148,7 @@ namespace Atlassian.Bitbucket.Tests
         [InlineData("https", DC_SERVER_HOST, "jsquire", "password")]
         // cloud
         [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password")]
-        public void BitbucketHostProvider_GetCredentialAsync_Succeeds_ForFreshValidBasicAuthAccount(string protocol, string host, string username,string password)
+        public void BitbucketHostProvider_GetCredentialAsync_Succeeds_ForFreshValidBasicAuthAccount(string protocol, string host, string username, string password)
         {
             InputArguments input = MockInput(protocol, host, username);
 
@@ -156,7 +156,7 @@ namespace Atlassian.Bitbucket.Tests
 
             MockUserEntersValidBasicCredentials(bitbucketAuthentication, input, password);
 
-            if (BITBUCKET_DOT_ORG_HOST.Equals(host)) 
+            if (BITBUCKET_DOT_ORG_HOST.Equals(host))
             {
                 MockRemoteOAuthAccountIsValid(bitbucketApi, input, password, true);
             }
@@ -202,7 +202,7 @@ namespace Atlassian.Bitbucket.Tests
         [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password", "basic")]
         [InlineData("https", BITBUCKET_DOT_ORG_HOST, "jsquire", "password", "oauth")]
         // Basic Auth works
-        public void BitbucketHostProvider_GetCredentialAsync_ForcedAuthMode_IsRespected(string protocol, string host, string username, string password, 
+        public void BitbucketHostProvider_GetCredentialAsync_ForcedAuthMode_IsRespected(string protocol, string host, string username, string password,
             string preconfiguredAuthModes)
         {
             var input = MockInput(protocol, host, username);
@@ -249,7 +249,7 @@ namespace Atlassian.Bitbucket.Tests
         [InlineData("https", DC_SERVER_HOST, "jsquire", "password", "1")]
         [InlineData("https", DC_SERVER_HOST, "jsquire", "password", "true")]
         [InlineData("https", DC_SERVER_HOST, "jsquire", "password", null)]
-        public void BitbucketHostProvider_GetCredentialAsync_AlwaysRefreshCredentials_IsRespected(string protocol, string host, string username, string password, 
+        public void BitbucketHostProvider_GetCredentialAsync_AlwaysRefreshCredentials_IsRespected(string protocol, string host, string username, string password,
             string alwaysRefreshCredentials)
         {
             var input = MockInput(protocol, host, username);
@@ -257,7 +257,7 @@ namespace Atlassian.Bitbucket.Tests
             var context = new TestCommandContext();
             if (alwaysRefreshCredentials != null)
             {
-                context.Environment.Variables.Add(BitbucketConstants.EnvironmentVariables.AlwaysRefreshCredentials, alwaysRefreshCredentials.ToString());
+                context.Environment.Variables.Add(BitbucketConstants.EnvironmentVariables.AlwaysRefreshCredentials, alwaysRefreshCredentials);
             }
 
             MockStoredAccount(context, input, password);
@@ -269,8 +269,8 @@ namespace Atlassian.Bitbucket.Tests
 
             var credential = provider.GetCredentialAsync(input);
 
-            var alwaysRefreshCredentialsBool = "1".Equals(alwaysRefreshCredentials) 
-                || "on".Equals(alwaysRefreshCredentials) 
+            var alwaysRefreshCredentialsBool = "1".Equals(alwaysRefreshCredentials)
+                || "on".Equals(alwaysRefreshCredentials)
                 || "true".Equals(alwaysRefreshCredentials) ? true : false;
 
             if (alwaysRefreshCredentialsBool)
@@ -314,7 +314,7 @@ namespace Atlassian.Bitbucket.Tests
 
             Assert.Equal(expectedModes, actualModes);
         }
-        
+
         [Theory]
         // DC
         [InlineData("https", DC_SERVER_HOST, "jsquire", "password")]
@@ -347,8 +347,6 @@ namespace Atlassian.Bitbucket.Tests
 
                 var credential = await provider.GetCredentialAsync(input);
             }
-
-            
         }
 
         [Theory]
@@ -367,7 +365,7 @@ namespace Atlassian.Bitbucket.Tests
 
             Assert.Equal(1, context.CredentialStore.Count);
         }
-        
+
         [Theory]
         [InlineData("https", DC_SERVER_HOST, "jsquire", "password")]
         public async Task BitbucketHostProvider_EraseCredentialAsync(string protocol, string host, string username, string password)
@@ -400,14 +398,14 @@ namespace Atlassian.Bitbucket.Tests
             });
         }
 
-        private void VerifyBasicAuthFlowRan(string password, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential,
+        private void VerifyBasicAuthFlowRan(string password, bool expected, InputArguments input, Task<ICredential> credential,
             string preconfiguredAuthModes)
         {
             Assert.Equal(expected, credential != null);
 
             var remoteUri = input.GetRemoteUri();
 
-            bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Once);
+            bitbucketAuthentication.Verify(m => m.GetCredentialsAsync(remoteUri, input.UserName, It.IsAny<AuthenticationModes>()), Times.Once);
 
             // check username/password for Bitbucket.org
             if ((preconfiguredAuthModes == null && BITBUCKET_DOT_ORG_HOST == remoteUri.Host)
@@ -417,12 +415,12 @@ namespace Atlassian.Bitbucket.Tests
             }
         }
 
-        private void VerifyInteractiveBasicAuthFlowRan(string password, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
+        private void VerifyInteractiveBasicAuthFlowRan(string password, InputArguments input, Task<ICredential> credential)
         {
             var remoteUri = input.GetRemoteUri();
 
             // verify users was prompted for username/password credentials
-            bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Once);
+            bitbucketAuthentication.Verify(m => m.GetCredentialsAsync(remoteUri, input.UserName, It.IsAny<AuthenticationModes>()), Times.Once);
 
             // check username/password for Bitbucket.org
             if (BITBUCKET_DOT_ORG_HOST == remoteUri.Host)
@@ -440,23 +438,23 @@ namespace Atlassian.Bitbucket.Tests
                 (preconfiguredAuthModes == null || preconfiguredAuthModes.Contains("basic")) )
             {
                 // never prompt the user for basic credentials
-                bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Once);
+                bitbucketAuthentication.Verify(m => m.GetCredentialsAsync(remoteUri, input.UserName, It.IsAny<AuthenticationModes>()), Times.Once);
             }
             else
             {
                 // never prompt the user for basic credentials
-                bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Never);
+                bitbucketAuthentication.Verify(m => m.GetCredentialsAsync(remoteUri, input.UserName, It.IsAny<AuthenticationModes>()), Times.Never);
             }
         }
 
-        private void VerifyInteractiveBasicAuthFlowNeverRan(string password, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
+        private void VerifyInteractiveBasicAuthFlowNeverRan(string password, InputArguments input, Task<ICredential> credential)
         {
             var remoteUri = input.GetRemoteUri();
 
-            bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Never);
+            bitbucketAuthentication.Verify(m => m.GetCredentialsAsync(remoteUri, input.UserName, It.IsAny<AuthenticationModes>()), Times.Never);
         }
 
-        private void VerifyOAuthFlowRan(string password, bool storedAccount, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential,
+        private void VerifyOAuthFlowRan(string password, bool storedAccount, bool expected, InputArguments input, Task<ICredential> credential,
             string preconfiguredAuthModes)
         {
             Assert.Equal(expected, credential != null);
@@ -476,7 +474,7 @@ namespace Atlassian.Bitbucket.Tests
                 if (preconfiguredAuthModes == null || preconfiguredAuthModes.Contains("basic"))
                 {
                     // prompt user for basic auth, if basic auth is not excluded
-                    bitbucketAuthentication.Verify(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName), Times.Once);
+                    bitbucketAuthentication.Verify(m => m.GetCredentialsAsync(remoteUri, input.UserName, It.IsAny<AuthenticationModes>()), Times.Once);
 
                     // check if entered Basic Auth credentials work, if basic auth is not excluded
                     bitbucketApi.Verify(m => m.GetUserInformationAsync(input.UserName, password, false), Times.Once);
@@ -493,7 +491,7 @@ namespace Atlassian.Bitbucket.Tests
 
             // Basic Auth 403-ed so push user through OAuth flow
             bitbucketAuthentication.Verify(m => m.ShowOAuthRequiredPromptAsync(), Times.Once);
-                
+
         }
 
         private void VerifyOAuthFlowDidNotRun(string password, bool expected, InputArguments input, System.Threading.Tasks.Task<ICredential> credential)
@@ -526,25 +524,25 @@ namespace Atlassian.Bitbucket.Tests
             bitbucketApi.Verify(m => m.GetUserInformationAsync(null, MOCK_ACCESS_TOKEN, true), Times.Never);
         }
 
-        private void VerifyValidateBasicAuthCredentialsNeverRan() 
+        private void VerifyValidateBasicAuthCredentialsNeverRan()
         {
             // never check username/password works
             bitbucketApi.Verify(m => m.GetUserInformationAsync(It.IsAny<string>(), It.IsAny<string>(), false), Times.Never);
         }
 
-        private void VerifyValidateBasicAuthCredentialsRan() 
+        private void VerifyValidateBasicAuthCredentialsRan()
         {
             // check username/password works
             bitbucketApi.Verify(m => m.GetUserInformationAsync(It.IsAny<string>(), It.IsAny<string>(), false), Times.Once);
         }
 
-        private void VerifyValidateOAuthCredentialsNeverRan() 
+        private void VerifyValidateOAuthCredentialsNeverRan()
         {
             // never check username/password works
             bitbucketApi.Verify(m => m.GetUserInformationAsync(null, It.IsAny<string>(), false), Times.Never);
         }
 
-        private void VerifyValidateOAuthCredentialsRan() 
+        private void VerifyValidateOAuthCredentialsRan()
         {
             // check username/password works
             bitbucketApi.Verify(m => m.GetUserInformationAsync(null, It.IsAny<string>(), true), Times.Once);
@@ -565,30 +563,35 @@ namespace Atlassian.Bitbucket.Tests
 
         private static void MockInvalidRemoteBasicAccount(Mock<IBitbucketRestApi> bitbucketApi, Mock<IBitbucketAuthentication> bitbucketAuthentication)
         {
-            bitbucketAuthentication.Setup(m => m.GetBasicCredentialsAsync(It.IsAny<Uri>(), It.IsAny<String>())).ReturnsAsync((TestCredential)null);
+            bitbucketAuthentication.Setup(m => m.GetCredentialsAsync(It.IsAny<Uri>(), It.IsAny<String>(), It.IsAny<AuthenticationModes>()))
+                .ReturnsAsync(new CredentialsPromptResult(AuthenticationModes.Basic, null));
 
-            bitbucketApi.Setup(x => x.GetUserInformationAsync(It.IsAny<String>(), It.IsAny<String>(), false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.Unauthorized));
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(It.IsAny<String>(), It.IsAny<String>(), false))
+                .ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.Unauthorized));
 
         }
         private static void MockUserEntersValidBasicCredentials(Mock<IBitbucketAuthentication> bitbucketAuthentication, InputArguments input, string password)
         {
             var remoteUri = input.GetRemoteUri();
-            bitbucketAuthentication.Setup(m => m.GetBasicCredentialsAsync(remoteUri, input.UserName)).ReturnsAsync(new TestCredential(input.Host, input.UserName, password));
+            bitbucketAuthentication.Setup(m => m.GetCredentialsAsync(remoteUri, input.UserName, It.IsAny<AuthenticationModes>()))
+                .ReturnsAsync(new CredentialsPromptResult(AuthenticationModes.Basic, new TestCredential(input.Host, input.UserName, password)));
         }
 
         private static void MockUserDoesNotEntersValidBasicCredentials(Mock<IBitbucketAuthentication> bitbucketAuthentication)
         {
-            bitbucketAuthentication.Setup(m => m.GetBasicCredentialsAsync(It.IsAny<Uri>(), It.IsAny<String>())).ReturnsAsync((TestCredential)null);
+            bitbucketAuthentication.Setup(m => m.GetCredentialsAsync(It.IsAny<Uri>(), It.IsAny<String>(), It.IsAny<AuthenticationModes>()))
+                .ReturnsAsync(new CredentialsPromptResult(AuthenticationModes.Basic, null));
         }
 
         private static void MockRemoteBasicAuthAccountIsValid(Mock<IBitbucketRestApi> bitbucketApi, InputArguments input, string password, bool twoFAEnabled)
         {
             var userInfo = new UserInfo() { IsTwoFactorAuthenticationEnabled = twoFAEnabled };
             // Basic
-            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, false))
+                .ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
 
         }
-            
+
         private static void MockRemoteBasicAuthAccountIsValidRequires2FA(Mock<IBitbucketRestApi> bitbucketApi, InputArguments input, string password)
         {
             MockRemoteBasicAuthAccountIsValid(bitbucketApi, input, password, true);
@@ -603,7 +606,8 @@ namespace Atlassian.Bitbucket.Tests
         {
             var userInfo = new UserInfo();
             // Basic
-            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.Forbidden, userInfo));
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(input.UserName, password, false))
+                .ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.Forbidden, userInfo));
 
         }
 
@@ -611,7 +615,8 @@ namespace Atlassian.Bitbucket.Tests
         {
             var userInfo = new UserInfo() { IsTwoFactorAuthenticationEnabled = twoFAEnabled };
             // OAuth
-            bitbucketApi.Setup(x => x.GetUserInformationAsync(null, password, true)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
+            bitbucketApi.Setup(x => x.GetUserInformationAsync(null, password, true))
+                .ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
         }
 
         private static void MockStoredAccount(TestCommandContext context, InputArguments input, string password)
@@ -624,7 +629,8 @@ namespace Atlassian.Bitbucket.Tests
         private static void MockValidStoredOAuthUser(TestCommandContext context, Mock<IBitbucketRestApi> bitbucketApi)
         {
             var userInfo = new UserInfo() { IsTwoFactorAuthenticationEnabled = false };
-            bitbucketApi.Setup(x => x.GetUserInformationAsync("jsquire", "password1", false)).ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
+            bitbucketApi.Setup(x => x.GetUserInformationAsync("jsquire", "password1", false))
+                .ReturnsAsync(new RestApiResult<UserInfo>(System.Net.HttpStatusCode.OK, userInfo));
             context.CredentialStore.Add("https://bitbucket.org", new TestCredential("https://bitbucket.org", "jsquire", "password1"));
         }
 

--- a/src/shared/Atlassian.Bitbucket.UI.Avalonia/Controls/TesterWindow.axaml.cs
+++ b/src/shared/Atlassian.Bitbucket.UI.Avalonia/Controls/TesterWindow.axaml.cs
@@ -51,7 +51,10 @@ namespace Atlassian.Bitbucket.UI.Controls
 
         private void ShowCredentials(object sender, RoutedEventArgs e)
         {
-            var vm = new CredentialsViewModel(_environment);
+            var vm = new CredentialsViewModel(_environment)
+            {
+                ShowOAuth = true
+            };
             var view = new CredentialsView();
             var window = new DialogWindow(view) {DataContext = vm};
             window.ShowDialog(this);

--- a/src/shared/Atlassian.Bitbucket.UI.Avalonia/Views/CredentialsView.axaml
+++ b/src/shared/Atlassian.Bitbucket.UI.Avalonia/Views/CredentialsView.axaml
@@ -34,11 +34,16 @@
                      HorizontalAlignment="Stretch"
                      Watermark="Password" PasswordChar="●"
                      Text="{Binding Password}" />
-            <Button IsDefault="True"
+            <Button IsDefault="True" Margin="0,0,0,10"
                     HorizontalAlignment="Center" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                     Command="{Binding LoginCommand}"
                     Content="Continue" Width="140" Height="40"
-                    Classes="accent"/>
+                    Classes="accent" />
+            <Button HorizontalAlignment="Center" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    IsVisible="{Binding ShowOAuth}"
+                    Command="{Binding OAuthCommand}"
+                    Classes="hyperlink"
+                    Content="Sign in with OAuth" />
         </StackPanel>
     </DockPanel>
 </UserControl>

--- a/src/shared/Atlassian.Bitbucket.UI/Commands/CredentialsCommand.cs
+++ b/src/shared/Atlassian.Bitbucket.UI/Commands/CredentialsCommand.cs
@@ -19,14 +19,19 @@ namespace Atlassian.Bitbucket.UI.Commands
                 new Option<string>("--username", "Username or email.")
             );
 
-            Handler = CommandHandler.Create<string>(ExecuteAsync);
+            AddOption(
+                new Option("--show-oauth", "Show OAuth option.")
+            );
+
+            Handler = CommandHandler.Create<string, bool>(ExecuteAsync);
         }
 
-        private async Task<int> ExecuteAsync(string userName)
+        private async Task<int> ExecuteAsync(string userName, bool showOAuth)
         {
             var viewModel = new CredentialsViewModel(Context.Environment)
             {
-                UserName = userName
+                UserName = userName,
+                ShowOAuth = showOAuth
             };
 
             await ShowAsync(viewModel, CancellationToken.None);
@@ -36,11 +41,22 @@ namespace Atlassian.Bitbucket.UI.Commands
                 throw new Exception("User cancelled dialog.");
             }
 
-            WriteResult(new Dictionary<string, string>
+            if (viewModel.UseOAuth)
             {
-                ["username"] = viewModel.UserName,
-                ["password"] = viewModel.Password,
-            });
+                WriteResult(new Dictionary<string, string>
+                {
+                    ["mode"] = "oauth"
+                });
+            }
+            else
+            {
+                WriteResult(new Dictionary<string, string>
+                {
+                    ["mode"] = "basic",
+                    ["username"] = viewModel.UserName,
+                    ["password"] = viewModel.Password,
+                });
+            }
 
             return 0;
         }

--- a/src/shared/Atlassian.Bitbucket.UI/ViewModels/CredentialsViewModel.cs
+++ b/src/shared/Atlassian.Bitbucket.UI/ViewModels/CredentialsViewModel.cs
@@ -12,6 +12,7 @@ namespace Atlassian.Bitbucket.UI.ViewModels
 
         private string _userName;
         private string _password;
+        private bool _showOAuth;
 
         public CredentialsViewModel()
         {
@@ -27,6 +28,7 @@ namespace Atlassian.Bitbucket.UI.ViewModels
             Title = "Connect to Bitbucket";
             LoginCommand = new RelayCommand(Accept, CanLogin);
             CancelCommand = new RelayCommand(Cancel);
+            OAuthCommand = new RelayCommand(AcceptOAuth, CanAcceptOAuth);
             ForgotPasswordCommand = new RelayCommand(ForgotPassword);
             SignUpCommand = new RelayCommand(SignUp);
 
@@ -47,6 +49,17 @@ namespace Atlassian.Bitbucket.UI.ViewModels
         private bool CanLogin()
         {
             return !string.IsNullOrWhiteSpace(UserName) && !string.IsNullOrWhiteSpace(Password);
+        }
+
+        private void AcceptOAuth()
+        {
+            UseOAuth = true;
+            Accept();
+        }
+
+        private bool CanAcceptOAuth()
+        {
+            return ShowOAuth;
         }
 
         private void ForgotPassword()
@@ -72,6 +85,24 @@ namespace Atlassian.Bitbucket.UI.ViewModels
         }
 
         /// <summary>
+        /// Show the direct-to-OAuth button.
+        /// </summary>
+        public bool ShowOAuth
+        {
+            get => _showOAuth;
+            set => SetAndRaisePropertyChanged(ref _showOAuth, value);
+        }
+
+        /// <summary>
+        /// User indicated a preference to use OAuth authentication over username/password.
+        /// </summary>
+        public bool UseOAuth
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
         /// Start the process to validate the username/password
         /// </summary>
         public RelayCommand LoginCommand { get; }
@@ -80,6 +111,11 @@ namespace Atlassian.Bitbucket.UI.ViewModels
         /// Cancel the authentication attempt.
         /// </summary>
         public ICommand CancelCommand { get; }
+
+        /// <summary>
+        /// Use OAuth authentication instead of username/password.
+        /// </summary>
+        public ICommand OAuthCommand { get; }
 
         /// <summary>
         /// Hyperlink to the Bitbucket forgotten password process.

--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -22,10 +22,28 @@ namespace Atlassian.Bitbucket
     }
     public interface IBitbucketAuthentication : IDisposable
     {
-        Task<ICredential> GetBasicCredentialsAsync(Uri targetUri, string userName);
+        Task<CredentialsPromptResult> GetCredentialsAsync(Uri targetUri, string userName, AuthenticationModes modes);
         Task<bool> ShowOAuthRequiredPromptAsync();
         Task<OAuth2TokenResult> CreateOAuthCredentialsAsync(Uri targetUri);
         Task<OAuth2TokenResult> RefreshOAuthCredentialsAsync(string refreshToken);
+    }
+
+    public class CredentialsPromptResult
+    {
+        public CredentialsPromptResult(AuthenticationModes mode)
+        {
+            AuthenticationMode = mode;
+        }
+
+        public CredentialsPromptResult(AuthenticationModes mode, ICredential credential)
+            : this(mode)
+        {
+            Credential = credential;
+        }
+
+        public AuthenticationModes AuthenticationMode { get; }
+
+        public ICredential Credential { get; set; }
     }
 
     public class BitbucketAuthentication : AuthenticationBase, IBitbucketAuthentication
@@ -46,11 +64,30 @@ namespace Atlassian.Bitbucket
 
         #region IBitbucketAuthentication
 
-        public async Task<ICredential> GetBasicCredentialsAsync(Uri targetUri, string userName)
+        public async Task<CredentialsPromptResult> GetCredentialsAsync(Uri targetUri, string userName, AuthenticationModes modes)
         {
             ThrowIfUserInteractionDisabled();
 
             string password;
+
+            // If we don't have a desktop session/GUI then we cannot offer OAuth since the only
+            // supported grant is authcode (i.e, using a web browser; device code is not supported).
+            if (!Context.SessionManager.IsDesktopSession)
+            {
+                modes = modes & ~AuthenticationModes.OAuth;
+            }
+
+            // If the only supported mode is OAuth then just return immediately
+            if (modes == AuthenticationModes.OAuth)
+            {
+                return new CredentialsPromptResult(AuthenticationModes.OAuth);
+            }
+
+            // We need at least one mode!
+            if (modes == AuthenticationModes.None)
+            {
+                throw new ArgumentException(@$"Must specify at least one {nameof(AuthenticationModes)}", nameof(modes));
+            }
 
             // Shell out to the UI helper and show the Bitbucket u/p prompt
             if (Context.SessionManager.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
@@ -61,41 +98,86 @@ namespace Atlassian.Bitbucket
                     cmdArgs.AppendFormat(" --username {0}", QuoteCmdArg(userName));
                 }
 
+                if ((modes & AuthenticationModes.OAuth) != 0)
+                {
+                    cmdArgs.Append(" --show-oauth");
+                }
+
                 IDictionary<string, string> output = await InvokeHelperAsync(helperPath, cmdArgs.ToString());
 
-                if (!output.TryGetValue("username", out userName))
+                if (output.TryGetValue("mode", out string mode) &&
+                    StringComparer.OrdinalIgnoreCase.Equals(mode, "oauth"))
                 {
-                    throw new Exception("Missing username in response");
+                    return new CredentialsPromptResult(AuthenticationModes.OAuth);
                 }
-
-                if (!output.TryGetValue("password", out password))
+                else
                 {
-                    throw new Exception("Missing password in response");
-                }
+                    if (!output.TryGetValue("username", out userName))
+                    {
+                        throw new Exception("Missing username in response");
+                    }
 
-                return new GitCredential(userName, password);
+                    if (!output.TryGetValue("password", out password))
+                    {
+                        throw new Exception("Missing password in response");
+                    }
+
+                    return new CredentialsPromptResult(
+                        AuthenticationModes.Basic,
+                        new GitCredential(userName, password));
+                }
             }
             else
             {
                 ThrowIfTerminalPromptsDisabled();
 
-                Context.Terminal.WriteLine("Enter Bitbucket credentials for '{0}'...", targetUri);
-
-                if (!string.IsNullOrWhiteSpace(userName))
+                switch (modes)
                 {
-                    // Don't need to prompt for the username if it has been specified already
-                    Context.Terminal.WriteLine("Username: {0}", userName);
-                }
-                else
-                {
-                    // Prompt for username
-                    userName = Context.Terminal.Prompt("Username");
-                }
+                    case AuthenticationModes.Basic:
+                        Context.Terminal.WriteLine("Enter Bitbucket credentials for '{0}'...", targetUri);
 
-                // Prompt for password
-                password = Context.Terminal.PromptSecret("Password");
+                        if (!string.IsNullOrWhiteSpace(userName))
+                        {
+                            // Don't need to prompt for the username if it has been specified already
+                            Context.Terminal.WriteLine("Username: {0}", userName);
+                        }
+                        else
+                        {
+                            // Prompt for username
+                            userName = Context.Terminal.Prompt("Username");
+                        }
 
-                return new GitCredential(userName, password);
+                        // Prompt for password
+                        password = Context.Terminal.PromptSecret("Password");
+
+                        return new CredentialsPromptResult(
+                            AuthenticationModes.Basic,
+                            new GitCredential(userName, password));
+
+                    case AuthenticationModes.OAuth:
+                        return new CredentialsPromptResult(AuthenticationModes.OAuth);
+
+                    case AuthenticationModes.None:
+                        throw new ArgumentOutOfRangeException(nameof(modes), @$"At least one {nameof(AuthenticationModes)} must be supplied");
+
+                    default:
+                        var menuTitle = $"Select an authentication method for '{targetUri}'";
+                        var menu = new TerminalMenu(Context.Terminal, menuTitle);
+
+                        TerminalMenuItem oauthItem = null;
+                        TerminalMenuItem basicItem = null;
+
+                        if ((modes & AuthenticationModes.OAuth) != 0) oauthItem = menu.Add("OAuth");
+                        if ((modes & AuthenticationModes.Basic) != 0) basicItem = menu.Add("Username/password");
+
+                        // Default to the 'first' choice in the menu
+                        TerminalMenuItem choice = menu.Show(0);
+
+                        if (choice == oauthItem) goto case AuthenticationModes.OAuth;
+                        if (choice == basicItem) goto case AuthenticationModes.Basic;
+
+                        throw new Exception();
+                }
             }
         }
 

--- a/src/shared/Core/UriExtensions.cs
+++ b/src/shared/Core/UriExtensions.cs
@@ -74,6 +74,11 @@ namespace GitCredentialManager
 
         public static Uri WithoutUserInfo(this Uri uri)
         {
+            if (string.IsNullOrEmpty(uri.UserInfo))
+            {
+                return uri;
+            }
+
             return new UriBuilder(uri) {UserName = string.Empty, Password = string.Empty}.Uri;
         }
 

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Controls/TesterWindow.xaml.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Controls/TesterWindow.xaml.cs
@@ -17,7 +17,10 @@ namespace Atlassian.Bitbucket.UI.Controls
 
         private void ShowCredentials(object sender, RoutedEventArgs e)
         {
-            var vm = new CredentialsViewModel(_environment);
+            var vm = new CredentialsViewModel(_environment)
+            {
+                ShowOAuth = true
+            };
             var view = new CredentialsView();
             var window = new DialogWindow(view) { DataContext = vm };
             window.ShowDialog();

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Views/CredentialsView.xaml
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Views/CredentialsView.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:viewModels="clr-namespace:Atlassian.Bitbucket.UI.ViewModels;assembly=Atlassian.Bitbucket.UI.Shared"
              xmlns:sharedControls="clr-namespace:GitCredentialManager.UI.Controls;assembly=gcmcoreuiwpf"
+             xmlns:sharedConverters="clr-namespace:GitCredentialManager.UI.Converters;assembly=gcmcoreuiwpf"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance viewModels:CredentialsViewModel}"
              d:DesignWidth="300">
@@ -13,6 +14,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="../Assets/Styles.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+            <sharedConverters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
     <DockPanel LastChildFill="True">
@@ -50,6 +52,7 @@
                                           PromptText="Password"
                                           Password="{Binding Password, UpdateSourceTrigger=PropertyChanged, Delay=300, Mode=OneWayToSource}" />
             <Button IsDefault="True"
+                    Margin="0,0,0,10"
                     HorizontalAlignment="Center"
                     HorizontalContentAlignment="Center"
                     VerticalContentAlignment="Center"
@@ -57,6 +60,12 @@
                     Content="Continue"
                     Width="140" Height="40"
                     Style="{StaticResource AccentButton}"/>
+            <TextBlock FontSize="14" TextAlignment="Center"
+                       Visibility="{Binding ShowOAuth, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Hyperlink Command="{Binding OAuthCommand}">
+                    Sign in with OAuth
+                </Hyperlink>
+            </TextBlock>
         </StackPanel>
     </DockPanel>
 </UserControl>


### PR DESCRIPTION
Today if the user has 2FA enabled on their Atlassian account they need to either:

1. Enter their username/password, then perform the OAuth dance in a browser (potentially needing to re-enter their user/pass again), or
2. Set the [`credential.bitbucketAuthModes`](https://aka.ms/gcm/config#credentialbitbucketauthmodes) setting to `oauth`.

This change adds a new option to the initial credential prompt "Sign in with OAuth". Selecting this option allows the user to avoid typing their username/password in the dialog, and GCM proceeds directly to performing the OAuth dance in the browser!

Before|After
-|-
![image](https://user-images.githubusercontent.com/5658207/146974096-820d9f48-5d22-40bd-81e0-d33683359e76.png)|![image](https://user-images.githubusercontent.com/5658207/146974049-dd66c3bf-1291-4c39-b83f-86f13cd1019b.png)


Fixes #427

cc: @mminns 