### PR TITLE
Fix GitHub Enterprise API URL for raw source code links.

### DIFF
--- a/src/shared/GitHub/GitHubRestApi.cs
+++ b/src/shared/GitHub/GitHubRestApi.cs
@@ -212,7 +212,10 @@ namespace GitHub
             {
                 // If we're here, it's GitHub Enterprise via a configured authority
                 var baseUrl = targetUri.GetLeftPart(UriPartial.Authority);
+
+                // Check for 'raw.' in the hostname and remove it to get the correct GHE API URL
                 baseUrl = Regex.Replace(baseUrl, @"^(https?://)raw\.", "$1", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
                 return new Uri(baseUrl + $"/api/v3/{apiUrl}");
             }
         }

--- a/src/shared/GitHub/GitHubRestApi.cs
+++ b/src/shared/GitHub/GitHubRestApi.cs
@@ -212,6 +212,7 @@ namespace GitHub
             {
                 // If we're here, it's GitHub Enterprise via a configured authority
                 var baseUrl = targetUri.GetLeftPart(UriPartial.Authority);
+                baseUrl = Regex.Replace(baseUrl, @"^(https?://)raw\.", "$1", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
                 return new Uri(baseUrl + $"/api/v3/{apiUrl}");
             }
         }


### PR DESCRIPTION
This is a simple fix of #598 for GitHub Enterprise instances that use a `raw.` hostname prefix for raw source code links. I've verified this fix locally by swapping out the `GitHub.dll` that is used by Visual Studio.