### PR TITLE
Add option to disable GUI prompts/prefer terminal prompts instead

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,25 @@ git config --global credential.ghe.contoso.com.authority github
 
 ---
 
+### credential.guiPrompt
+
+Permit or disable GCM from presenting GUI prompts. If an equivalent terminal/
+text-based prompt is available, that will be shown instead.
+
+To disable all interactivity see [credential.interactive](#credentialinteractive).
+
+#### Example
+
+```shell
+git config --global credential.guiPrompt false
+```
+
+Defaults to enabled.
+
+**Also see: [GCM_GUI_PROMPT](environment.md#GCM_GUI_PROMPT)**
+
+---
+
 ### credential.autoDetectTimeout
 
 Set the maximum length of time, in milliseconds, that GCM should wait for a

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -226,6 +226,33 @@ export GCM_AUTHORITY=github
 
 ---
 
+### GCM_GUI_PROMPT
+
+Permit or disable GCM from presenting GUI prompts. If an equivalent terminal/
+text-based prompt is available, that will be shown instead.
+
+To disable all interactivity see [GCM_INTERACTIVE](#gcm_interactive).
+
+#### Example
+
+##### Windows
+
+```batch
+SET GCM_GUI_PROMPT=0
+```
+
+##### macOS/Linux
+
+```bash
+export GCM_GUI_PROMPT=0
+```
+
+Defaults to enabled.
+
+**Also see: [credential.guiPrompt](configuration.md#credentialguiprompt)**
+
+---
+
 ### GCM_AUTODETECT_TIMEOUT
 
 Set the maximum length of time, in milliseconds, that GCM should wait for a

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -109,3 +109,17 @@ Follow the instructions in [our WSL guide](wsl.md) carefully. Especially note th
 ### Does GCM work with multiple users? If so, how?
 
 That's a fairly complicated question to answer, but in short, yes. See [our document on multiple users](multiple-users.md) for details.
+
+### How can I extend GUI prompts/integrate prompts with my application?
+
+You can replace the GUI prompts of the Bitbucket and GitHub host providers
+specifically by using the `credential.gitHubHelper`/`credential.bitbucketHelper`
+settings or `GCM_GITHUB_HELPER`/`GCM_BITBUCKET_HELPER` environment variables.
+
+Set these variables to the path of an external helper executable that responds
+to the requests as the bundled UI helpers do. See the current `--help` documents
+for the bundled UI helpers (`GitHub.UI`/`Atlassian.Bitbucket.UI`) for more
+information.
+
+You may also set these variables to the empty string `""` to force terminal/
+text-based prompts instead.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -121,6 +121,10 @@ customize how GCM will prompt you (or not) for input. Please see the following:
 
 ### How can I extend GUI prompts/integrate prompts with my application?
 
+Application developers who use Git - think Visual Studio, GitKraken, etc. - may
+want to replace the GCM default UI with prompts styled to look like their
+application. This isn't complicated (though it is a bit of work).
+
 You can replace the GUI prompts of the Bitbucket and GitHub host providers
 specifically by using the `credential.gitHubHelper`/`credential.bitbucketHelper`
 settings or `GCM_GITHUB_HELPER`/`GCM_BITBUCKET_HELPER` environment variables.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -110,6 +110,15 @@ Follow the instructions in [our WSL guide](wsl.md) carefully. Especially note th
 
 That's a fairly complicated question to answer, but in short, yes. See [our document on multiple users](multiple-users.md) for details.
 
+### How can I disable GUI dialogs and prompts?
+
+There are various environment variables and configuration options available to
+customize how GCM will prompt you (or not) for input. Please see the following:
+
+- [`GCM_INTERACTIVE`](environment.md#GCM_INTERACTIVE) / [`credential.interactive`](configuration.md#credentialinteractive)
+- [`GCM_GUI_PROMPT`](environment.md#GCM_GUI_PROMPT) / [`credential.guiPrompt`](configuration.md#credentialguiprompt)
+- [`GIT_TERMINAL_PROMPT`](https://git-scm.com/docs/git#Documentation/git.txt-codeGITTERMINALPROMPTcode) (note this is a _Git setting_ that will affect Git as well as GCM)
+
 ### How can I extend GUI prompts/integrate prompts with my application?
 
 You can replace the GUI prompts of the Bitbucket and GitHub host providers

--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -90,7 +90,8 @@ namespace Atlassian.Bitbucket
             }
 
             // Shell out to the UI helper and show the Bitbucket u/p prompt
-            if (Context.SessionManager.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
+            if (Context.Settings.IsGuiPromptsEnabled && Context.SessionManager.IsDesktopSession &&
+                TryFindHelperExecutablePath(out string helperPath))
             {
                 var cmdArgs = new StringBuilder("userpass");
                 if (!string.IsNullOrWhiteSpace(userName))
@@ -186,7 +187,8 @@ namespace Atlassian.Bitbucket
             ThrowIfUserInteractionDisabled();
 
             // Shell out to the UI helper and show the Bitbucket prompt
-            if (Context.SessionManager.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
+            if (Context.Settings.IsGuiPromptsEnabled && Context.SessionManager.IsDesktopSession &&
+                TryFindHelperExecutablePath(out string helperPath))
             {
                 IDictionary<string, string> output = await InvokeHelperAsync(helperPath, "oauth");
 

--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -89,6 +87,16 @@ namespace GitCredentialManager.Authentication
                 Context.Trace.WriteLine($"{envName} / {cfgName} is false/never; user interactivity has been disabled.");
 
                 throw new InvalidOperationException("Cannot prompt because user interactivity has been disabled.");
+            }
+        }
+
+        protected void ThrowIfGuiPromptsDisabled()
+        {
+            if (!Context.Settings.IsGuiPromptsEnabled)
+            {
+                Context.Trace.WriteLine($"{Constants.EnvironmentVariables.GitTerminalPrompts} is 0; GUI prompts have been disabled.");
+
+                throw new InvalidOperationException("Cannot show prompt because GUI prompts have been disabled.");
             }
         }
 

--- a/src/shared/Core/Authentication/BasicAuthentication.cs
+++ b/src/shared/Core/Authentication/BasicAuthentication.cs
@@ -32,7 +32,8 @@ namespace GitCredentialManager.Authentication
             ThrowIfUserInteractionDisabled();
 
             // TODO: we only support system GUI prompts on Windows currently
-            if (Context.SessionManager.IsDesktopSession && PlatformUtils.IsWindows())
+            if (Context.Settings.IsGuiPromptsEnabled && Context.SessionManager.IsDesktopSession &&
+                PlatformUtils.IsWindows())
             {
                 return GetCredentialsByUi(resource, userName);
             }

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -86,6 +86,7 @@ namespace GitCredentialManager
             public const string GitExecutablePath     = "GIT_EXEC_PATH";
             public const string GpgExecutablePath     = "GCM_GPG_PATH";
             public const string GcmAutoDetectTimeout  = "GCM_AUTODETECT_TIMEOUT";
+            public const string GcmGuiPromptsEnabled  = "GCM_GUI_PROMPT";
         }
 
         public static class Http
@@ -120,6 +121,7 @@ namespace GitCredentialManager
                 public const string DpapiStorePath = "dpapiStorePath";
                 public const string UserName = "username";
                 public const string AutoDetectTimeout = "autoDetectTimeout";
+                public const string GuiPromptsEnabled = "guiPrompt";
             }
 
             public static class Http

--- a/src/shared/Core/Settings.cs
+++ b/src/shared/Core/Settings.cs
@@ -66,6 +66,14 @@ namespace GitCredentialManager
         bool IsTerminalPromptsEnabled { get; }
 
         /// <summary>
+        /// True if GUI prompts are enabled, false otherwise.
+        /// </summary>
+        /// <remarks>
+        /// If GUI prompts are disabled but an equivalent terminal prompt is available, the latter will be used instead.
+        /// </remarks>
+        bool IsGuiPromptsEnabled { get; }
+
+        /// <summary>
         /// True if it is permitted to interact with the user, false otherwise.
         /// </summary>
         /// <remarks>
@@ -436,6 +444,25 @@ namespace GitCredentialManager
         public bool IsDebuggingEnabled => _environment.Variables.GetBooleanyOrDefault(KnownEnvars.GcmDebug, false);
 
         public bool IsTerminalPromptsEnabled => _environment.Variables.GetBooleanyOrDefault(KnownEnvars.GitTerminalPrompts, true);
+
+        public bool IsGuiPromptsEnabled
+        {
+            get
+            {
+                const bool defaultValue = true;
+
+                if (TryGetSetting(
+                        KnownEnvars.GcmGuiPromptsEnabled,
+                        KnownGitCfg.Credential.SectionName,
+                        KnownGitCfg.Credential.GuiPromptsEnabled,
+                        out string str))
+                {
+                    return str.ToBooleanyOrDefault(defaultValue);
+                }
+
+                return defaultValue;
+            }
+        }
 
         public bool IsInteractionAllowed
         {

--- a/src/shared/GitHub/GitHubAuthentication.cs
+++ b/src/shared/GitHub/GitHubAuthentication.cs
@@ -81,11 +81,13 @@ namespace GitHub
             if (modes == AuthenticationModes.Browser ||
                 modes == AuthenticationModes.Device)
             {
-                    return new AuthenticationPromptResult(modes);
+                return new AuthenticationPromptResult(modes);
             }
 
             ThrowIfUserInteractionDisabled();
-            if (Context.SessionManager.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
+
+            if (Context.Settings.IsGuiPromptsEnabled && Context.SessionManager.IsDesktopSession &&
+                TryFindHelperExecutablePath(out string helperPath))
             {
                 var promptArgs = new StringBuilder("prompt");
                 if (modes == AuthenticationModes.All)
@@ -213,7 +215,8 @@ namespace GitHub
         {
             ThrowIfUserInteractionDisabled();
 
-            if (Context.SessionManager.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
+            if (Context.Settings.IsGuiPromptsEnabled && Context.SessionManager.IsDesktopSession &&
+                TryFindHelperExecutablePath(out string helperPath))
             {
                 var args = new StringBuilder("2fa");
                 if (isSms) args.Append(" --sms");
@@ -282,7 +285,8 @@ namespace GitHub
             OAuth2DeviceCodeResult dcr = await oauthClient.GetDeviceCodeAsync(scopes, CancellationToken.None);
 
             // If we have a desktop session show the device code in a dialog
-            if (Context.SessionManager.IsDesktopSession && TryFindHelperExecutablePath(out string helperPath))
+            if (Context.Settings.IsGuiPromptsEnabled && Context.SessionManager.IsDesktopSession &&
+                TryFindHelperExecutablePath(out string helperPath))
             {
                 var args = new StringBuilder("device");
                 args.AppendFormat(" --code {0} ", QuoteCmdArg(dcr.UserCode));

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -13,6 +13,8 @@ namespace GitCredentialManager.Tests.Objects
 
         public bool IsTerminalPromptsEnabled { get; set; } = true;
 
+        public bool IsGuiPromptsEnabled { get; set; } = true;
+
         public bool IsInteractionAllowed { get; set; } = true;
 
         public string Trace { get; set; }
@@ -96,6 +98,8 @@ namespace GitCredentialManager.Tests.Objects
         bool ISettings.IsDebuggingEnabled => IsDebuggingEnabled;
 
         bool ISettings.IsTerminalPromptsEnabled => IsTerminalPromptsEnabled;
+
+        bool ISettings.IsGuiPromptsEnabled => IsGuiPromptsEnabled;
 
         bool ISettings.IsInteractionAllowed => IsInteractionAllowed;
 


### PR DESCRIPTION
Add a new setting and environment variable that allows a user to disable the use of GUI prompts (in favour of terminal/text-based ones where available). The `GCM_GUI_PROMPT` envar mirrors the existing Git `GIT_TERMINAL_PROMPT` setting in its naming (being singular).

Note that we don't do anything with the MSAL prompts here, since there is already an existing setting for controlling the auth flow used (`GCM_MSAUTH_FLOW`). Also prompting is not always deterministic or avoidable with some MSAuth flows (i.e, Windows broker).

We also don't consider the user's web browser to be a "prompt" and continue to offer those authentication modes. This is only about input prompts GCM itself controls _where there is a terminal prompt available instead_.

Also update the FAQ document to include a note about the new settings, and also mention the "helper" variables that allow users to override the UI helpers for GitHub and Bitbucket.

Fixes #580