### PR TITLE
Use correct window title for device code in GitHub UI

### DIFF
--- a/src/shared/GitHub.UI/ViewModels/DeviceCodeViewModel.cs
+++ b/src/shared/GitHub.UI/ViewModels/DeviceCodeViewModel.cs
@@ -24,7 +24,7 @@ namespace GitHub.UI.ViewModels
 
             _environment = environment;
 
-            Title = "Two-factor authentication required";
+            Title = "Device code authentication";
             VerificationUrlCommand = new RelayCommand(OpenVerificationUrl);
         }
 


### PR DESCRIPTION
Use the correct window title for the GitHub device code dialog window. Previously this was re-using the same title as the 2FA code window.