### PR TITLE
Issue/573 OAuth2 support for Bitbucket DC

### DIFF
--- a/docs/bitbucket-development.md
+++ b/docs/bitbucket-development.md
@@ -123,6 +123,76 @@ be accessed using the credentials `admin`/`admin` at
 Atlassian has [documentation][atlassian-sdk] on how to download and install
 their SDK.
 
+## OAuth2 Configuration
+
+Bitbucket DC [7.20](https://confluence.atlassian.com/bitbucketserver/bitbucket-data-center-and-server-7-20-release-notes-1101934428.html)
+added support for OAuth2 Incoming Application Links and this can be used to
+support OAuth2 authentication for Git. This is especially useful in environments
+where Bitbucket uses SSO as it removes the requirement for users to manage
+[SSH keys](https://confluence.atlassian.com/display/BITBUCKETSERVER0717/Using+SSH+keys+to+secure+Git+operations)
+or manual [HTTP access tokens](https://confluence.atlassian.com/display/BITBUCKETSERVER0717/Personal+access+tokens).
+
+### Host Configuration
+
+For more details see
+[Bitbucket's documentation on Data Center and Server Application Links to other Applications](https://confluence.atlassian.com/bitbucketserver/link-to-other-applications-1018764620.html)
+
+Create Incoming OAuth 2 Application Link:
+<!-- markdownlint-disable MD034 -->
+1. Navigate to Administration/Application Links
+1. Create Link
+   1. Screen 1
+      - External Application [check]
+      - Incoming Application [check]
+   1. Screen 2
+      - Name : GCM
+      - Redirect URL : `http://localhost:34106/`
+      - Application Permissions : Repositories.Read [check], Repositories.Write [check]
+   1. Save
+   <!-- markdownlint-enable MD034 -->
+   1. Copy the `ClientId` and `ClientSecret` to configure GCM
+
+### Client Configuration
+
+Set the OAuth2 configuration use the `ClientId` and `ClientSecret` copied above,
+(for details see [credential.bitbucketDataCenterOAuthClientId](configuration.md#credential.bitbucketDataCenterOAuthClientId)
+and [credential.bitbucketDataCenterOAuthClientSecret](configuration.md#credential.bitbucketDataCenterOAuthClientSecret))
+
+    ❯ git config --global credential.bitbucketDataCenterOAuthClientId {`Copied ClientId`}
+
+    ❯ git config --global credential.bitbucketDataCenterOAuthClientSecret {`Copied ClientSecret`}
+<!-- markdownlint-disable MD034 -->
+As described in [Configuration options](configuration.md#Configuration%20options)
+the settings can be made more specific to apply only to a specific Bitbucket DC
+host by specifying the host url, e.g. https://bitbucket.example.com/
+<!-- markdownlint-enable MD034 -->
+
+    ❯ git config --global credential.https://bitbucket.example.com.bitbucketDataCenterOAuthClientId {`Copied ClientId`}
+
+    ❯ git config --global credential.https://bitbucket.example.com.bitbucketDataCenterOAuthClientSecret {`Copied ClientSecret`}
+<!-- markdownlint-disable MD034 -->
+Due to the way GCM resolves hosts and determines REST API urls, if the Bitbucket
+DC instance is hosted under a relative url (e.g. https://example.com/bitbucket)
+it is necessary to configure Git to send the full path to GCM. This is done
+using the [credential.useHttpPath](configuration.md#credential.useHttpPath)  
+setting.
+    ❯ git config --global credential.https://example.com/bitbucket.usehttppath true
+<!-- markdownlint-enable MD034 -->
+
+If a port number is used in the url of the Bitbucket DC instance the Git
+configuration needs to reflect this. However, due to [Issue 608](https://github.com/GitCredentialManager/git-credential-manager/issues/608)
+the port is ignored when resolving [credential.bitbucketDataCenterOAuthClientId](configuration.md#credential.bitbucketDataCenterOAuthClientId)
+and [credential.bitbucketDataCenterOAuthClientSecret](configuration.md#credential.bitbucketDataCenterOAuthClientSecret).
+<!-- markdownlint-disable MD034 -->
+For example, a Bitbucket DC host at https://example.com:7990/bitbucket would
+require configuration in the form:
+<!-- markdownlint-enable MD034 -->
+    ❯ git config --global credential.https://example.com/bitbucket.bitbucketDataCenterOAuthClientId {`Copied ClientId`}
+
+    ❯ git config --global credential.https://example.com/bitbucket.bitbucketDataCenterOAuthClientSecret {`Copied ClientSecret`}
+
+    ❯ git config --global credential.https://example.com:7990/bitbucket.usehttppath true
+
 [additional-info]:https://confluence.atlassian.com/display/BITBUCKET/App+passwords
 [atlas-run-standalone]: https://developer.atlassian.com/server/framework/atlassian-sdk/atlas-run-standalone/
 [bitbucket]: https://bitbucket.org

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,12 +272,85 @@ Value|Refresh Credentials Before Returning
 #### Example
 
 ```shell
-git config --global credential.bitbucketAlwaysRefreshCredentials 1
+git config --global credential.bitbucketAlwaysRefreshCredentials true
 ```
 
 Defaults to false/disabled.
 
 **Also see: [GCM_BITBUCKET_ALWAYS_REFRESH_CREDENTIALS][gcm-bitbucket-always-refresh-credentials]**
+
+---
+
+### credential.bitbucketValidateStoredCredentials
+
+Forces GCM to validate any stored credentials before returning them to Git. It
+does this by calling a REST API resource that requires authentication.
+
+Disabling this option reduces the HTTP traffic within GCM when it is retrieving
+credentials. This may improve user performance, but will increase the number of
+times Git remote calls fail to authenticate with the host and therefore require
+the user to re-try the Git remote call.
+
+Enabling this option helps ensure Git is always provided with valid credentials.
+
+Value|Validate credentials
+-|-
+`true`, `1`, `yes`, `on`_(default)_|Always
+`false`, `0`, `no`, `off`|Never
+
+#### Example
+
+```shell
+git config --global credential.bitbucketValidateStoredCredentials true
+```
+
+Defaults to true/enabled.
+
+**Also see: [GCM_BITBUCKET_VALIDATE_STORED_CREDENTIALS](environment.md#GCM_BITBUCKET_VALIDATE_STORED_CREDENTIALS)**
+
+---
+
+### credential.bitbucketDataCenterOAuthClientId
+
+To use OAuth with Bitbucket DC it is necessary to create an external, incoming
+[AppLink](https://confluence.atlassian.com/bitbucketserver/configure-an-incoming-link-1108483657.html).
+
+It is then necessary to configure the local GCM installation with both the OAuth
+[ClientId](configuration.md#credential.bitbucketDataCenterOAuthClientId) and
+[ClientSecret](configuration.md#credential.bitbucketDataCenterOauthSecret) from
+the AppLink.
+
+#### Example
+
+```shell
+git config --global credential.bitbucketDataCenterOAuthClientId 1111111111111111111
+```
+
+Defaults to undefined.
+
+**Also see: [GCM_BITBUCKET_DATACENTER_CLIENTID](environment.md#GCM_BITBUCKET_DATACENTER_CLIENTID)**
+
+---
+
+### credential.bitbucketDataCenterOAuthClientSecret
+
+To use OAuth with Bitbucket DC it is necessary to create an external, incoming
+[AppLink](https://confluence.atlassian.com/bitbucketserver/configure-an-incoming-link-1108483657.html).
+
+It is then necessary to configure the local GCM installation with both the OAuth
+[ClientId](configuration.md#credential.bitbucketDataCenterOAuthClientId) and
+[ClientSecret](configuration.md#credential.bitbucketDataCenterOauthSecret)
+from the AppLink.
+
+#### Example
+
+```shell
+git config --global credential.bitbucketDataCenterOAuthClientSecret 222222222222222222222
+```
+
+Defaults to undefined.
+
+**Also see: [GCM_BITBUCKET_DATACENTER_CLIENTSECRET](environment.md#GCM_BITBUCKET_DATACENTER_CLIENTSECRET)**
 
 ---
 
@@ -336,7 +409,8 @@ git config --global credential.gitLabAuthModes "browser"
 ### credential.namespace
 
 Use a custom namespace prefix for credentials read and written in the OS
-credential store. Credentials will be stored in the format `{namespace}:{service}`.
+credential store. Credentials will be stored in the format
+`{namespace}:{service}`.
 
 Defaults to the value `git`.
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -430,7 +430,98 @@ export GCM_BITBUCKET_ALWAYS_REFRESH_CREDENTIALS=1
 
 Defaults to false/disabled.
 
-**Also see: [credential.bitbucketAlwaysRefreshCredentials][credential-bitbucketalwaysrefreshcredentials]**
+**Also see: [credential.bitbucketAlwaysRefreshCredentials](configuration.md#credentialbitbucketAlwaysRefreshCredentials)**
+
+---
+
+### GCM_BITBUCKET_VALIDATE_STORED_CREDENTIALS
+
+Forces GCM to validate any stored credentials before returning them to Git. It
+does this by calling a REST API resource that requires authentication.
+
+Disabling this option reduces the HTTP traffic within GCM when it is retrieving
+credentials. This may improve user performance, but will increase the number of
+times Git remote calls fail to authenticate with the host and therefore require
+the user to re-try the Git remote call.
+
+Enabling this option helps ensure Git is always provided with valid credentials.
+
+Value|Validate credentials
+-|-
+`true`, `1`, `yes`, `on`_(default)_|Always
+`false`, `0`, `no`, `off`|Never
+
+#### Windows
+
+```batch
+SET GCM_BITBUCKET_VALIDATE_STORED_CREDENTIALS=1
+```
+
+#### macOS/Linux
+
+```bash
+export GCM_BITBUCKET_VALIDATE_STORED_CREDENTIALS=1
+```
+
+Defaults to true/enabled.
+
+**Also see: [credential.bitbucketValidateStoredCredentials](configuration.md#credentialbitbucketValidateStoredCredentials)**
+
+---
+
+### GCM_BITBUCKET_DATACENTER_CLIENTID
+
+To use OAuth with Bitbucket DC it is necessary to create an external, incoming
+[AppLink](https://confluence.atlassian.com/bitbucketserver/configure-an-incoming-link-1108483657.html).
+
+It is then necessary to configure the local GCM installation with the OAuth
+[ClientId](environment.md#GCM_BITBUCKET_DATACENTER_CLIENTID) and
+[ClientSecret](environment.md#GCM_BITBUCKET_DATACENTER_CLIENTSECRET)
+from the AppLink.
+
+#### Windows
+
+```batch
+SET GCM_BITBUCKET_DATACENTER_CLIENTID=1111111111111111111
+```
+
+#### macOS/Linux
+
+```bash
+export GCM_BITBUCKET_DATACENTER_CLIENTID=1111111111111111111
+```
+
+Defaults to undefined.
+
+**Also see: [credential.bitbucketDataCenterOAuthClientId](configuration.md#credentialbitbucketDataCenterOAuthClientId)**
+
+---
+
+### GCM_BITBUCKET_DATACENTER_CLIENTSECRET
+
+To use OAuth with Bitbucket DC it is necessary to create an external, incoming
+[AppLink](https://confluence.atlassian.com/bitbucketserver/configure-an-incoming-link-1108483657.html).
+
+It is then necessary to configure the local GCM installation with the OAuth
+[ClientId](environment.md#GCM_BITBUCKET_DATACENTER_CLIENTID) and
+[ClientSecret](environment.md#GCM_BITBUCKET_DATACENTER_CLIENTSECRET)
+from the AppLink.
+
+#### Windows
+
+```batch
+SET GCM_BITBUCKET_DATACENTER_CLIENTSECRET=222222222222222222222
+```
+
+#### macOS/Linux
+
+```bash
+export GCM_BITBUCKET_DATACENTER_CLIENTSECRET=222222222222222222222
+```
+
+Defaults to undefined.
+
+**Also see: [credential.bitbucketDataCenterOAuthClientSecret](configuration.md#credentialbitbucketDataCenterOAuthClientSecret)**
 
 ---
 
@@ -501,7 +592,8 @@ export GCM_GITLAB_AUTHMODES="browser"
 ### GCM_NAMESPACE
 
 Use a custom namespace prefix for credentials read and written in the OS
-credential store. Credentials will be stored in the format `{namespace}:{service}`.
+credential store. Credentials will be stored in the format
+`{namespace}:{service}`.
 
 Defaults to the value `git`.
 

--- a/src/shared/Atlassian.Bitbucket.Tests/Atlassian.Bitbucket.Tests.csproj
+++ b/src/shared/Atlassian.Bitbucket.Tests/Atlassian.Bitbucket.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="ReportGenerator" Version="4.8.13" />
+    <PackageReference Include="ReportGenerator" Version="5.1.9" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketHelperTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketHelperTest.cs
@@ -1,0 +1,60 @@
+using System;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests
+{
+    public class BitbucketHelperTest
+    {
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("    ", false)]
+        [InlineData("bitbucket.org", true)]
+        [InlineData("BITBUCKET.ORG", true)]
+        [InlineData("BiTbUcKeT.OrG", true)]
+        [InlineData("bitbucket.example.com", false)]
+        [InlineData("bitbucket.example.org", false)]
+        [InlineData("bitbucket.org.com", false)]
+        [InlineData("bitbucket.org.org", false)]
+        public void BitbucketHelper_IsBitbucketOrg_StringHost(string str, bool expected)
+        {
+            bool actual = BitbucketHelper.IsBitbucketOrg(str);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("http://bitbucket.org", true)]
+        [InlineData("https://bitbucket.org", true)]
+        [InlineData("http://bitbucket.org/path", true)]
+        [InlineData("https://bitbucket.org/path", true)]
+        [InlineData("http://BITBUCKET.ORG", true)]
+        [InlineData("https://BITBUCKET.ORG", true)]
+        [InlineData("http://BITBUCKET.ORG/PATH", true)]
+        [InlineData("https://BITBUCKET.ORG/PATH", true)]
+        [InlineData("http://BiTbUcKeT.OrG", true)]
+        [InlineData("https://BiTbUcKeT.OrG", true)]
+        [InlineData("http://BiTbUcKeT.OrG/pAtH", true)]
+        [InlineData("https://BiTbUcKeT.OrG/pAtH", true)]
+        [InlineData("http://bitbucket.example.com", false)]
+        [InlineData("https://bitbucket.example.com", false)]
+        [InlineData("http://bitbucket.example.com/path", false)]
+        [InlineData("https://bitbucket.example.com/path", false)]
+        [InlineData("http://bitbucket.example.org", false)]
+        [InlineData("https://bitbucket.example.org", false)]
+        [InlineData("http://bitbucket.example.org/path", false)]
+        [InlineData("https://bitbucket.example.org/path", false)]
+        [InlineData("http://bitbucket.org.com", false)]
+        [InlineData("https://bitbucket.org.com", false)]
+        [InlineData("http://bitbucket.org.com/path", false)]
+        [InlineData("https://bitbucket.org.com/path", false)]
+        [InlineData("http://bitbucket.org.org", false)]
+        [InlineData("https://bitbucket.org.org", false)]
+        [InlineData("http://bitbucket.org.org/path", false)]
+        [InlineData("https://bitbucket.org.org/path", false)]
+        public void BitbucketHelper_IsBitbucketOrg_Uri(string str, bool expected)
+        {
+            bool actual = BitbucketHelper.IsBitbucketOrg(new Uri(str));
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketRestApiRegistryTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketRestApiRegistryTest.cs
@@ -32,5 +32,27 @@ namespace Atlassian.Bitbucket.Tests
             Assert.IsType<Atlassian.Bitbucket.Cloud.BitbucketRestApi>(api);
 
         }
+
+        [Fact]
+        public void BitbucketRestApiRegistry_Get_ReturnsDataCenterApi_ForBitbucketDC()
+        {
+            // Given
+            settings.Setup(s => s.RemoteUri).Returns(new System.Uri("https://example.com"));
+            context.Setup(c => c.Settings).Returns(settings.Object);
+
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "http",
+                ["host"] = "example.com",
+            });
+
+            // When
+            var registry = new BitbucketRestApiRegistry(context.Object);
+            var api = registry.Get(input);
+
+            // Then
+            Assert.NotNull(api);
+            Assert.IsType<Atlassian.Bitbucket.DataCenter.BitbucketRestApi>(api);
+        }
     }
 }

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketRestApiRegistryTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketRestApiRegistryTest.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using GitCredentialManager;
+using Moq;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests
+{
+    public class BitbucketRestApiRegistryTest
+    {
+        private Mock<ICommandContext> context = new Mock<ICommandContext>(MockBehavior.Strict);
+        private Mock<ISettings> settings = new Mock<ISettings>(MockBehavior.Strict);
+
+        [Fact]
+        public void BitbucketRestApiRegistry_Get_ReturnsCloudApi_ForBitbucketOrg()
+        {
+            // Given
+            settings.Setup(s => s.RemoteUri).Returns(new System.Uri("https://bitbucket.org"));
+            context.Setup(c => c.Settings).Returns(settings.Object);
+
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "bitbucket.org",
+            });
+
+            // When
+            var registry = new BitbucketRestApiRegistry(context.Object);
+            var api = registry.Get(input);
+        
+            // Then
+            Assert.NotNull(api);
+            Assert.IsType<Atlassian.Bitbucket.Cloud.BitbucketRestApi>(api);
+
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketTokenEndpointResponseJsonTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketTokenEndpointResponseJsonTest.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests
+{
+    public class BitbucketTokenEndpointResponseJsonTest
+    {
+        [Fact]
+        public void BitbucketTokenEndpointResponseJson_Deserialize_Scopes_Not_Scope()
+        {
+            var scopesString = "a,b,c";
+            var json = "{access_token: '', token_type: '', scopes:'" + scopesString + "', scope: 'x,y,z'}";
+
+            var result = JsonConvert.DeserializeObject<BitbucketTokenEndpointResponseJson>(json);
+
+            Assert.Equal(scopesString, result.Scope);
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket.Tests/Cloud/BitbucketRestApiTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/Cloud/BitbucketRestApiTest.cs
@@ -2,11 +2,12 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Atlassian.Bitbucket.Cloud;
 using GitCredentialManager.Tests;
 using GitCredentialManager.Tests.Objects;
 using Xunit;
 
-namespace Atlassian.Bitbucket.Tests
+namespace Atlassian.Bitbucket.Tests.Cloud
 {
     public class BitbucketRestApiTest
     {
@@ -51,9 +52,9 @@ namespace Atlassian.Bitbucket.Tests
 
             Assert.NotNull(result);
             Assert.Equal(username, result.Response.UserName);
-            Assert.Equal(accountId, result.Response.AccountId);
-            Assert.Equal(uuid, result.Response.Uuid);
             Assert.Equal(twoFactorAuthenticationEnabled, result.Response.IsTwoFactorAuthenticationEnabled);
+            Assert.Equal(accountId, ((UserInfo)result.Response).AccountId);
+            Assert.Equal(uuid, ((UserInfo)result.Response).Uuid);
 
             httpHandler.AssertRequest(HttpMethod.Get, expectedRequestUri, 1);
         }

--- a/src/shared/Atlassian.Bitbucket.Tests/Cloud/UserInfoTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/Cloud/UserInfoTest.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using Atlassian.Bitbucket.Cloud;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests.Cloud
+{
+    public class UserInfoTest
+    {
+        [Fact]
+        public void UserInfo_Set()
+        {
+            var uuid = System.Guid.NewGuid();
+            var userInfo = new UserInfo()
+            {
+                AccountId = "abc",
+                IsTwoFactorAuthenticationEnabled = false,
+                UserName = "123",
+                Uuid = uuid
+            };
+
+            Assert.Equal("abc", userInfo.AccountId);
+            Assert.False(userInfo.IsTwoFactorAuthenticationEnabled);
+            Assert.Equal("123", userInfo.UserName);
+            Assert.Equal(uuid, userInfo.Uuid);
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket.Tests/DataCenter/BitbucketOAuth2ClientTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/DataCenter/BitbucketOAuth2ClientTest.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Atlassian.Bitbucket.DataCenter;
+using GitCredentialManager;
+using GitCredentialManager.Authentication.OAuth;
+using Moq;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests.DataCenter
+{
+    public class BitbucketOAuth2ClientTest
+    {
+        private Mock<HttpClient> httpClient = new Mock<HttpClient>(MockBehavior.Strict);
+        private Mock<ISettings> settings = new Mock<ISettings>(MockBehavior.Loose);
+        private Mock<Trace> trace = new Mock<Trace>(MockBehavior.Loose);
+        private Mock<IOAuth2WebBrowser> browser = new Mock<IOAuth2WebBrowser>(MockBehavior.Strict);
+        private Mock<IOAuth2CodeGenerator> codeGenerator = new Mock<IOAuth2CodeGenerator>(MockBehavior.Strict);
+        private CancellationToken ct = new CancellationToken();
+        private Uri rootCallbackUri = new Uri("http://localhost:34106/");
+        private string nonce = "12345";
+        private string pkceCodeVerifier = "abcde";
+        private string pkceCodeChallenge = "xyz987";
+        private string authorization_code = "authorization_token";
+
+        [Fact]
+        public async Task BitbucketOAuth2Client_GetAuthorizationCodeAsync_ReturnsCode()
+        {
+            var remoteUrl = MockRemoteUri("http://example.com");
+            var clientId = MockClientIdOverride("dc-client-id");
+            MockClientSecretOverride("dc-client-seccret");
+
+            Uri finalCallbackUri = MockFinalCallbackUri(rootCallbackUri);
+
+            var client = GetBitbucketOAuth2Client();
+
+            MockGetAuthenticationCodeAsync(remoteUrl, rootCallbackUri, finalCallbackUri, clientId, client.Scopes);
+
+            MockCodeGenerator();
+
+            var result = await client.GetAuthorizationCodeAsync(browser.Object, ct);
+
+            VerifyAuthorizationCodeResult(result, rootCallbackUri);
+        }
+
+        [Fact]
+        public async Task BitbucketOAuth2Client_GetAuthorizationCodeAsync_ReturnsCode_WhileRespectingRedirectUriOverride()
+        {
+            var rootCallbackUrl = MockRootCallbackUriOverride("http://localhost:12345/");
+            var remoteUrl = MockRemoteUri("http://example.com");
+            var clientId = MockClientIdOverride("dc-client-id");
+            MockClientSecretOverride("dc-client-seccret");
+
+            Uri finalCallbackUri = MockFinalCallbackUri(new Uri(rootCallbackUrl));
+
+            var client = GetBitbucketOAuth2Client();
+
+            MockGetAuthenticationCodeAsync(remoteUrl, new Uri(rootCallbackUrl), finalCallbackUri, clientId, client.Scopes);
+
+            MockCodeGenerator();
+
+            var result = await client.GetAuthorizationCodeAsync(browser.Object, ct);
+
+            VerifyAuthorizationCodeResult(result, new Uri(rootCallbackUrl));
+        }
+
+        private void VerifyAuthorizationCodeResult(OAuth2AuthorizationCodeResult result, Uri redirectUri)
+        {
+            Assert.NotNull(result);
+            Assert.Equal(authorization_code, result.Code);
+            Assert.Equal(redirectUri, result.RedirectUri);
+            Assert.Equal(pkceCodeVerifier, result.CodeVerifier);
+        }
+
+        private Bitbucket.DataCenter.BitbucketOAuth2Client GetBitbucketOAuth2Client()
+        {
+            var client = new Bitbucket.DataCenter.BitbucketOAuth2Client(httpClient.Object, settings.Object, trace.Object);
+            client.CodeGenerator = codeGenerator.Object;
+            return client;
+        }
+
+        private void MockCodeGenerator()
+        {
+            codeGenerator.Setup(c => c.CreateNonce()).Returns(nonce);
+            codeGenerator.Setup(c => c.CreatePkceCodeVerifier()).Returns(pkceCodeVerifier);
+            codeGenerator.Setup(c => c.CreatePkceCodeChallenge(OAuth2PkceChallengeMethod.Sha256, pkceCodeVerifier)).Returns(pkceCodeChallenge);
+        }
+
+        private void MockGetAuthenticationCodeAsync(string url, Uri redirectUri, Uri finalCallbackUri, string overrideClientId, IEnumerable<string> scopes)
+        {
+            var authorizationUri = new UriBuilder(url + "/rest/oauth2/latest/authorize")
+            {
+                Query = "?response_type=code"
+             + "&client_id=" + (overrideClientId ?? "clientId")
+             + "&state=12345"
+             + "&code_challenge_method=" + OAuth2Constants.AuthorizationEndpoint.PkceChallengeMethodS256
+             + "&code_challenge=" + WebUtility.UrlEncode(pkceCodeChallenge).ToLower()
+             + "&redirect_uri=" + WebUtility.UrlEncode(redirectUri.AbsoluteUri).ToLower()
+             + "&scope=" + WebUtility.UrlEncode(string.Join(" ", scopes)).ToUpper()
+            }.Uri;
+
+            browser.Setup(b => b.GetAuthenticationCodeAsync(authorizationUri, redirectUri, ct)).Returns(Task.FromResult(finalCallbackUri));
+        }
+
+        private Uri MockFinalCallbackUri(Uri redirectUri)
+        {
+            var finalUri = new Uri(rootCallbackUri, "?state=" + nonce + "&code=" + authorization_code);
+            // This is a simplification but consistent
+            browser.Setup(b => b.UpdateRedirectUri(redirectUri)).Returns(redirectUri);
+            return finalUri;
+        }
+
+        private string MockRemoteUri(string value)
+        {
+            settings.Setup(s => s.RemoteUri).Returns(new Uri(value));
+            return value;
+        }
+
+        private string MockClientIdOverride(string value)
+        {
+            settings.Setup(s => s.TryGetSetting(
+                DataCenterConstants.EnvironmentVariables.OAuthClientId,
+                Constants.GitConfiguration.Credential.SectionName, DataCenterConstants.GitConfiguration.Credential.OAuthClientId,
+                out value)).Returns(true);
+            return value;
+        }
+
+        private string MockClientSecretOverride(string value)
+        {
+            settings.Setup(s => s.TryGetSetting(
+                DataCenterConstants.EnvironmentVariables.OAuthClientSecret,
+                Constants.GitConfiguration.Credential.SectionName, DataCenterConstants.GitConfiguration.Credential.OAuthClientSecret,
+                out value)).Returns(true);
+            return value;
+        }
+
+        private string MockRootCallbackUriOverride(string value)
+        {
+            settings.Setup(s => s.TryGetSetting(
+                DataCenterConstants.EnvironmentVariables.OAuthRedirectUri,
+                Constants.GitConfiguration.Credential.SectionName, DataCenterConstants.GitConfiguration.Credential.OAuthRedirectUri,
+                out value)).Returns(true);
+            return value;
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket.Tests/DataCenter/BitbucketRestApiTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/DataCenter/BitbucketRestApiTest.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Atlassian.Bitbucket.DataCenter;
+using GitCredentialManager.Tests.Objects;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests.DataCenter
+{
+    public class BitbucketRestApiTest
+    {
+        [Fact]
+        public async Task BitbucketRestApi_GetUserInformationAsync_ReturnsUserInfo_ForSuccessfulRequest_DoesNothing() 
+        {
+            var twoFactorAuthenticationEnabled = false;
+
+            var context = new TestCommandContext();
+
+            var expectedRequestUri = new Uri("http://example.com/rest/api/1.0/users");
+            var httpHandler = new TestHttpMessageHandler();
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            httpHandler.Setup(HttpMethod.Get, expectedRequestUri, request =>
+            {
+                return httpResponse;
+            });
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            
+            context.Settings.RemoteUri = new Uri("http://example.com");
+
+            var api = new BitbucketRestApi(context);
+            var result = await api.GetUserInformationAsync("never used", "never used", false);
+
+            Assert.NotNull(result);
+            Assert.Equal(DataCenterConstants.OAuthUserName, result.Response.UserName);
+            Assert.Equal(twoFactorAuthenticationEnabled, result.Response.IsTwoFactorAuthenticationEnabled);
+
+            httpHandler.AssertRequest(HttpMethod.Get, expectedRequestUri, 1);
+        }
+    
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized, true)] 
+        [InlineData(HttpStatusCode.NotFound, false)] 
+        public async Task BitbucketRestApi_IsOAuthInstalledAsync_ReflectsBitbucketAuthenticationResponse(HttpStatusCode responseCode, bool impliedSupport)
+        {
+            var context = new TestCommandContext();
+            var httpHandler = new TestHttpMessageHandler();
+
+            var expectedRequestUri = new Uri("http://example.com/rest/oauth2/1.0/client");
+
+            var httpResponse = new HttpResponseMessage(responseCode);
+            httpHandler.Setup(HttpMethod.Get, expectedRequestUri, request =>
+            {
+                return httpResponse;
+            });
+
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            context.Settings.RemoteUri = new Uri("http://example.com");
+
+            var api = new BitbucketRestApi(context);
+
+            var isInstalled = await api.IsOAuthInstalledAsync();
+
+            httpHandler.AssertRequest(HttpMethod.Get, expectedRequestUri, 1);
+
+            Assert.Equal(impliedSupport, isInstalled);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAuthenticationMethodsAsyncData))]
+        public async Task BitbucketRestApi_GetAuthenticationMethodsAsync_ReflectRestApiResponse(string loginOptionResponseJson, List<AuthenticationMethod> impliedSupportedMethods, List<AuthenticationMethod> impliedUnsupportedMethods)
+        {
+            var context = new TestCommandContext();
+            var httpHandler = new TestHttpMessageHandler();
+
+            var expectedRequestUri = new Uri("http://example.com/rest/authconfig/1.0/login-options");
+            
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(loginOptionResponseJson)
+            };
+
+            httpHandler.Setup(HttpMethod.Get, expectedRequestUri, request =>
+            {
+                return httpResponse;
+            });
+
+            context.HttpClientFactory.MessageHandler = httpHandler;
+            context.Settings.RemoteUri = new Uri("http://example.com");
+
+            var api = new BitbucketRestApi(context);
+
+            var authMethods = await api.GetAuthenticationMethodsAsync();
+
+            httpHandler.AssertRequest(HttpMethod.Get, expectedRequestUri, 1);
+
+            Assert.NotNull(authMethods);
+            Assert.Equal(authMethods.Count, impliedSupportedMethods.Count);
+            Assert.Contains(authMethods, m => impliedSupportedMethods.Contains(m));
+            Assert.DoesNotContain(authMethods, m => impliedUnsupportedMethods.Contains(m));
+        } 
+
+        public static IEnumerable<object[]> GetAuthenticationMethodsAsyncData => 
+        new List<object[]>
+        {
+            new object[] { $"{{ \"results\":[ {{ \"type\":\"LOGIN_FORM\"}}]}}", 
+                            new List<AuthenticationMethod>{AuthenticationMethod.BasicAuth}, 
+                            new List<AuthenticationMethod>{AuthenticationMethod.Sso}},
+            new object[] { $"{{ \"results\":[{{\"type\":\"IDP\"}}]}}", 
+                            new List<AuthenticationMethod>{AuthenticationMethod.Sso}, 
+                            new List<AuthenticationMethod>{AuthenticationMethod.BasicAuth}},
+            new object[] { $"{{ \"results\":[{{\"type\":\"IDP\"}}, {{ \"type\":\"LOGIN_FORM\"}},  {{ \"type\":\"UNDEFINED\"}}]}}", 
+                            new List<AuthenticationMethod>{AuthenticationMethod.Sso, AuthenticationMethod.BasicAuth}, 
+                            new List<AuthenticationMethod>()},
+        };
+    }
+}

--- a/src/shared/Atlassian.Bitbucket.Tests/DataCenter/LoginOptionsTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/DataCenter/LoginOptionsTest.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Atlassian.Bitbucket.DataCenter;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests.DataCenter
+{
+    public class LoginOptionsTest
+    {
+
+        [Fact]
+        public void LoginOptions_Set()
+        {
+            var loginOption = new LoginOption() 
+            { 
+                Type = "abc", 
+                Id = 1
+            };
+
+            var results = new List<LoginOption>() 
+            { 
+                loginOption
+            };
+
+            var loginOptions = new LoginOptions()
+            {
+                Results = results
+            };
+
+            Assert.NotNull(loginOptions.Results);
+            Assert.Contains(loginOption, loginOptions.Results);
+
+            Assert.Equal("abc", loginOptions.Results.First().Type);
+            Assert.Equal(1, loginOptions.Results.First().Id);
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket.Tests/DataCenter/UserInfoTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/DataCenter/UserInfoTest.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using Atlassian.Bitbucket.DataCenter;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests.DataCenter
+{
+    public class UserInfoTest
+    {
+        [Fact]
+        public void UserInfo_Set()
+        {
+            var uuid = System.Guid.NewGuid();
+            var userInfo = new UserInfo()
+            {
+                UserName = "123"
+            };
+
+            Assert.False(userInfo.IsTwoFactorAuthenticationEnabled);
+            Assert.Equal("123", userInfo.UserName);
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket.Tests/OAuth2ClientRegistryTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/OAuth2ClientRegistryTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using Atlassian.Bitbucket.Cloud;
+using Atlassian.Bitbucket.DataCenter;
 using GitCredentialManager;
 using Moq;
 using Xunit;
@@ -36,6 +37,30 @@ namespace Atlassian.Bitbucket.Tests
             // Then
             Assert.NotNull(api);
             Assert.IsType<Atlassian.Bitbucket.Cloud.BitbucketOAuth2Client>(api);
+
+        }
+
+        [Fact]
+        public void BitbucketRestApiRegistry_Get_ReturnsDataCenterOAuth2Client_ForBitbucketDC()
+        {
+            var host = "example.com";
+
+            // Given
+            settings.Setup(s => s.RemoteUri).Returns(new System.Uri("https://example.com"));
+            context.Setup(c => c.Settings).Returns(settings.Object);
+            MockSettingOverride(DataCenterConstants.EnvironmentVariables.OAuthClientId, DataCenterConstants.GitConfiguration.Credential.OAuthClientId, "", true);
+            MockSettingOverride(DataCenterConstants.EnvironmentVariables.OAuthClientSecret, DataCenterConstants.GitConfiguration.Credential.OAuthClientSecret, "", true); ;
+            MockSettingOverride(DataCenterConstants.EnvironmentVariables.OAuthRedirectUri, DataCenterConstants.GitConfiguration.Credential.OAuthRedirectUri,  "never used", false);
+            MockHttpClientFactory();
+            var input = MockInputArguments(host);
+
+            // When
+            var registry = new OAuth2ClientRegistry(context.Object);
+            var api = registry.Get(input);
+
+            // Then
+            Assert.NotNull(api);
+            Assert.IsType<Atlassian.Bitbucket.DataCenter.BitbucketOAuth2Client>(api);
 
         }
 

--- a/src/shared/Atlassian.Bitbucket.Tests/OAuth2ClientRegistryTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/OAuth2ClientRegistryTest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Atlassian.Bitbucket.Cloud;
+using GitCredentialManager;
+using Moq;
+using Xunit;
+
+namespace Atlassian.Bitbucket.Tests
+{
+    public class OAuth2ClientRegistryTest
+    {
+        private Mock<ICommandContext> context = new Mock<ICommandContext>(MockBehavior.Loose);
+        private Mock<ISettings> settings = new Mock<ISettings>(MockBehavior.Strict);
+        private Mock<IHttpClientFactory> httpClientFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+        private Mock<ITrace> trace = new Mock<ITrace>(MockBehavior.Strict);
+
+        [Fact]
+        public void BitbucketRestApiRegistry_Get_ReturnsCloudOAuth2Client()
+        {
+            var host = "bitbucket.org";
+
+            // Given
+            settings.Setup(s => s.RemoteUri).Returns(new System.Uri("https://" + host));
+            context.Setup(c => c.Settings).Returns(settings.Object);
+            MockSettingOverride(CloudConstants.EnvironmentVariables.OAuthClientId, CloudConstants.GitConfiguration.Credential.OAuthClientId, "never used", false);
+            MockSettingOverride(CloudConstants.EnvironmentVariables.OAuthClientSecret, CloudConstants.GitConfiguration.Credential.OAuthClientSecret, "never used", false);
+            MockSettingOverride(CloudConstants.EnvironmentVariables.OAuthRedirectUri, CloudConstants.GitConfiguration.Credential.OAuthRedirectUri,  "never used", false);
+            MockHttpClientFactory();
+            var input = MockInputArguments(host);
+
+            // When
+            var registry = new OAuth2ClientRegistry(context.Object);
+            var api = registry.Get(input);
+
+            // Then
+            Assert.NotNull(api);
+            Assert.IsType<Atlassian.Bitbucket.Cloud.BitbucketOAuth2Client>(api);
+
+        }
+
+        private static InputArguments MockInputArguments(string host)
+        {
+            return new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = host,
+            });
+        }
+
+        private void MockHttpClientFactory()
+        {
+            context.Setup(c => c.HttpClientFactory).Returns(httpClientFactory.Object);
+            httpClientFactory.Setup(f => f.CreateClient()).Returns(new HttpClient());
+        }
+
+        private string MockSettingOverride(string envKey, string configKey, string settingValue, bool isOverridden)
+        {
+            settings.Setup(s => s.TryGetSetting(
+                envKey,
+                Constants.GitConfiguration.Credential.SectionName, configKey,
+                out settingValue)).Returns(isOverridden);
+            return settingValue;
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/AuthenticationMethod.cs
+++ b/src/shared/Atlassian.Bitbucket/AuthenticationMethod.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace Atlassian.Bitbucket
+{
+    public enum AuthenticationMethod
+    {
+        BasicAuth,
+        Sso
+    }
+}
+

--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Atlassian.Bitbucket.Cloud;
 using GitCredentialManager;
 using GitCredentialManager.Authentication;
 using GitCredentialManager.Authentication.OAuth;
@@ -23,8 +24,9 @@ namespace Atlassian.Bitbucket
     public interface IBitbucketAuthentication : IDisposable
     {
         Task<CredentialsPromptResult> GetCredentialsAsync(Uri targetUri, string userName, AuthenticationModes modes);
-        Task<OAuth2TokenResult> CreateOAuthCredentialsAsync(Uri targetUri);
-        Task<OAuth2TokenResult> RefreshOAuthCredentialsAsync(string refreshToken);
+        Task<OAuth2TokenResult> CreateOAuthCredentialsAsync(InputArguments input);
+        Task<OAuth2TokenResult> RefreshOAuthCredentialsAsync(InputArguments input, string refreshToken);
+        string GetRefreshTokenServiceName(InputArguments input);
     }
 
     public class CredentialsPromptResult
@@ -49,17 +51,20 @@ namespace Atlassian.Bitbucket
     {
         public static readonly string[] AuthorityIds =
         {
-            "bitbucket",
+            BitbucketConstants.Id,
         };
 
-        private static readonly string[] Scopes =
-        {
-            BitbucketConstants.OAuthScopes.RepositoryWrite,
-            BitbucketConstants.OAuthScopes.Account,
-        };
+        private readonly IRegistry<BitbucketOAuth2Client> _oauth2ClientRegistry;
 
         public BitbucketAuthentication(ICommandContext context)
-            : base(context) { }
+            : this(context, new OAuth2ClientRegistry(context)) { }
+
+        public BitbucketAuthentication(ICommandContext context, IRegistry<BitbucketOAuth2Client> oauth2ClientRegistry)
+    : base(context)
+        {
+            EnsureArgument.NotNull(oauth2ClientRegistry, nameof(oauth2ClientRegistry));
+            this._oauth2ClientRegistry = oauth2ClientRegistry;
+        }
 
         public async Task<CredentialsPromptResult> GetCredentialsAsync(Uri targetUri, string userName, AuthenticationModes modes)
         {
@@ -91,7 +96,7 @@ namespace Atlassian.Bitbucket
                 TryFindHelperExecutablePath(out string helperPath))
             {
                 var cmdArgs = new StringBuilder("prompt");
-                if (!BitbucketHostProvider.IsBitbucketOrg(targetUri))
+                if (!BitbucketHelper.IsBitbucketOrg(targetUri))
                 {
                     cmdArgs.AppendFormat(" --url {0}", QuoteCmdArg(targetUri.ToString()));
                 }
@@ -189,11 +194,9 @@ namespace Atlassian.Bitbucket
             }
         }
 
-        public async Task<OAuth2TokenResult> CreateOAuthCredentialsAsync(Uri targetUri)
+        public async Task<OAuth2TokenResult> CreateOAuthCredentialsAsync(InputArguments input)
         {
             ThrowIfUserInteractionDisabled();
-
-            var oauthClient = new BitbucketOAuth2Client(HttpClient, Context.Settings);
 
             var browserOptions = new OAuth2WebBrowserOptions
             {
@@ -202,16 +205,22 @@ namespace Atlassian.Bitbucket
             };
 
             var browser = new OAuth2SystemWebBrowser(Context.Environment, browserOptions);
-            var authCodeResult = await oauthClient.GetAuthorizationCodeAsync(Scopes, browser, CancellationToken.None);
+            var oauth2Client = _oauth2ClientRegistry.Get(input);
 
-            return await oauthClient.GetTokenByAuthorizationCodeAsync(authCodeResult, CancellationToken.None);
+            var authCodeResult = await oauth2Client.GetAuthorizationCodeAsync(browser, CancellationToken.None);
+            return await oauth2Client.GetTokenByAuthorizationCodeAsync(authCodeResult, CancellationToken.None);
         }
 
-        public async Task<OAuth2TokenResult> RefreshOAuthCredentialsAsync(string refreshToken)
+        public async Task<OAuth2TokenResult> RefreshOAuthCredentialsAsync(InputArguments input, string refreshToken)
         {
-            var oauthClient = new BitbucketOAuth2Client(HttpClient, Context.Settings);
+            var client = _oauth2ClientRegistry.Get(input);
+            return await client.GetTokenByRefreshTokenAsync(refreshToken, CancellationToken.None);
+        }
 
-            return await oauthClient.GetTokenByRefreshTokenAsync(refreshToken, CancellationToken.None);
+        public string GetRefreshTokenServiceName(InputArguments input)
+        {
+            var client = _oauth2ClientRegistry.Get(input);
+            return client.GetRefreshTokenServiceName(input);
         }
 
         protected internal virtual bool TryFindHelperExecutablePath(out string path)

--- a/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
@@ -4,36 +4,18 @@ namespace Atlassian.Bitbucket
 {
     public static class BitbucketConstants
     {
-        public const string BitbucketBaseUrlHost = "bitbucket.org";
-        public static readonly Uri BitbucketApiUri = new Uri("https://api.bitbucket.org");
+        public const string Id = "bitbucket";
+
+        public const string Name = "Bitbucket";
+
         public const string DefaultAuthenticationHelper = "Atlassian.Bitbucket.UI";
-
-        // TODO: use the GCM client ID and secret once we have this approved.
-        // Until then continue to use Sourcetree's values like GCM Windows.
-        //public const string OAuth2ClientId = "b5AKdPfpgFdEGpKzPE";
-        //public const string OAuth2ClientSecret = "7NUP5qUtSR3SxdFK4xAGaU6PMNvNdE59";
-        //public static readonly Uri OAuth2RedirectUri = new Uri("http://localhost:46337/");
-        public const string OAuth2ClientId = "HJdmKXV87DsmC9zSWB";
-        public const string OAuth2ClientSecret = "wwWw47VB9ZHwMsD4Q4rAveHkbxNrMp3n";
-        public static readonly Uri OAuth2RedirectUri = new Uri("http://localhost:34106/");
-
-        public static readonly Uri OAuth2AuthorizationEndpoint = new Uri("https://bitbucket.org/site/oauth2/authorize");
-        public static readonly Uri OAuth2TokenEndpoint = new Uri("https://bitbucket.org/site/oauth2/access_token");
-
-        public static class OAuthScopes
-        {
-            public const string RepositoryWrite = "repository:write";
-            public const string Account = "account";
-        }
 
         public static class EnvironmentVariables
         {
             public const string AuthenticationHelper = "GCM_BITBUCKET_HELPER";
-            public const string DevOAuthClientId = "GCM_DEV_BITBUCKET_CLIENTID";
-            public const string DevOAuthClientSecret = "GCM_DEV_BITBUCKET_CLIENTSECRET";
-            public const string DevOAuthRedirectUri = "GCM_DEV_BITBUCKET_REDIRECTURI";
             public const string AuthenticationModes = "GCM_BITBUCKET_AUTHMODES";
             public const string AlwaysRefreshCredentials = "GCM_BITBUCKET_ALWAYS_REFRESH_CREDENTIALS";
+            public const String ValidateStoredCredentials = "GCM_BITBUCKET_VALIDATE_STORED_CREDENTIALS";
         }
 
         public static class GitConfiguration
@@ -41,14 +23,11 @@ namespace Atlassian.Bitbucket
             public static class Credential
             {
                 public const string AuthenticationHelper = "bitbucketHelper";
-                public const string DevOAuthClientId = "bitbucketDevClientId";
-                public const string DevOAuthClientSecret = "bitbucketDevClientSecret";
-                public const string DevOAuthRedirectUri = "bitbucketDevRedirectUri";
                 public const string AuthenticationModes = "bitbucketAuthModes";
                 public const string AlwaysRefreshCredentials = "bitbucketAlwaysRefreshCredentials";
+                public const string ValidateStoredCredentials = "bitbucketValidateStoredCredentials";
             }
         }
-
         public static class HelpUrls
         {
             public const string DataCenterPasswordReset = "/passwordreset";
@@ -58,14 +37,5 @@ namespace Atlassian.Bitbucket
             public const string TwoFactor = "https://support.atlassian.com/bitbucket-cloud/docs/enable-two-step-verification/";
         }
 
-        /// <summary>
-        /// Supported authentication modes for Bitbucket.org
-        /// </summary>
-        public const AuthenticationModes DotOrgAuthenticationModes = AuthenticationModes.Basic | AuthenticationModes.OAuth;
-
-        /// <summary>
-        /// Supported authentication modes for Bitbucket Server/DC
-        /// </summary>
-        public const AuthenticationModes ServerAuthenticationModes = AuthenticationModes.Basic;
     }
 }

--- a/src/shared/Atlassian.Bitbucket/BitbucketHelper.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketHelper.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Atlassian.Bitbucket.Cloud;
+using GitCredentialManager;
+
+namespace Atlassian.Bitbucket
+{
+    public static class BitbucketHelper
+    {
+        public static string GetBaseUri(Uri remoteUri)
+        {
+            var pathParts = remoteUri.PathAndQuery.Split('/');
+            var pathPart = remoteUri.PathAndQuery.StartsWith("/") ? pathParts[1] : pathParts[0];
+            var path = !string.IsNullOrWhiteSpace(pathPart) ? "/" + pathPart : null;
+            return $"{remoteUri.Scheme}://{remoteUri.Host}:{remoteUri.Port}{path}";
+        }
+
+        public static bool IsBitbucketOrg(InputArguments input)     
+        {
+            return IsBitbucketOrg(input.GetRemoteUri());
+        }
+
+        public static bool IsBitbucketOrg(Uri targetUri)
+        {
+            return IsBitbucketOrg(targetUri.Host);
+        }
+
+        public static bool IsBitbucketOrg(string targetHost)
+        {
+            return StringComparer.OrdinalIgnoreCase.Equals(targetHost, CloudConstants.BitbucketBaseUrlHost);
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -404,7 +404,8 @@ namespace Atlassian.Bitbucket
                 }
                 catch (Exception ex)
                 {
-                    _context.Trace.WriteLine($"Failed to validate existing credentials using OAuth: {ex.Message}");
+                    _context.Trace.WriteLine($"Failed to validate existing credentials using OAuth");
+                    _context.Trace.WriteException(ex);
                 }
             }
 
@@ -418,7 +419,8 @@ namespace Atlassian.Bitbucket
                 }
                 catch (Exception ex)
                 {
-                    _context.Trace.WriteLine($"Failed to validate existing credentials using Basic Auth: {ex.Message}");
+                    _context.Trace.WriteLine($"Failed to validate existing credentials using Basic Auth");
+                    _context.Trace.WriteException(ex);
                     return false;
                 }
             }

--- a/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketHostProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Atlassian.Bitbucket.Cloud;
 using GitCredentialManager;
 using GitCredentialManager.Authentication.OAuth;
 
@@ -12,27 +13,27 @@ namespace Atlassian.Bitbucket
     {
         private readonly ICommandContext _context;
         private readonly IBitbucketAuthentication _bitbucketAuth;
-        private readonly IBitbucketRestApi _bitbucketApi;
+        private readonly IRegistry<IBitbucketRestApi> _restApiRegistry;
 
         public BitbucketHostProvider(ICommandContext context)
-            : this(context, new BitbucketAuthentication(context), new BitbucketRestApi(context)) { }
+            : this(context, new BitbucketAuthentication(context), new BitbucketRestApiRegistry(context)) { }
 
-        public BitbucketHostProvider(ICommandContext context, IBitbucketAuthentication bitbucketAuth, IBitbucketRestApi bitbucketApi)
+        public BitbucketHostProvider(ICommandContext context, IBitbucketAuthentication bitbucketAuth, IRegistry<IBitbucketRestApi> restApiRegistry)
         {
             EnsureArgument.NotNull(context, nameof(context));
             EnsureArgument.NotNull(bitbucketAuth, nameof(bitbucketAuth));
-            EnsureArgument.NotNull(bitbucketApi, nameof(bitbucketApi));
+            EnsureArgument.NotNull(restApiRegistry, nameof(restApiRegistry));
 
             _context = context;
             _bitbucketAuth = bitbucketAuth;
-            _bitbucketApi = bitbucketApi;
+            _restApiRegistry = restApiRegistry;
         }
 
         #region IHostProvider
 
-        public string Id => "bitbucket";
+        public string Id => BitbucketConstants.Id;
 
-        public string Name => "Bitbucket";
+        public string Name => BitbucketConstants.Name;
 
         public IEnumerable<string> SupportedAuthorityIds => BitbucketAuthentication.AuthorityIds;
 
@@ -54,7 +55,7 @@ namespace Atlassian.Bitbucket
             // error message for the user in `GetCredentialAsync`.
             return (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http") ||
                     StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "https")) &&
-                   hostName.EndsWith(BitbucketConstants.BitbucketBaseUrlHost, StringComparison.OrdinalIgnoreCase);
+                    hostName.EndsWith(CloudConstants.BitbucketBaseUrlHost, StringComparison.OrdinalIgnoreCase);
         }
 
         public bool IsSupported(HttpResponseMessage response)
@@ -76,20 +77,18 @@ namespace Atlassian.Bitbucket
         {
             // We should not allow unencrypted communication and should inform the user
             if (StringComparer.OrdinalIgnoreCase.Equals(input.Protocol, "http")
-                && input.TryGetHostAndPort(out string host, out _) && IsBitbucketOrg(host))
+                && BitbucketHelper.IsBitbucketOrg(input))
             {
                 throw new Exception("Unencrypted HTTP is not supported for Bitbucket.org. Ensure the repository remote URL is using HTTPS.");
             }
 
-            Uri remoteUri = input.GetRemoteUri();
+            var authModes = await GetSupportedAuthenticationModesAsync(input);
 
-            AuthenticationModes authModes = GetSupportedAuthenticationModes(remoteUri);
-
-            return await GetStoredCredentials(remoteUri, input.UserName, authModes) ??
-                   await GetRefreshedCredentials(remoteUri, input.UserName, authModes);
+            return await GetStoredCredentials(input, authModes) ??
+                   await GetRefreshedCredentials(input, authModes);
         }
 
-        private async Task<ICredential> GetStoredCredentials(Uri remoteUri, string userName, AuthenticationModes authModes)
+        private async Task<ICredential> GetStoredCredentials(InputArguments input, AuthenticationModes authModes)
         {
             if (_context.Settings.TryGetSetting(BitbucketConstants.EnvironmentVariables.AlwaysRefreshCredentials,
                 Constants.GitConfiguration.Credential.SectionName, BitbucketConstants.GitConfiguration.Credential.AlwaysRefreshCredentials,
@@ -99,10 +98,11 @@ namespace Atlassian.Bitbucket
                 return null;
             }
 
+            Uri remoteUri = input.GetRemoteUri();
             string credentialService = GetServiceName(remoteUri);
             _context.Trace.WriteLine($"Look for existing credentials under {credentialService} ...");
 
-            ICredential credentials = _context.CredentialStore.Get(credentialService, userName);
+            ICredential credentials = _context.CredentialStore.Get(credentialService, input.UserName);
 
             if (credentials == null)
             {
@@ -113,7 +113,7 @@ namespace Atlassian.Bitbucket
             _context.Trace.WriteLineSecrets($"Found stored credentials: {credentials.Account}/{{0}}", new object[] { credentials.Password });
 
             // Check credentials are still valid
-            if (!await ValidateCredentialsWork(remoteUri, credentials, authModes))
+            if (!await ValidateCredentialsWork(input, credentials, authModes))
             {
                 return null;
             }
@@ -121,16 +121,17 @@ namespace Atlassian.Bitbucket
             return credentials;
         }
 
-        private async Task<ICredential> GetRefreshedCredentials(Uri remoteUri, string userName, AuthenticationModes authModes)
+        private async Task<ICredential> GetRefreshedCredentials(InputArguments input, AuthenticationModes authModes)
         {
             _context.Trace.WriteLine("Refresh credentials...");
 
             // Check for presence of refresh_token entry in credential store
+            Uri remoteUri = input.GetRemoteUri();
             var refreshTokenService = GetRefreshTokenServiceName(remoteUri);
 
             _context.Trace.WriteLine("Checking for refresh token...");
             ICredential refreshToken = SupportsOAuth(authModes)
-                ? _context.CredentialStore.Get(refreshTokenService, userName)
+                ? _context.CredentialStore.Get(refreshTokenService, input.UserName)
                 : null;
 
             if (refreshToken is null)
@@ -141,7 +142,7 @@ namespace Atlassian.Bitbucket
 
                 _context.Trace.WriteLine("Prompt for credentials...");
 
-                var result = await _bitbucketAuth.GetCredentialsAsync(remoteUri, userName, authModes);
+                var result = await _bitbucketAuth.GetCredentialsAsync(remoteUri, input.UserName, authModes);
                 if (result is null || result.AuthenticationMode == AuthenticationModes.None)
                 {
                     _context.Trace.WriteLine("User cancelled credential prompt");
@@ -171,7 +172,7 @@ namespace Atlassian.Bitbucket
 
                 try
                 {
-                    return await GetOAuthCredentialsViaRefreshFlow(remoteUri, refreshToken);
+                    return await GetOAuthCredentialsViaRefreshFlow(input, refreshToken);
                 }
                 catch (OAuth2Exception ex)
                 {
@@ -183,19 +184,21 @@ namespace Atlassian.Bitbucket
                 }
             }
 
-            return await GetOAuthCredentialsViaInteractiveBrowserFlow(remoteUri);
+            return await GetOAuthCredentialsViaInteractiveBrowserFlow(input);
         }
 
-        private async Task<ICredential> GetOAuthCredentialsViaRefreshFlow(Uri remoteUri, ICredential refreshToken)
+        private async Task<ICredential> GetOAuthCredentialsViaRefreshFlow(InputArguments input, ICredential refreshToken)
         {
+            Uri remoteUri = input.GetRemoteUri();
+
             var refreshTokenService = GetRefreshTokenServiceName(remoteUri);
             _context.Trace.WriteLine("Refreshing OAuth credentials using refresh token...");
 
-            OAuth2TokenResult refreshResult = await _bitbucketAuth.RefreshOAuthCredentialsAsync(refreshToken.Password);
+            OAuth2TokenResult refreshResult = await _bitbucketAuth.RefreshOAuthCredentialsAsync(input, refreshToken.Password);
 
             // Resolve the username
             _context.Trace.WriteLine("Resolving username for refreshed OAuth credential...");
-            string refreshUserName = await ResolveOAuthUserNameAsync(refreshResult.AccessToken);
+            string refreshUserName = await ResolveOAuthUserNameAsync(input, refreshResult.AccessToken);
             _context.Trace.WriteLine($"Username for refreshed OAuth credential is '{refreshUserName}'");
 
             // Store the refreshed RT
@@ -206,8 +209,10 @@ namespace Atlassian.Bitbucket
             return new GitCredential(refreshUserName, refreshResult.AccessToken);
         }
 
-        private async Task<ICredential> GetOAuthCredentialsViaInteractiveBrowserFlow(Uri remoteUri)
+        private async Task<ICredential> GetOAuthCredentialsViaInteractiveBrowserFlow(InputArguments input)
         {
+            Uri remoteUri = input.GetRemoteUri();
+
             var refreshTokenService = GetRefreshTokenServiceName(remoteUri);
 
             // We failed to use the refresh token either because it didn't exist, or because the refresh token is no
@@ -215,11 +220,11 @@ namespace Atlassian.Bitbucket
 
             // Start OAuth authentication flow
             _context.Trace.WriteLine("Starting OAuth authentication flow...");
-            OAuth2TokenResult oauthResult = await _bitbucketAuth.CreateOAuthCredentialsAsync(remoteUri);
+            OAuth2TokenResult oauthResult = await _bitbucketAuth.CreateOAuthCredentialsAsync(input);
 
             // Resolve the username
             _context.Trace.WriteLine("Resolving username for OAuth credential...");
-            string newUserName = await ResolveOAuthUserNameAsync(oauthResult.AccessToken);
+            string newUserName = await ResolveOAuthUserNameAsync(input, oauthResult.AccessToken);
             _context.Trace.WriteLine($"Username for OAuth credential is '{newUserName}'");
 
             // Store the new RT
@@ -241,14 +246,8 @@ namespace Atlassian.Bitbucket
             return (authModes & AuthenticationModes.Basic) != 0;
         }
 
-        public AuthenticationModes GetSupportedAuthenticationModes(Uri targetUri)
+        public async Task<AuthenticationModes> GetSupportedAuthenticationModesAsync(InputArguments input)
         {
-            if (!IsBitbucketOrg(targetUri))
-            {
-                // Bitbucket Server/DC should use Basic only
-                return BitbucketConstants.ServerAuthenticationModes;
-            }
-
             // Check for an explicit override for supported authentication modes
             if (_context.Settings.TryGetSetting(
                 BitbucketConstants.EnvironmentVariables.AuthenticationModes,
@@ -266,10 +265,47 @@ namespace Atlassian.Bitbucket
                 }
             }
 
-            // Bitbucket.org should use Basic, OAuth or manual PAT based authentication only
-            _context.Trace.WriteLine($"{targetUri} is bitbucket.org - authentication schemes: '{BitbucketConstants.DotOrgAuthenticationModes}'");
-            return BitbucketConstants.DotOrgAuthenticationModes;
+            // It isn't possible to detect what Bitbucket.org is expecting so return the predefined answers.
+            if (BitbucketHelper.IsBitbucketOrg(input))
+            {
+                // Bitbucket should use Basic, OAuth or manual PAT based authentication only
+                _context.Trace.WriteLine($"{input.GetRemoteUri()} is bitbucket.org - authentication schemes: '{CloudConstants.DotOrgAuthenticationModes}'");
+                return CloudConstants.DotOrgAuthenticationModes;
+            }
 
+            // For Bitbucket DC/Server the supported modes can be detected
+            _context.Trace.WriteLine($"{input.GetRemoteUri()} is Bitbucket DC - checking for supported authentication schemes...");
+
+            try
+            {
+                var authenticationMethods = await _restApiRegistry.Get(input).GetAuthenticationMethodsAsync();
+                
+                var modes = AuthenticationModes.None;
+
+                if (authenticationMethods.Contains(AuthenticationMethod.BasicAuth))
+                {
+                    modes |= AuthenticationModes.Basic;
+                }
+
+                var isOauthInstalled = await _restApiRegistry.Get(input).IsOAuthInstalledAsync();
+                if (isOauthInstalled)
+                {
+                    modes |= AuthenticationModes.OAuth;
+                }
+
+                _context.Trace.WriteLine($"Bitbucket DC/Server instance supports authentication schemes: {modes}");
+                return modes;
+            }
+            catch (Exception ex)
+            {
+                _context.Trace.WriteLine($"Failed to query '{input.GetRemoteUri()}' for supported authentication schemes.");
+                _context.Trace.WriteException(ex);
+
+                _context.Terminal.WriteLine($"warning: failed to query '{input.GetRemoteUri()}' for supported authentication schemes.");
+
+                // Fall-back to offering all modes so the user is never blocked from authenticating by at least one mode
+                return AuthenticationModes.All;
+            }
         }
 
         public Task StoreCredentialAsync(InputArguments input)
@@ -312,9 +348,9 @@ namespace Atlassian.Bitbucket
 
         #region Private Methods
 
-        private async Task<string> ResolveOAuthUserNameAsync(string accessToken)
+        private async Task<string> ResolveOAuthUserNameAsync(InputArguments input, string accessToken)
         {
-            RestApiResult<UserInfo> result = await _bitbucketApi.GetUserInformationAsync(null, accessToken, isBearerToken: true);
+            RestApiResult<IUserInfo> result = await _restApiRegistry.Get(input).GetUserInformationAsync(null, accessToken, isBearerToken: true);
             if (result.Succeeded)
             {
                 return result.Response.UserName;
@@ -323,9 +359,9 @@ namespace Atlassian.Bitbucket
             throw new Exception($"Failed to resolve username. HTTP: {result.StatusCode}");
         }
 
-        private async Task<string> ResolveBasicAuthUserNameAsync(string username, string password)
+        private async Task<string> ResolveBasicAuthUserNameAsync(InputArguments input, string username, string password)
         {
-            RestApiResult<UserInfo> result = await _bitbucketApi.GetUserInformationAsync(username, password, isBearerToken: false);
+            RestApiResult<IUserInfo> result = await _restApiRegistry.Get(input).GetUserInformationAsync(username, password, isBearerToken: false);
             if (result.Succeeded)
             {
                 return result.Response.UserName;
@@ -334,8 +370,17 @@ namespace Atlassian.Bitbucket
             throw new Exception($"Failed to resolve username. HTTP: {result.StatusCode}");
         }
 
-        private async Task<bool> ValidateCredentialsWork(Uri remoteUri, ICredential credentials, AuthenticationModes authModes)
+        private async Task<bool> ValidateCredentialsWork(InputArguments input, ICredential credentials, AuthenticationModes authModes)
         {
+            if (_context.Settings.TryGetSetting(
+                BitbucketConstants.EnvironmentVariables.ValidateStoredCredentials,
+                Constants.GitConfiguration.Credential.SectionName, BitbucketConstants.GitConfiguration.Credential.ValidateStoredCredentials,
+                out string validateStoredCredentials) && !validateStoredCredentials.ToBooleanyOrDefault(true))
+            {
+                _context.Trace.WriteLine($"Skipping validation of stored credentials due to {BitbucketConstants.GitConfiguration.Credential.ValidateStoredCredentials} = {validateStoredCredentials}");
+                return true;
+            }
+
             if (credentials is null)
             {
                 return false;
@@ -344,17 +389,8 @@ namespace Atlassian.Bitbucket
             // TODO: ideally we'd also check if the credentials have expired based on some local metadata
             // (once/if we get such metadata storage), and return false if they have.
             // This would be more efficient than having to make REST API calls to check.
-
+            Uri remoteUri = input.GetRemoteUri();
             _context.Trace.WriteLineSecrets($"Validate credentials ({credentials.Account}/{{0}}) are fresh for {remoteUri} ...", new object[] { credentials.Password });
-
-            if (!IsBitbucketOrg(remoteUri))
-            {
-                // TODO: Validate DC/Server credentials before returning them to Git
-                // Currently credentials for DC/Server are not checked by GCM.
-                // Instead the validation relies on Git to try and fail with the credentials and then request GCM to erase them
-                _context.Trace.WriteLine("For DC/Server skip validating existing credentials");
-                return await Task.FromResult(true);
-            }
 
             // Bitbucket supports both OAuth + Basic Auth unless there is explicit GCM configuration.
             // The credentials could be for either scheme therefore need to potentially test both possibilities.
@@ -362,13 +398,13 @@ namespace Atlassian.Bitbucket
             {
                 try
                 {
-                    await ResolveOAuthUserNameAsync(credentials.Password);
+                    await ResolveOAuthUserNameAsync(input, credentials.Password);
                     _context.Trace.WriteLine("Validated existing credentials using OAuth");
                     return true;
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    _context.Trace.WriteLine("Failed to validate existing credentials using OAuth");
+                    _context.Trace.WriteLine($"Failed to validate existing credentials using OAuth: {ex.Message}");
                 }
             }
 
@@ -376,13 +412,13 @@ namespace Atlassian.Bitbucket
             {
                 try
                 {
-                    await ResolveBasicAuthUserNameAsync(credentials.Account, credentials.Password);
+                    await ResolveBasicAuthUserNameAsync(input, credentials.Account, credentials.Password);
                     _context.Trace.WriteLine("Validated existing credentials using BasicAuth");
                     return true;
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    _context.Trace.WriteLine("Failed to validate existing credentials using Basic Auth");
+                    _context.Trace.WriteLine($"Failed to validate existing credentials using Basic Auth: {ex.Message}");
                     return false;
                 }
             }
@@ -406,21 +442,11 @@ namespace Atlassian.Bitbucket
             return uri.AbsoluteUri.TrimEnd('/');
         }
 
-        public static bool IsBitbucketOrg(Uri targetUri)
-        {
-            return IsBitbucketOrg(targetUri.Host);
-        }
-
-        public static bool IsBitbucketOrg(string host)
-        {
-            return StringComparer.OrdinalIgnoreCase.Equals(host, BitbucketConstants.BitbucketBaseUrlHost);
-        }
-
         #endregion
 
         public void Dispose()
         {
-            _bitbucketApi.Dispose();
+            _restApiRegistry.Dispose();
             _bitbucketAuth.Dispose();
         }
     }

--- a/src/shared/Atlassian.Bitbucket/BitbucketRestApiRegistry.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketRestApiRegistry.cs
@@ -7,6 +7,7 @@ namespace Atlassian.Bitbucket
     {
         private readonly ICommandContext context;
         private BitbucketRestApi cloudApi;
+        private DataCenter.BitbucketRestApi dataCenterApi;
 
         public BitbucketRestApiRegistry(ICommandContext context)
         {
@@ -15,6 +16,11 @@ namespace Atlassian.Bitbucket
 
         public IBitbucketRestApi Get(InputArguments input)
         {
+            if(!BitbucketHelper.IsBitbucketOrg(input))
+            {
+                return DataCenterApi;
+            }
+
             return CloudApi;
         }
 
@@ -22,8 +28,10 @@ namespace Atlassian.Bitbucket
         {
             context.Dispose();
             cloudApi?.Dispose();
+            dataCenterApi?.Dispose();
         }
 
         private Cloud.BitbucketRestApi CloudApi => cloudApi ??= new Cloud.BitbucketRestApi(context);
+        private DataCenter.BitbucketRestApi DataCenterApi => dataCenterApi ??= new DataCenter.BitbucketRestApi(context);
     }
 }

--- a/src/shared/Atlassian.Bitbucket/BitbucketRestApiRegistry.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketRestApiRegistry.cs
@@ -1,0 +1,29 @@
+using Atlassian.Bitbucket.Cloud;
+using GitCredentialManager;
+
+namespace Atlassian.Bitbucket
+{
+    public class BitbucketRestApiRegistry : IRegistry<IBitbucketRestApi>
+    {
+        private readonly ICommandContext context;
+        private BitbucketRestApi cloudApi;
+
+        public BitbucketRestApiRegistry(ICommandContext context)
+        {
+            this.context = context;
+        }
+
+        public IBitbucketRestApi Get(InputArguments input)
+        {
+            return CloudApi;
+        }
+
+        public void Dispose()
+        {
+            context.Dispose();
+            cloudApi?.Dispose();
+        }
+
+        private Cloud.BitbucketRestApi CloudApi => cloudApi ??= new Cloud.BitbucketRestApi(context);
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/BitbucketTokenEndpointResponseJson.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketTokenEndpointResponseJson.cs
@@ -1,0 +1,12 @@
+using GitCredentialManager.Authentication.OAuth.Json;
+using Newtonsoft.Json;
+
+namespace Atlassian.Bitbucket 
+{
+        public class BitbucketTokenEndpointResponseJson : TokenEndpointResponseJson
+        {
+            // Bitbucket uses "scopes" for the scopes property name rather than the standard "scope" name
+            [JsonProperty("scopes")]
+            public override string Scope { get; set; }
+        }
+}

--- a/src/shared/Atlassian.Bitbucket/Cloud/BitbucketOAuth2Client.cs
+++ b/src/shared/Atlassian.Bitbucket/Cloud/BitbucketOAuth2Client.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using GitCredentialManager;
+using GitCredentialManager.Authentication.OAuth;
+
+namespace Atlassian.Bitbucket.Cloud
+{
+    public class BitbucketOAuth2Client : Bitbucket.BitbucketOAuth2Client
+    {
+        public BitbucketOAuth2Client(HttpClient httpClient, ISettings settings, ITrace trace)
+            : base(httpClient, GetEndpoints(),
+                GetClientId(settings), GetRedirectUri(settings), GetClientSecret(settings), trace)
+        {
+        }
+
+        public override IEnumerable<string> Scopes => new string[] {
+            CloudConstants.OAuthScopes.RepositoryWrite,
+            CloudConstants.OAuthScopes.Account,
+        };
+
+        private static string GetClientId(ISettings settings)
+        {
+            // Check for developer override value
+            if (settings.TryGetSetting(
+                CloudConstants.EnvironmentVariables.OAuthClientId,
+                Constants.GitConfiguration.Credential.SectionName, CloudConstants.GitConfiguration.Credential.OAuthClientId,
+                out string clientId))
+            {
+                return clientId;
+            }
+
+            return CloudConstants.OAuth2ClientId;
+        }
+
+        private static Uri GetRedirectUri(ISettings settings)
+        {
+            // Check for developer override value
+            if (settings.TryGetSetting(
+                CloudConstants.EnvironmentVariables.OAuthRedirectUri,
+                Constants.GitConfiguration.Credential.SectionName, CloudConstants.GitConfiguration.Credential.OAuthRedirectUri,
+                out string redirectUriStr) && Uri.TryCreate(redirectUriStr, UriKind.Absolute, out Uri redirectUri))
+            {
+                return redirectUri;
+            }
+
+            return CloudConstants.OAuth2RedirectUri;
+        }
+
+        private static string GetClientSecret(ISettings settings)
+        {
+            // Check for developer override value
+            if (settings.TryGetSetting(
+                CloudConstants.EnvironmentVariables.OAuthClientSecret,
+                Constants.GitConfiguration.Credential.SectionName, CloudConstants.GitConfiguration.Credential.OAuthClientSecret,
+                out string clientSecret))
+            {
+                return clientSecret;
+            }
+
+            return CloudConstants.OAuth2ClientSecret;
+        }
+        
+        private static OAuth2ServerEndpoints GetEndpoints()
+        {
+            return new OAuth2ServerEndpoints(
+                CloudConstants.OAuth2AuthorizationEndpoint,
+                CloudConstants.OAuth2TokenEndpoint
+            );
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/Cloud/CloudConstants.cs
+++ b/src/shared/Atlassian.Bitbucket/Cloud/CloudConstants.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace Atlassian.Bitbucket.Cloud
+{
+    public static class CloudConstants
+    {
+        public const string BitbucketBaseUrlHost = "bitbucket.org";
+        public static readonly Uri BitbucketApiUri = new Uri("https://api.bitbucket.org");
+
+        // TODO: use the GCM client ID and secret once we have this approved.
+        // Until then continue to use Sourcetree's values like GCM Windows.
+        //public const string OAuth2ClientId = "b5AKdPfpgFdEGpKzPE";
+        //public const string OAuth2ClientSecret = "7NUP5qUtSR3SxdFK4xAGaU6PMNvNdE59";
+        //public static readonly Uri OAuth2RedirectUri = new Uri("http://localhost:46337/");
+        public const string OAuth2ClientId = "HJdmKXV87DsmC9zSWB";
+        public const string OAuth2ClientSecret = "wwWw47VB9ZHwMsD4Q4rAveHkbxNrMp3n";
+        public static readonly Uri OAuth2RedirectUri = new Uri("http://localhost:34106/");
+
+        public static readonly Uri OAuth2AuthorizationEndpoint = new Uri("https://bitbucket.org/site/oauth2/authorize");
+        public static readonly Uri OAuth2TokenEndpoint = new Uri("https://bitbucket.org/site/oauth2/access_token");
+
+        public static class OAuthScopes
+        {
+            public const string RepositoryWrite = "repository:write";
+            public const string Account = "account";
+        }
+
+        /// <summary>
+        /// Supported authentication modes for Bitbucket.org
+        /// </summary>
+        public const AuthenticationModes DotOrgAuthenticationModes = AuthenticationModes.Basic | AuthenticationModes.OAuth;
+
+        public static class EnvironmentVariables
+        {
+            public const string OAuthClientId = "GCM_BITBUCKET_CLOUD_CLIENTID";
+            public const string OAuthClientSecret = "GCM_BITBUCKET_CLOUD_CLIENTSECRET";
+            public const string OAuthRedirectUri = "GCM_BITBUCKET_CLOUD_OAUTH_REDIRECTURI";
+        }
+
+        public static class GitConfiguration
+        {
+            public static class Credential
+            {
+                public const string OAuthClientId = "cloudOAuthClientId";
+                public const string OAuthClientSecret = "cloudOAuthClientSecret";
+                public const string OAuthRedirectUri = "cloudOauthRedirectUri";
+            }
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/Cloud/UserInfo.cs
+++ b/src/shared/Atlassian.Bitbucket/Cloud/UserInfo.cs
@@ -1,0 +1,20 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Atlassian.Bitbucket.Cloud
+{
+    public class UserInfo : IUserInfo
+    {
+        [JsonProperty("has_2fa_enabled")]
+        public bool IsTwoFactorAuthenticationEnabled { get; set; }
+
+        [JsonProperty("username")]
+        public string UserName { get; set; }
+
+        [JsonProperty("account_id")]
+        public string AccountId { get; set; }
+
+        [JsonProperty("uuid")]
+        public Guid Uuid { get; set; }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketOAuth2Client.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketOAuth2Client.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager;
+using GitCredentialManager.Authentication.OAuth;
+
+namespace Atlassian.Bitbucket.DataCenter
+{
+    public class BitbucketOAuth2Client : Bitbucket.BitbucketOAuth2Client
+    {
+        public BitbucketOAuth2Client(HttpClient httpClient, ISettings settings, ITrace trace)
+            : base(httpClient, GetEndpoints(settings),
+                GetClientId(settings), GetRedirectUri(settings), GetClientSecret(settings), trace)
+        {
+        }
+
+        public override IEnumerable<string> Scopes => new string[] {
+            DataCenterConstants.OAuthScopes.PublicRepos,
+            DataCenterConstants.OAuthScopes.RepoRead,
+            DataCenterConstants.OAuthScopes.RepoWrite
+        };
+
+        private static string GetClientId(ISettings settings)
+        {
+            // Check for developer override value
+            if (settings.TryGetSetting(
+                DataCenterConstants.EnvironmentVariables.OAuthClientId,
+                Constants.GitConfiguration.Credential.SectionName, DataCenterConstants.GitConfiguration.Credential.OAuthClientId,
+                out string clientId))
+            {
+                return clientId;
+            }
+
+            throw new ArgumentException("Bitbucket DC OAuth Client ID must be defined");
+        }
+
+        private static Uri GetRedirectUri(ISettings settings)
+        {
+            // Check for developer override value
+            if (settings.TryGetSetting(
+                DataCenterConstants.EnvironmentVariables.OAuthRedirectUri,
+                Constants.GitConfiguration.Credential.SectionName, DataCenterConstants.GitConfiguration.Credential.OAuthRedirectUri,
+                out string redirectUriStr) && Uri.TryCreate(redirectUriStr, UriKind.Absolute, out Uri redirectUri))
+            {
+                return redirectUri;
+            }
+
+            return DataCenterConstants.OAuth2RedirectUri;
+        }
+
+        private static string GetClientSecret(ISettings settings)
+        {
+            // Check for developer override value
+            if (settings.TryGetSetting(
+                DataCenterConstants.EnvironmentVariables.OAuthClientSecret,
+                Constants.GitConfiguration.Credential.SectionName, DataCenterConstants.GitConfiguration.Credential.OAuthClientSecret,
+                out string clientSecret))
+            {
+                return clientSecret;
+            }
+
+            throw new ArgumentException("Bitbucket DC OAuth Client Secret must be defined");
+        }
+
+        private static OAuth2ServerEndpoints GetEndpoints(ISettings settings)
+        {
+            var remoteUri = settings.RemoteUri;
+            if (remoteUri == null)
+            {
+                throw new ArgumentException("RemoteUri must be defined to generate Bitbucket DC OAuth2 endpoint Urls");
+            }
+
+            return new OAuth2ServerEndpoints(
+                new Uri(BitbucketHelper.GetBaseUri(remoteUri) + "/rest/oauth2/latest/authorize"),
+                new Uri(BitbucketHelper.GetBaseUri(remoteUri) + "/rest/oauth2/latest/token")
+                );
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketRestApi.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/BitbucketRestApi.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using GitCredentialManager;
+using Newtonsoft.Json;
+
+namespace Atlassian.Bitbucket.DataCenter
+{
+    public class BitbucketRestApi : IBitbucketRestApi
+    {
+        private readonly ICommandContext _context;
+
+        private HttpClient _httpClient;
+
+        public BitbucketRestApi(ICommandContext context)
+        {
+            EnsureArgument.NotNull(context, nameof(context));
+
+            _context = context;
+        
+        }
+
+        public async Task<RestApiResult<IUserInfo>> GetUserInformationAsync(string userName, string password, bool isBearerToken)
+        {
+            if (_context.Settings.TryGetSetting(
+                BitbucketConstants.EnvironmentVariables.ValidateStoredCredentials,
+                Constants.GitConfiguration.Credential.SectionName, BitbucketConstants.GitConfiguration.Credential.ValidateStoredCredentials,
+                out string validateStoredCredentials) && !validateStoredCredentials.ToBooleanyOrDefault(true))
+            {
+                _context.Trace.WriteLine($"Skipping retreival of user information due to {BitbucketConstants.GitConfiguration.Credential.ValidateStoredCredentials} = {validateStoredCredentials}");
+                return new RestApiResult<IUserInfo>(HttpStatusCode.OK, new UserInfo() { UserName = DataCenterConstants.OAuthUserName });;
+            }
+
+            // Bitbucket Server/DC doesn't actually provide a REST API we can use to trade an access_token for the owning username,
+            // therefore this is always going to return a placeholder username, however this call does provide a way to validate the 
+            // credentials we do have
+            var requestUri = new Uri(ApiUri, "api/1.0/users");
+            using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri))
+            {
+                if (isBearerToken)
+                {
+                    request.AddBearerAuthenticationHeader(password);
+                }
+                else
+                {
+                    request.AddBasicAuthenticationHeader(userName, password);
+                }
+
+                _context.Trace.WriteLine($"HTTP: GET {requestUri}");
+                using (HttpResponseMessage response = await HttpClient.SendAsync(request))
+                {
+                    _context.Trace.WriteLine($"HTTP: Response {(int) response.StatusCode} [{response.StatusCode}]");
+
+                    string json = await response.Content.ReadAsStringAsync();
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        // No REST API in BBS that can be used to return just my user account based on my login AFAIK.
+                        // but we can prove the credentials work.
+                        return new RestApiResult<IUserInfo>(HttpStatusCode.OK, new UserInfo() { UserName = DataCenterConstants.OAuthUserName });
+                    }
+
+                    return new RestApiResult<IUserInfo>(response.StatusCode);
+                }
+            }
+
+        }
+
+        public async Task<bool> IsOAuthInstalledAsync()
+        {
+            var requestUri = new Uri(ApiUri.AbsoluteUri + "oauth2/1.0/client");
+            using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri))
+            {
+                _context.Trace.WriteLine($"HTTP: GET {requestUri}");
+                using (HttpResponseMessage response = await HttpClient.SendAsync(request))
+                {
+                    _context.Trace.WriteLine($"HTTP: Response {(int)response.StatusCode} [{response.StatusCode}]");
+
+                    if (HttpStatusCode.Unauthorized == response.StatusCode)
+                    {
+                        // accessed anonymously so no access but it does exist.
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+        }
+
+        public async Task<List<AuthenticationMethod>> GetAuthenticationMethodsAsync()
+        {
+            var authenticationMethods = new List<AuthenticationMethod>();
+
+            var requestUri = new Uri(ApiUri.AbsoluteUri + "authconfig/1.0/login-options");
+            using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri))
+            {
+                _context.Trace.WriteLine($"HTTP: GET {requestUri}");
+                using (HttpResponseMessage response = await HttpClient.SendAsync(request))
+                {
+                    _context.Trace.WriteLine($"HTTP: Response {(int)response.StatusCode} [{response.StatusCode}]");
+
+                    string json = await response.Content.ReadAsStringAsync();
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var loginOptions = JsonConvert.DeserializeObject<LoginOptions>(json, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+
+                        if (loginOptions.Results.Any(r => "LOGIN_FORM".Equals(r.Type)))
+                        {
+                            authenticationMethods.Add(AuthenticationMethod.BasicAuth);
+                        }
+
+                        if (loginOptions.Results.Any(r => "IDP".Equals(r.Type)))
+                        {
+                            authenticationMethods.Add(AuthenticationMethod.Sso);
+                        }
+                    }
+                }
+            }
+
+            return authenticationMethods;
+        }
+
+        public void Dispose()
+        {
+            _httpClient?.Dispose();
+        }
+
+        private HttpClient HttpClient => _httpClient ??= _context.HttpClientFactory.CreateClient();
+
+        private Uri ApiUri 
+        {
+            get 
+            {
+                var remoteUri = _context.Settings?.RemoteUri;
+                if (remoteUri == null)
+                {
+                    throw new ArgumentException("RemoteUri must be defined to generate Bitbucket DC OAuth2 endpoint Urls");
+                }
+
+                return new Uri(BitbucketHelper.GetBaseUri(remoteUri) + "/rest/");
+            }
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/DataCenter/DataCenterConstants.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/DataCenterConstants.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Atlassian.Bitbucket.DataCenter
+{
+    public static class DataCenterConstants
+    {
+        public static class OAuthScopes
+        {
+            public const string PublicRepos = "PUBLIC_REPOS";
+            public const string RepoWrite = "REPO_WRITE";
+            public const string RepoRead = "REPO_READ";
+        }
+
+        public static readonly Uri OAuth2RedirectUri = new Uri("http://localhost:34106/");
+
+        /// <summary>
+        /// Supported authentication modes for Bitbucket Server/DC
+        /// </summary>
+        public const AuthenticationModes ServerAuthenticationModes = AuthenticationModes.Basic  | AuthenticationModes.OAuth;
+
+        /// <summary>
+        /// Bitbucket Server/DC does not have a REST API we can use to trade an OAuth access_token for the owning username.
+        /// However one is needed to construct the Basic Auth request made by Git HTTP requests, therefore use a hardcoded
+        /// placeholder for the username.
+        /// </summary>
+        public const string OAuthUserName = "OAUTH_USERNAME";
+
+        public static class EnvironmentVariables
+        {
+            public const string OAuthClientId = "GCM_BITBUCKET_DATACENTER_CLIENTID";
+            public const string OAuthClientSecret = "GCM_BITBUCKET_DATACENTER_CLIENTSECRET";
+            public const string OAuthRedirectUri = "GCM_BITBUCKET_DATACENTER_OAUTH_REDIRECTURI";
+        }
+
+        public static class GitConfiguration
+        {
+            public static class Credential
+            {
+                public const string OAuthClientId = "bitbucketDataCenterOAuthClientId";
+                public const string OAuthClientSecret = "bitbucketDataCenterOAuthClientSecret";
+                public const string OAuthRedirectUri = "bitbucketDataCenterOauthRedirectUri";
+            }
+        }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/DataCenter/LoginOption.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/LoginOption.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Atlassian.Bitbucket.DataCenter
+{
+    public class LoginOption
+    {
+        [JsonProperty("type")]
+        public string Type { get ; set; }
+
+        [JsonProperty("id")]
+        public int Id { get; set; }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/DataCenter/LoginOptions.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/LoginOptions.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Atlassian.Bitbucket.DataCenter
+{
+    public class LoginOptions
+    {
+        [JsonProperty("results")]
+        public List<LoginOption> Results { get; set; }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/DataCenter/UserInfo.cs
+++ b/src/shared/Atlassian.Bitbucket/DataCenter/UserInfo.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Atlassian.Bitbucket.DataCenter
+{
+    public class UserInfo : IUserInfo
+    {
+        // Bitbucket DC does not support this property per-user
+        public bool IsTwoFactorAuthenticationEnabled { get => false; }
+
+        public string UserName { get; set; }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/IBitbucketRestApi.cs
+++ b/src/shared/Atlassian.Bitbucket/IBitbucketRestApi.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Atlassian.Bitbucket
+{
+    public interface IBitbucketRestApi : IDisposable
+    {
+        Task<RestApiResult<IUserInfo>> GetUserInformationAsync(string userName, string password, bool isBearerToken);
+        Task<bool> IsOAuthInstalledAsync();
+        Task<List<AuthenticationMethod>> GetAuthenticationMethodsAsync();
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/IRegistry.cs
+++ b/src/shared/Atlassian.Bitbucket/IRegistry.cs
@@ -1,0 +1,10 @@
+using System;
+using GitCredentialManager;
+
+namespace Atlassian.Bitbucket
+{
+    public interface IRegistry<T> : IDisposable
+    {
+        T Get(InputArguments input);
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/IUserInfo.cs
+++ b/src/shared/Atlassian.Bitbucket/IUserInfo.cs
@@ -1,0 +1,9 @@
+﻿using System;
+namespace Atlassian.Bitbucket
+{
+    public interface IUserInfo
+    {
+        string UserName{ get; }
+        bool IsTwoFactorAuthenticationEnabled { get; }
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/OAuth2ClientRegistry.cs
+++ b/src/shared/Atlassian.Bitbucket/OAuth2ClientRegistry.cs
@@ -1,0 +1,34 @@
+using System.Net.Http;
+using GitCredentialManager;
+
+namespace Atlassian.Bitbucket
+{
+    public class OAuth2ClientRegistry : IRegistry<BitbucketOAuth2Client>
+    {
+        private readonly HttpClient http;
+        private ISettings settings;
+        private readonly ITrace trace;
+        private Cloud.BitbucketOAuth2Client cloudClient;
+
+        public OAuth2ClientRegistry(ICommandContext context)
+        {
+            this.http = context.HttpClientFactory.CreateClient();
+            this.settings = context.Settings;
+            this.trace = context.Trace;
+        }
+
+        public BitbucketOAuth2Client Get(InputArguments input)
+        {
+            return CloudClient;
+        }
+
+        public void Dispose()
+        {
+            http.Dispose();
+            settings.Dispose();
+            cloudClient = null;
+        }
+
+        private Cloud.BitbucketOAuth2Client CloudClient => cloudClient ??= new Cloud.BitbucketOAuth2Client(http, settings, trace);
+    }
+}

--- a/src/shared/Atlassian.Bitbucket/OAuth2ClientRegistry.cs
+++ b/src/shared/Atlassian.Bitbucket/OAuth2ClientRegistry.cs
@@ -9,6 +9,7 @@ namespace Atlassian.Bitbucket
         private ISettings settings;
         private readonly ITrace trace;
         private Cloud.BitbucketOAuth2Client cloudClient;
+        private DataCenter.BitbucketOAuth2Client dataCenterClient;
 
         public OAuth2ClientRegistry(ICommandContext context)
         {
@@ -19,6 +20,11 @@ namespace Atlassian.Bitbucket
 
         public BitbucketOAuth2Client Get(InputArguments input)
         {
+            if (!BitbucketHelper.IsBitbucketOrg(input))
+            {
+                return DataCenterClient;
+            }
+
             return CloudClient;
         }
 
@@ -27,8 +33,10 @@ namespace Atlassian.Bitbucket
             http.Dispose();
             settings.Dispose();
             cloudClient = null;
+            dataCenterClient = null;
         }
 
         private Cloud.BitbucketOAuth2Client CloudClient => cloudClient ??= new Cloud.BitbucketOAuth2Client(http, settings, trace);
+        private DataCenter.BitbucketOAuth2Client DataCenterClient => dataCenterClient ??= new DataCenter.BitbucketOAuth2Client(http, settings, trace);
     }
 }

--- a/src/shared/Atlassian.Bitbucket/RestApiResult.cs
+++ b/src/shared/Atlassian.Bitbucket/RestApiResult.cs
@@ -1,0 +1,22 @@
+﻿using System.Net;
+
+namespace Atlassian.Bitbucket
+{
+    public class RestApiResult<T>
+    {
+        public RestApiResult(HttpStatusCode statusCode)
+            : this(statusCode, default(T)) { }
+
+        public RestApiResult(HttpStatusCode statusCode, T response)
+        {
+            StatusCode = statusCode;
+            Response = response;
+        }
+
+        public HttpStatusCode StatusCode { get; }
+
+        public T Response { get; }
+
+        public bool Succeeded => 199 < (int)StatusCode && (int)StatusCode < 300;
+    }
+}

--- a/src/shared/Core.Tests/Core.Tests.csproj
+++ b/src/shared/Core.Tests/Core.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="ReportGenerator" Version="4.8.13" />
+    <PackageReference Include="ReportGenerator" Version="5.1.9" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
+++ b/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
@@ -197,14 +197,15 @@ namespace GitCredentialManager.Authentication.OAuth
             }
         }
 
-        public virtual async Task<OAuth2TokenResult> GetTokenByAuthorizationCodeAsync(OAuth2AuthorizationCodeResult authorizationCodeResult, CancellationToken ct)
+        public async Task<OAuth2TokenResult> GetTokenByAuthorizationCodeAsync(OAuth2AuthorizationCodeResult authorizationCodeResult, CancellationToken ct)
         {
             var formData = new Dictionary<string, string>
             {
                 [OAuth2Constants.TokenEndpoint.GrantTypeParameter] = OAuth2Constants.TokenEndpoint.AuthorizationCodeGrantType,
                 [OAuth2Constants.TokenEndpoint.AuthorizationCodeParameter] = authorizationCodeResult.Code,
                 [OAuth2Constants.TokenEndpoint.PkceVerifierParameter] = authorizationCodeResult.CodeVerifier,
-                [OAuth2Constants.ClientIdParameter] = _clientId
+                [OAuth2Constants.ClientIdParameter] = _clientId,
+                [OAuth2Constants.ClientSecretParameter] = _clientSecret
             };
 
             if (authorizationCodeResult.RedirectUri != null)
@@ -232,13 +233,14 @@ namespace GitCredentialManager.Authentication.OAuth
             }
         }
 
-        public virtual async Task<OAuth2TokenResult> GetTokenByRefreshTokenAsync(string refreshToken, CancellationToken ct)
+        public async Task<OAuth2TokenResult> GetTokenByRefreshTokenAsync(string refreshToken, CancellationToken ct)
         {
             var formData = new Dictionary<string, string>
             {
                 [OAuth2Constants.TokenEndpoint.GrantTypeParameter] = OAuth2Constants.TokenEndpoint.RefreshTokenGrantType,
                 [OAuth2Constants.TokenEndpoint.RefreshTokenParameter] = refreshToken,
                 [OAuth2Constants.ClientIdParameter] = _clientId,
+                [OAuth2Constants.ClientSecretParameter] = _clientSecret
             };
 
             if (_redirectUri != null)
@@ -348,7 +350,7 @@ namespace GitCredentialManager.Authentication.OAuth
 
         #region Helpers
 
-        protected HttpRequestMessage CreateRequestMessage(HttpMethod method, Uri requestUri, HttpContent content = null, bool addAuthHeader = false)
+        private HttpRequestMessage CreateRequestMessage(HttpMethod method, Uri requestUri, HttpContent content = null, bool addAuthHeader = false)
         {
             var request = new HttpRequestMessage(method, requestUri) {Content = content};
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(Constants.Http.MimeTypeJson));

--- a/src/shared/Core/Authentication/OAuth/OAuth2Constants.cs
+++ b/src/shared/Core/Authentication/OAuth/OAuth2Constants.cs
@@ -4,6 +4,7 @@ namespace GitCredentialManager.Authentication.OAuth
     public static class OAuth2Constants
     {
         public const string ClientIdParameter = "client_id";
+        public const string ClientSecretParameter = "client_secret";
         public const string RedirectUriParameter = "redirect_uri";
         public const string ScopeParameter = "scope";
 

--- a/src/shared/Core/Commands/GetCommand.cs
+++ b/src/shared/Core/Commands/GetCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -34,6 +35,9 @@ namespace GitCredentialManager.Commands
             // Return the credential to Git
             output["username"] = credential.Account;
             output["password"] = credential.Password;
+
+            Context.Trace.WriteLine("Writing credentials to output:");
+            Context.Trace.WriteDictionarySecrets(output, new []{ "password" }, StringComparer.OrdinalIgnoreCase);
 
             // Write the values to standard out
             Context.Streams.Out.WriteDictionary(output);

--- a/src/shared/GitHub.Tests/GitHub.Tests.csproj
+++ b/src/shared/GitHub.Tests/GitHub.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="ReportGenerator" Version="4.8.13" />
+    <PackageReference Include="ReportGenerator" Version="5.1.9" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/shared/GitLab.Tests/GitLab.Tests.csproj
+++ b/src/shared/GitLab.Tests/GitLab.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="ReportGenerator" Version="4.8.13" />
+    <PackageReference Include="ReportGenerator" Version="5.1.9" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/shared/Microsoft.AzureRepos.Tests/Microsoft.AzureRepos.Tests.csproj
+++ b/src/shared/Microsoft.AzureRepos.Tests/Microsoft.AzureRepos.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="ReportGenerator" Version="4.8.13" />
+    <PackageReference Include="ReportGenerator" Version="5.1.9" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/shared/TestInfrastructure/Objects/TestHttpMessageHandler.cs
+++ b/src/shared/TestInfrastructure/Objects/TestHttpMessageHandler.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using GitCredentialManager.Authentication;
 using Xunit;
 
 namespace GitCredentialManager.Tests.Objects
@@ -23,6 +22,8 @@ namespace GitCredentialManager.Tests.Objects
 
         public bool ThrowOnUnexpectedRequest { get; set; }
         public bool SimulateNoNetwork { get; set; }
+
+        public IDictionary<(HttpMethod method, Uri uri), int> RequestCounts => _requestCounts;
 
         public void Setup(HttpMethod method, Uri uri, AsyncRequestHandler handler)
         {
@@ -58,6 +59,11 @@ namespace GitCredentialManager.Tests.Objects
             }
 
             Assert.Equal(expectedNumberOfCalls, numCalls);
+        }
+
+        public void AssertNoRequests()
+        {
+            Assert.Equal(0, _requestCounts.Count);
         }
 
         #region HttpMessageHandler

--- a/src/shared/TestInfrastructure/TestInfrastructure.csproj
+++ b/src/shared/TestInfrastructure/TestInfrastructure.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="ReportGenerator" Version="4.8.13" />
+    <PackageReference Include="ReportGenerator" Version="5.1.9" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>


### PR DESCRIPTION
(Bloody Hell it works.)

Bitbucket DC 7.20 now supports OAuth 2.0 connections from external applications.
https://confluence.atlassian.com/bitbucketserver/bitbucket-data-center-and-server-7-20-release-notes-1101934428.html

This means OAuth 2.0 access_tokens can be used as authentication between Git and Bitbucket DC.

The PR refactors the Bitbucket module provide a more generic framework for supporting OAuth 2.0 and providing implementations for both Bitbucket Cloud and Bitbucket DC as they are unfortunately not exactly the same.

Because each Bitbucket DC installation is a unique instance the OAuth 2.0 ClientId and ClientSecret are unique to each installation and therefore GCM must be configured to support each Bitbucket DC instance.

Documentation is updated to describe how to configure and use the feature.

Tests are extended to cover Bitbucket DC.

I've been dogfooding it for the last month.

