### PR TITLE
Update `IsWslPath` to detect `\\wsl.localhost`-style paths

### DIFF
--- a/src/shared/Core.Tests/WslUtilsTests.cs
+++ b/src/shared/Core.Tests/WslUtilsTests.cs
@@ -6,7 +6,7 @@ namespace GitCredentialManager.Tests
 {
     public class WslUtilsTests
     {
-        [PlatformTheory(Platforms.Windows)]
+        [Theory]
         [InlineData(null, false)]
         [InlineData(@"", false)]
         [InlineData(@" ", false)]
@@ -26,6 +26,18 @@ namespace GitCredentialManager.Tests
         [InlineData(@"\\WSL$\UBUNTU\home", true)]
         [InlineData(@"\\wsl$\ubuntu\home\", true)]
         [InlineData(@"\\wsl$\openSUSE-42\home", true)]
+        [InlineData(@"wsl.localhost", false)]
+        [InlineData(@"\wsl.localhost\ubuntu\home", false)]
+        [InlineData(@"wsl.localhost\ubuntu\home", false)]
+        [InlineData(@"//wsl.localhost/ubuntu/home", false)]
+        [InlineData(@"\\wsl.localhost", false)]
+        [InlineData(@"\\wsl.localhost\", false)]
+        [InlineData(@"\\wsl.localhost\ubuntu", true)]
+        [InlineData(@"\\wsl.localhost\ubuntu\", true)]
+        [InlineData(@"\\wsl.localhost\ubuntu\home", true)]
+        [InlineData(@"\\WSL.LOCALHOST\UBUNTU\home", true)]
+        [InlineData(@"\\wsl.localhost\ubuntu\home\", true)]
+        [InlineData(@"\\wsl.localhost\openSUSE-42\home", true)]
         public void WslUtils_IsWslPath(string path, bool expected)
         {
             bool actual = WslUtils.IsWslPath(path);
@@ -40,6 +52,13 @@ namespace GitCredentialManager.Tests
         [InlineData(@"\\wsl$\UBUNTU\home", "UBUNTU", "/home")]
         [InlineData(@"\\wsl$\ubuntu\home\", "ubuntu", "/home/")]
         [InlineData(@"\\wsl$\openSUSE-42\home", "openSUSE-42", "/home")]
+        [InlineData(@"\\wsl.localhost\ubuntu", "ubuntu", "/")]
+        [InlineData(@"\\wsl.localhost\ubuntu\", "ubuntu", "/")]
+        [InlineData(@"\\wsl.localhost\ubuntu\home", "ubuntu", "/home")]
+        [InlineData(@"\\wsl.localhost\ubuntu\HOME", "ubuntu", "/HOME")]
+        [InlineData(@"\\wsl.localhost\UBUNTU\home", "UBUNTU", "/home")]
+        [InlineData(@"\\wsl.localhost\ubuntu\home\", "ubuntu", "/home/")]
+        [InlineData(@"\\wsl.localhost\openSUSE-42\home", "openSUSE-42", "/home")]
         public void WslUtils_ConvertToDistroPath(string path, string expectedDistro, string expectedPath)
         {
             string actualPath = WslUtils.ConvertToDistroPath(path, out string actualDistro);
@@ -47,7 +66,7 @@ namespace GitCredentialManager.Tests
             Assert.Equal(expectedDistro, actualDistro);
         }
 
-        [PlatformTheory(Platforms.Windows)]
+        [Theory]
         [InlineData(null)]
         [InlineData(@"")]
         [InlineData(@" ")]
@@ -61,6 +80,12 @@ namespace GitCredentialManager.Tests
         [InlineData(@"\\wsl")]
         [InlineData(@"\\wsl$")]
         [InlineData(@"\\wsl$\")]
+        [InlineData(@"wsl.localhost")]
+        [InlineData(@"\wsl.localhost\ubuntu\home")]
+        [InlineData(@"wsl.localhost\ubuntu\home")]
+        [InlineData(@"//wsl.localhost/ubuntu/home")]
+        [InlineData(@"\\wsl.localhost")]
+        [InlineData(@"\\wsl.localhost\")]
         public void WslUtils_ConvertToDistroPath_Invalid_ThrowsException(string path)
         {
             Assert.Throws<ArgumentException>(() => WslUtils.ConvertToDistroPath(path, out _));

--- a/src/shared/Core/WslUtils.cs
+++ b/src/shared/Core/WslUtils.cs
@@ -8,6 +8,7 @@ namespace GitCredentialManager
     public static class WslUtils
     {
         private const string WslUncPrefix = @"\\wsl$\";
+        private const string WslLocalHostUncPrefix = @"\\wsl.localhost\";
         private const string WslCommandName = "wsl.exe";
 
         /// <summary>
@@ -19,8 +20,10 @@ namespace GitCredentialManager
         {
             if (string.IsNullOrWhiteSpace(path)) return false;
 
-            return path.StartsWith(WslUncPrefix, StringComparison.OrdinalIgnoreCase) &&
-                   path.Length > WslUncPrefix.Length;
+            return (path.StartsWith(WslUncPrefix, StringComparison.OrdinalIgnoreCase) &&
+                    path.Length > WslUncPrefix.Length) ||
+                   (path.StartsWith(WslLocalHostUncPrefix, StringComparison.OrdinalIgnoreCase) &&
+                    path.Length > WslLocalHostUncPrefix.Length);
         }
 
         /// <summary>
@@ -54,7 +57,20 @@ namespace GitCredentialManager
         {
             if (!IsWslPath(path)) throw new ArgumentException("Must provide a WSL path", nameof(path));
 
-            int distroStart = WslUncPrefix.Length;
+            int distroStart;
+            if (path.StartsWith(WslUncPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                distroStart = WslUncPrefix.Length;
+            }
+            else if (path.StartsWith(WslLocalHostUncPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                distroStart = WslLocalHostUncPrefix.Length;
+            }
+            else
+            {
+                throw new Exception("Invalid WSL path prefix");
+            }
+
             int distroEnd = path.IndexOf('\\', distroStart);
 
             if (distroEnd < 0) distroEnd = path.Length;


### PR DESCRIPTION
Starting in [Windows build 21354](https://docs.microsoft.com/en-us/windows/wsl/release-notes#build-21354), the preferred WSL UNC file path is `\\wsl.localhost\<distro>\` and not the older administrative-share style `\\wsl$\<distro>\`.

The older "wsl$" style will continue to be supported, but won't be the default type of path we'll see from the system going forwards.

We now support detecting both styles as WSL paths.

Fixes #611