### PR TITLE
Add `install-from-source.sh` and surrounding infrastructure

### DIFF
--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -1,0 +1,33 @@
+name: validate-install-from-source
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker:
+    name: ${{matrix.vector.image}}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        vector:
+        - image: ubuntu
+        - image: debian
+        - image: linuxmintd/mint20-amd64
+        - image: fedora
+        - image: centos
+        - image: redhat/ubi8
+        - image: alpine
+    container: ${{matrix.vector.image}}
+    steps:
+      - uses: actions/checkout@v1
+      - run: |
+          if [ ${{matrix.vector.image}} == "centos" ]; then
+            sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+            sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+          fi
+
+          sh "${GITHUB_WORKSPACE}/src/linux/Packaging.Linux/install-from-source.sh" -y
+          git-credential-manager-core --help || exit 1

--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ sudo /usr/local/share/gcm-core/uninstall.sh
 <a name="linux-install-instructions"></a>
 ### Linux
 
+#### Experimental: install from source helper script
+
+If you would like to help dogfood our new install from source helper script,
+run the following:
+
+1. To ensure `curl` is installed:
+
+```shell
+curl --version
+```
+
+If `curl` is not installed, please use your distribution's package manager
+to install it.
+
+0. To download and run the script:
+
+```shell
+curl -LO https://raw.githubusercontent.com/GitCredentialManager/git-credential-manager/main/src/linux/Packaging.Linux/install-from-source.sh &&
+sh ./install-from-source.sh &&
+git-credential-manager-core configure
+```
+
+__Note:__ You will be prompted to enter your credentials so that the script
+can download GCM's dependencies using your distribution's package
+manager.
+
 #### Ubuntu/Debian distributions
 
 Download the latest [.deb package](https://github.com/GitCredentialManager/git-credential-manager/releases/latest), and run the following:

--- a/src/linux/Packaging.Linux/Packaging.Linux.csproj
+++ b/src/linux/Packaging.Linux/Packaging.Linux.csproj
@@ -7,6 +7,10 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <InstallFromSource>false</InstallFromSource>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="**/*" />
   </ItemGroup>
@@ -19,8 +23,8 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <Target Name="CoreCompile" DependsOnTargets="GetBuildVersion" Condition="'$(OSPlatform)'=='linux'">
-    <Message Text="$(MSBuildProjectDirectory)\build.sh --configuration='$(Configuration)' --version='$(BuildVersion)'" Importance="High" />
-    <Exec Command="$(MSBuildProjectDirectory)\build.sh --configuration='$(Configuration)' --version='$(BuildVersion)'" />
+    <Message Text="$(MSBuildProjectDirectory)\build.sh --install-from-source=$(InstallFromSource) --configuration='$(Configuration)' --version='$(BuildVersion)'" Importance="High" />
+    <Exec Command="$(MSBuildProjectDirectory)\build.sh --install-from-source=$(InstallFromSource) --configuration='$(Configuration)' --version='$(BuildVersion)'" />
   </Target>
 
   <Target Name="CoreClean">

--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -19,7 +19,6 @@ make_absolute () {
 # Building
 #####################################################################
 echo "Building Packaging.Linux..."
-
 # Parse script arguments
 for i in "$@"
 do
@@ -30,6 +29,10 @@ case "$i" in
     ;;
     --version=*)
     VERSION="${i#*=}"
+    shift # past argument=value
+    ;;
+    --install-from-source=*)
+    INSTALL_FROM_SOURCE=${i#*=}
     shift # past argument=value
     ;;
     *)
@@ -59,22 +62,28 @@ if [ -z "$VERSION" ]; then
     die "--version was not set"
 fi
 
-ARCH="`dpkg-architecture -q DEB_HOST_ARCH`"
-if test -z "$ARCH"; then
-  die "Could not determine host architecture!"
+if [ $INSTALL_FROM_SOURCE = false ]; then
+    ARCH="`dpkg-architecture -q DEB_HOST_ARCH`"
+    if test -z "$ARCH"; then
+    die "Could not determine host architecture!"
+    fi
 fi
 
 # Outputs
 PAYLOAD="$PROJ_OUT/payload/$CONFIGURATION"
 SYMBOLOUT="$PROJ_OUT/payload.sym/$CONFIGURATION"
 
-TAROUT="$PROJ_OUT/tar/$CONFIGURATION"
-TARBALL="$TAROUT/gcmcore-linux_$ARCH.$VERSION.tar.gz"
-SYMTARBALL="$TAROUT/symbols-linux_$ARCH.$VERSION.tar.gz"
+if [ $INSTALL_FROM_SOURCE = false ]; then
+    TAROUT="$PROJ_OUT/tar/$CONFIGURATION"
+    TARBALL="$TAROUT/gcmcore-linux_$ARCH.$VERSION.tar.gz"
+    SYMTARBALL="$TAROUT/symbols-linux_$ARCH.$VERSION.tar.gz"
 
-DEBOUT="$PROJ_OUT/deb/$CONFIGURATION"
-DEBROOT="$DEBOUT/root"
-DEBPKG="$DEBOUT/gcmcore-linux_$ARCH.$VERSION.deb"
+    DEBOUT="$PROJ_OUT/deb/$CONFIGURATION"
+    DEBROOT="$DEBOUT/root"
+    DEBPKG="$DEBOUT/gcmcore-linux_$ARCH.$VERSION.deb"
+else
+    INSTALL_LOCATION="/usr/local"
+fi
 
 # Cleanup payload directory
 if [ -d "$PAYLOAD" ]; then
@@ -89,7 +98,13 @@ if [ -d "$SYMBOLOUT" ]; then
 fi
 
 # Ensure directories exists
-mkdir -p "$PAYLOAD" "$SYMBOLOUT" "$DEBROOT"
+mkdir -p "$PAYLOAD" "$SYMBOLOUT"
+
+if [ $INSTALL_FROM_SOURCE = false ]; then
+    mkdir -p "$DEBROOT"
+else
+    mkdir -p "$INSTALL_LOCATION"
+fi
 
 # Publish core application executables
 echo "Publishing core application..."
@@ -135,40 +150,44 @@ mv "$PAYLOAD"/*.pdb "$SYMBOLOUT" || exit 1
 echo "Build complete."
 
 #####################################################################
-# PACKING
+# PACKING AND INSTALLING
 #####################################################################
-echo "Packing Packaging.Linux..."
-# Cleanup any old archive files
-if [ -e "$TAROUT" ]; then
-    echo "Deleteing old archive '$TAROUT'..."
-    rm "$TAROUT"
-fi
-
-# Ensure the parent directory for the archive exists
-mkdir -p "$TAROUT" || exit 1
-
 # Set full read, write, execute permissions for owner and just read and execute permissions for group and other
 echo "Setting file permissions..."
 /bin/chmod -R 755 "$PAYLOAD" || exit 1
 
-# Build binaries tarball
-echo "Building binaries tarball..."
-pushd "$PAYLOAD"
-tar -czvf "$TARBALL" * || exit 1
-popd
+if [ $INSTALL_FROM_SOURCE = false ]; then
+    echo "Packing Packaging.Linux..."
+    # Cleanup any old archive files
+    if [ -e "$TAROUT" ]; then
+        echo "Deleteing old archive '$TAROUT'..."
+        rm "$TAROUT"
+    fi
 
-# Build symbols tarball
-echo "Building symbols tarball..."
-pushd "$SYMBOLOUT"
-tar -czvf "$SYMTARBALL" * || exit 1
-popd
+    # Ensure the parent directory for the archive exists
+    mkdir -p "$TAROUT" || exit 1
 
-# Build .deb
-INSTALL_TO="$DEBROOT/usr/local/share/gcm-core/"
-LINK_TO="$DEBROOT/usr/local/bin/"
-mkdir -p "$DEBROOT/DEBIAN" "$INSTALL_TO" "$LINK_TO" || exit 1
+    # Build binaries tarball
+    echo "Building binaries tarball..."
+    pushd "$PAYLOAD"
+    tar -czvf "$TARBALL" * || exit 1
+    popd
+
+    # Build symbols tarball
+    echo "Building symbols tarball..."
+    pushd "$SYMBOLOUT"
+    tar -czvf "$SYMTARBALL" * || exit 1
+    popd
+
+    # Build .deb
+    INSTALL_TO="$DEBROOT/usr/local/share/gcm-core/"
+    LINK_TO="$DEBROOT/usr/bin/"
+    mkdir -p "$DEBROOT/DEBIAN" "$INSTALL_TO" "$LINK_TO" || exit 1
 
 # make the debian control file
+# this is purposefully not indented, see
+# https://stackoverflow.com/questions/9349616/bash-eof-in-if-statement
+# for details
 cat >"$DEBROOT/DEBIAN/control" <<EOF
 Package: gcmcore
 Version: $VERSION
@@ -183,13 +202,25 @@ Description: Cross Platform Git Credential Manager command line utility.
  For more information see https://aka.ms/gcm
 EOF
 
+    dpkg-deb --build "$DEBROOT" "$DEBPKG" || exit 1
+else
+    echo "Installing..."
+
+    # Install directories
+    INSTALL_TO="$INSTALL_LOCATION/share/gcm-core/"
+    LINK_TO="$INSTALL_LOCATION/bin/"
+    MESSAGE="Install complete."
+fi
+
+mkdir -p "$INSTALL_TO" "$LINK_TO"
+
 # Copy all binaries and shared libraries to target installation location
 cp -R "$PAYLOAD"/* "$INSTALL_TO" || exit 1
 
 # Create symlink
-ln -s -r "$INSTALL_TO/git-credential-manager-core" \
-    "$LINK_TO/git-credential-manager-core" || exit 1
+if [ ! -f "$LINK_TO/git-credential-manager-core" ]; then
+    ln -s -r "$INSTALL_TO/git-credential-manager-core" \
+        "$LINK_TO/git-credential-manager-core" || exit 1
+fi
 
-dpkg-deb --build "$DEBROOT" "$DEBPKG" || exit 1
-
-echo "Pack complete."
+echo $MESSAGE

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -1,0 +1,183 @@
+#!/bin/sh
+
+# halt execution immediately on failure
+# note there are some scenarios in which this will not exit;
+# see https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
+# for additional details
+set -e
+
+is_ci=
+for i in "$@"; do
+    case "$i" in
+        -y)
+        is_ci=true
+        shift # past argument=value
+        ;;
+    esac
+done
+
+# in non-ci scenarios, advertise what we will be doing and
+# give user the option to exit
+if [ -z $is_ci ]; then
+    echo "This script will download, compile, and install Git Credential Manager to:
+
+    /usr/local/bin
+
+Git Credential Manager is licensed under the MIT License: https://aka.ms/gcm/license"
+
+    while true; do
+        read -p "Do you want to continue? [Y/n] " yn
+        case $yn in
+            [Yy]*|"")
+                break
+            ;;
+            [Nn]*)
+                exit
+            ;;
+            *) 
+                echo "Please answer yes or no."
+            ;;
+        esac
+    done
+fi
+
+install_shared_packages() {
+    pkg_manager=$1
+    install_verb=$2
+
+    local shared_packages="git curl"
+    for package in $shared_packages; do
+        # ensure we don't stomp on existing installations
+        if [ ! -z $(which $package) ]; then
+            continue
+        fi
+
+        if [ $pkg_manager = apk ]; then
+            $sudo_cmd $pkg_manager $install_verb $package
+        else
+            $sudo_cmd $pkg_manager $install_verb $package -y
+        fi
+    done
+}
+
+ensure_dotnet_installed() {
+    if [ -z "$(verify_existing_dotnet_installation)" ]; then
+        curl -LO https://dot.net/v1/dotnet-install.sh
+        chmod +x ./dotnet-install.sh
+        bash -c "./dotnet-install.sh"
+
+        # since we have to run the dotnet install script with bash, dotnet isn't added
+        # to the process PATH, so we manually add it here
+        cd ~
+        export DOTNET_ROOT=$(pwd)/.dotnet
+        add_to_PATH $DOTNET_ROOT
+    fi
+}
+
+verify_existing_dotnet_installation() {
+    # get initial pieces of installed sdk version(s)
+    sdks=$(dotnet --list-sdks | cut -c 1-3)
+
+    # if we have a supported version installed, return
+    supported_dotnet_versions="6.0 5.0"
+    for v in $supported_dotnet_versions; do
+        if [ $(echo $sdks | grep "$v") ]; then
+            echo $sdks
+        fi
+    done
+}
+
+add_to_PATH () {
+  for directory; do
+    if [ ! -d "$directory" ]; then
+        continue; # skip nonexistent directory
+    fi
+    case ":$PATH:" in
+        *":$directory:"*)
+            break
+        ;;
+        *)
+            export PATH=$PATH:$directory
+        ;;
+    esac
+  done
+}
+
+sudo_cmd=
+
+# if the user isn't root, we need to use `sudo` for certain commands
+# (e.g. installing packages)
+if [ -z "$sudo_cmd" ]; then
+    if [ `id -u` != 0 ]; then
+        sudo_cmd=sudo
+    fi
+fi
+
+eval "$(sed -n 's/^ID=/distribution=/p' /etc/os-release)"
+eval "$(sed -n 's/^VERSION_ID=/version=/p' /etc/os-release | tr -d '"')"
+case "$distribution" in
+    debian | ubuntu)
+        $sudo_cmd apt update
+        install_shared_packages apt install
+
+        # add dotnet package repository/signing key
+        $sudo_cmd apt update && $sudo_cmd apt install wget -y
+        curl -LO https://packages.microsoft.com/config/"$distribution"/"$version"/packages-microsoft-prod.deb
+        $sudo_cmd dpkg -i packages-microsoft-prod.deb
+        rm packages-microsoft-prod.deb
+
+        # proactively install tzdata to prevent prompts
+        export DEBIAN_FRONTEND=noninteractive
+        $sudo_cmd apt install -y --no-install-recommends tzdata
+
+        # install dotnet packages and dependencies if needed
+        if [ -z "$(verify_existing_dotnet_installation)" ]; then
+            $sudo_cmd apt update
+            $sudo_cmd apt install apt-transport-https -y
+            $sudo_cmd apt update
+            $sudo_cmd apt install dotnet-sdk-5.0 dpkg-dev -y
+        fi
+    ;;
+    linuxmint)
+        $sudo_cmd apt update
+        install_shared_packages apt install
+
+        # install dotnet packages and dependencies
+        $sudo_cmd apt install libc6 libgcc1 libgssapi-krb5-2 libssl1.1 libstdc++6 zlib1g libicu66 -y
+        ensure_dotnet_installed
+    ;;
+    fedora | centos | rhel)
+        $sudo_cmd dnf update -y
+        install_shared_packages dnf install
+
+        # install dotnet/gcm dependencies
+        $sudo_cmd dnf install krb5-libs libicu openssl-libs zlib findutils which bash -y
+
+        ensure_dotnet_installed
+    ;;
+    alpine)
+        $sudo_cmd apk update
+        install_shared_packages apk add
+
+        # install dotnet/gcm dependencies
+        $sudo_cmd apk add icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib which bash coreutils gcompat
+
+        ensure_dotnet_installed
+    ;;
+    *)
+        echo "ERROR: Unsupported Linux distribution: $distribution"
+        exit
+    ;;
+esac
+
+# detect if the script is part of a full source checkout or standalone instead
+script_path="$(cd "$(dirname "$0")" && pwd)"
+toplevel_path="${script_path%/src/linux/Packaging.Linux}"
+if [ "z$script_path" = "z$toplevel_path" ] || [ ! -f "$toplevel_path/Git-Credential-Manager.sln" ]; then
+    toplevel_path="$PWD/git-credential-manager"
+    test -d "$toplevel_path" || git clone https://github.com/GitCredentialManager/git-credential-manager
+fi
+
+cd "$toplevel_path"
+$sudo_cmd dotnet build ./src/linux/Packaging.Linux/Packaging.Linux.csproj -c Release -p:InstallFromSource=true
+add_to_PATH "/usr/local/bin"


### PR DESCRIPTION
Add a helper script for Linux users to install GCM from source. This includes:

1. Updates to `build.sh` to support a new `--install-from-source` parameter.
2. Addition of the script itself.
3. Addition of a new GitHub actions workflow to validate the script on supported distributions.
4. Addition of instructions to obtain/run the script in `README.md`. __Note:__ These instructions _will not_ work currently, as they point to the future location of the script in `main`.