### PR TITLE
Update to .NET 6

### DIFF
--- a/.azure-pipelines/templates/linux/compile.yml
+++ b/.azure-pipelines/templates/linux/compile.yml
@@ -1,9 +1,9 @@
 steps:
   - task: UseDotNet@2
-    displayName: Use .NET SDK 5.0.203
+    displayName: Use .NET SDK 6.0.201
     inputs:
       packageType: sdk
-      version: 5.0.203
+      version: 6.0.201
 
   - task: DotNetCoreCLI@2
     displayName: Compile common code

--- a/.azure-pipelines/templates/osx/compile.yml
+++ b/.azure-pipelines/templates/osx/compile.yml
@@ -1,9 +1,9 @@
 steps:
   - task: UseDotNet@2
-    displayName: Use .NET SDK 5.0.203
+    displayName: Use .NET SDK 6.0.201
     inputs:
       packageType: sdk
-      version: 5.0.203
+      version: 6.0.201
 
   - task: DotNetCoreCLI@2
     displayName: Compile common code and macOS Helpers

--- a/.azure-pipelines/templates/osx/pack.signed/step3-pack.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step3-pack.yml
@@ -7,10 +7,10 @@ steps:
       downloadPath: '$(Build.StagingDirectory)/payload'
 
   - task: UseDotNet@2
-    displayName: Use .NET SDK 5.0.203
+    displayName: Use .NET SDK 6.0.201
     inputs:
       packageType: sdk
-      version: 5.0.203
+      version: 6.0.201
 
   - script: dotnet tool install --global nbgv
     displayName: Install Nerdbank.GitVersioning tool

--- a/.azure-pipelines/templates/windows/compile.signed.yml
+++ b/.azure-pipelines/templates/windows/compile.signed.yml
@@ -11,10 +11,10 @@ steps:
       signType: '$(SignType)'
 
   - task: UseDotNet@2
-    displayName: Use .NET SDK 5.0.203
+    displayName: Use .NET SDK 6.0.201
     inputs:
       packageType: sdk
-      version: 5.0.203
+      version: 6.0.201
 
   - task: NuGetToolInstaller@0
     displayName: Install NuGet tool >=4.3.0

--- a/.azure-pipelines/templates/windows/compile.yml
+++ b/.azure-pipelines/templates/windows/compile.yml
@@ -1,9 +1,9 @@
 steps:
   - task: UseDotNet@2
-    displayName: Use .NET SDK 5.0.203
+    displayName: Use .NET SDK 6.0.201
     inputs:
       packageType: sdk
-      version: 5.0.203
+      version: 6.0.201
 
   - task: DotNetCoreCLI@2
     displayName: Restore packages

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.103
+        dotnet-version: 6.0.201
 
     - name: Install dependencies
       run: dotnet restore --force

--- a/.github/workflows/build-signed-deb.yml
+++ b/.github/workflows/build-signed-deb.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.103
+        dotnet-version: 6.0.201
 
     - name: Install dependencies
       run: dotnet restore --force

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.103
+        dotnet-version: 6.0.201
 
     - name: Install dependencies
       run: dotnet restore

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/out/shared/Git-Credential-Manager/bin/Debug/net5.0/git-credential-manager-core.dll",
+            "program": "${workspaceFolder}/out/shared/Git-Credential-Manager/bin/Debug/net6.0/git-credential-manager-core.dll",
             "args": ["get"],
             "cwd": "${workspaceFolder}/out/shared/Git-Credential-Manager",
             "console": "integratedTerminal",
@@ -22,7 +22,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/out/shared/Git-Credential-Manager/bin/Debug/net5.0/git-credential-manager-core.dll",
+            "program": "${workspaceFolder}/out/shared/Git-Credential-Manager/bin/Debug/net6.0/git-credential-manager-core.dll",
             "args": ["store"],
             "cwd": "${workspaceFolder}/out/shared/Git-Credential-Manager",
             "console": "integratedTerminal",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -56,7 +56,7 @@
             "type": "shell",
             "group": "test",
             "args": [
-                "~/.nuget/packages/reportgenerator/*/*/net5.0/ReportGenerator.dll",
+                "~/.nuget/packages/reportgenerator/*/*/net6.0/ReportGenerator.dll",
                 "-reports:${workspaceFolder}/**/TestResults/**/coverage.cobertura.xml",
                 "-targetdir:${workspaceFolder}/out/code-coverage"
             ],
@@ -71,7 +71,7 @@
             "type": "shell",
             "group": "test",
             "args": [
-                "${env:USERROFILE}/.nuget/packages/reportgenerator/*/*/net5.0/ReportGenerator.dll",
+                "${env:USERROFILE}/.nuget/packages/reportgenerator/*/*/net6.0/ReportGenerator.dll",
                 "-reports:${workspaceFolder}/**/TestResults/**/coverage.cobertura.xml",
                 "-targetdir:${workspaceFolder}/out/code-coverage"
             ],

--- a/docs/development.md
+++ b/docs/development.md
@@ -113,12 +113,12 @@ test with coverage
 HTML reports can be generated using ReportGenerator, this should be installed during the build process, from the command line:
 
 ```shell
-$ dotnet ~/.nuget/packages/reportgenerator/*/*/net5.0/ReportGenerator.dll -reports:./**/TestResults/**/coverage.cobertura.xml -targetdir:./out/code-coverage
+$ dotnet ~/.nuget/packages/reportgenerator/*/*/net6.0/ReportGenerator.dll -reports:./**/TestResults/**/coverage.cobertura.xml -targetdir:./out/code-coverage
 ```
 or
 
 ```shell
-$ dotnet {$env:USERPROFILE}/.nuget/packages/reportgenerator/*/*/net5.0/ReportGenerator.dll -reports:./**/TestResults/**/coverage.cobertura.xml -targetdir:./out/code-coverage
+$ dotnet {$env:USERPROFILE}/.nuget/packages/reportgenerator/*/*/net6.0/ReportGenerator.dll -reports:./**/TestResults/**/coverage.cobertura.xml -targetdir:./out/code-coverage
 ```
 
 Or via VSCode Terminal/Run Task:

--- a/src/linux/Packaging.Linux/Packaging.Linux.csproj
+++ b/src/linux/Packaging.Linux/Packaging.Linux.csproj
@@ -3,7 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -53,7 +53,7 @@ GITLAB_UI_SRC="$SRC/shared/GitLab.UI.Avalonia"
 PROJ_OUT="$OUT/linux/Packaging.Linux"
 
 # Build parameters
-FRAMEWORK=net5.0
+FRAMEWORK=net6.0
 RUNTIME=linux-x64
 
 # Perform pre-execution checks

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -79,7 +79,7 @@ verify_existing_dotnet_installation() {
     sdks=$(dotnet --list-sdks | cut -c 1-3)
 
     # if we have a supported version installed, return
-    supported_dotnet_versions="6.0 5.0"
+    supported_dotnet_versions="6.0"
     for v in $supported_dotnet_versions; do
         if [ $(echo $sdks | grep "$v") ]; then
             echo $sdks
@@ -135,7 +135,7 @@ case "$distribution" in
             $sudo_cmd apt update
             $sudo_cmd apt install apt-transport-https -y
             $sudo_cmd apt update
-            $sudo_cmd apt install dotnet-sdk-5.0 dpkg-dev -y
+            $sudo_cmd apt install dotnet-sdk-6.0 dpkg-dev -y
         fi
     ;;
     linuxmint)

--- a/src/osx/Installer.Mac/Installer.Mac.csproj
+++ b/src/osx/Installer.Mac/Installer.Mac.csproj
@@ -3,7 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/osx/Installer.Mac/layout.sh
+++ b/src/osx/Installer.Mac/layout.sh
@@ -26,7 +26,7 @@ GITHUB_UI_SRC="$SRC/shared/GitHub.UI.Avalonia"
 GITLAB_UI_SRC="$SRC/shared/GitLab.UI.Avalonia"
 
 # Build parameters
-FRAMEWORK=net5.0
+FRAMEWORK=net6.0
 RUNTIME=osx-x64
 
 # Parse script arguments

--- a/src/osx/Installer.Mac/layout.sh
+++ b/src/osx/Installer.Mac/layout.sh
@@ -80,6 +80,7 @@ dotnet publish "$GCM_SRC" \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
+	--self-contained \
 	--output="$(make_absolute "$PAYLOAD")" || exit 1
 
 echo "Publishing Bitbucket UI helper..."
@@ -89,6 +90,7 @@ dotnet publish "$BITBUCKET_UI_SRC" \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
+	--self-contained \
 	--output="$(make_absolute "$PAYLOAD")" || exit 1
 
 echo "Publishing GitHub UI helper..."
@@ -98,6 +100,7 @@ dotnet publish "$GITHUB_UI_SRC" \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
+	--self-contained \
 	--output="$(make_absolute "$PAYLOAD")" || exit 1
 
 echo "Publishing GitLab UI helper..."
@@ -107,6 +110,7 @@ dotnet publish "$GITLAB_UI_SRC" \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
+	--self-contained \
 	--output="$(make_absolute "$PAYLOAD")" || exit 1
 
 # Collect symbols

--- a/src/osx/SignFiles.Mac/SignFiles.Mac.csproj
+++ b/src/osx/SignFiles.Mac/SignFiles.Mac.csproj
@@ -3,7 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <!-- MicroBuild hack: override OutDir to make all files we want to sign under it. -->
     <OutDir>$(RootDir)</OutDir>

--- a/src/shared/Atlassian.Bitbucket.Tests/Atlassian.Bitbucket.Tests.csproj
+++ b/src/shared/Atlassian.Bitbucket.Tests/Atlassian.Bitbucket.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>

--- a/src/shared/Atlassian.Bitbucket.UI.Avalonia/Atlassian.Bitbucket.UI.Avalonia.csproj
+++ b/src/shared/Atlassian.Bitbucket.UI.Avalonia/Atlassian.Bitbucket.UI.Avalonia.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifiers>osx-x64;linux-x64</RuntimeIdentifiers>
     <RootNamespace>Atlassian.Bitbucket.UI</RootNamespace>
     <AssemblyName>Atlassian.Bitbucket.UI</AssemblyName>

--- a/src/shared/Core.Tests/Core.Tests.csproj
+++ b/src/shared/Core.Tests/Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>

--- a/src/shared/Core.UI.Avalonia/Core.UI.Avalonia.csproj
+++ b/src/shared/Core.UI.Avalonia/Core.UI.Avalonia.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>gcmcoreuiavn</AssemblyName>
     <RootNamespace>GitCredentialManager.UI</RootNamespace>
   </PropertyGroup>

--- a/src/shared/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Core/Authentication/MicrosoftAuthentication.cs
@@ -478,7 +478,7 @@ namespace GitCredentialManager.Authentication
 
             return defaultValue;
 #else
-            // OS broker requires .NET Framework right now until we migrate to .NET 5.0 (net6.0-windows10.x.y.z)
+            // OS broker requires .NET Framework right now until we migrate to .NET 5.0 (net5.0-windows10.x.y.z)
             return false;
 #endif
         }

--- a/src/shared/Core/Authentication/MicrosoftAuthentication.cs
+++ b/src/shared/Core/Authentication/MicrosoftAuthentication.cs
@@ -478,7 +478,7 @@ namespace GitCredentialManager.Authentication
 
             return defaultValue;
 #else
-            // OS broker requires .NET Framework right now until we migrate to .NET 5.0 (net5.0-windows10.x.y.z)
+            // OS broker requires .NET Framework right now until we migrate to .NET 5.0 (net6.0-windows10.x.y.z)
             return false;
 #endif
         }

--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net472;net6.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x86;osx-x64;linux-x64</RuntimeIdentifiers>
     <PlatformTarget Condition="'$(OSPlatform)'=='windows'">x86</PlatformTarget>
     <AssemblyName>git-credential-manager-core</AssemblyName>

--- a/src/shared/GitHub.Tests/GitHub.Tests.csproj
+++ b/src/shared/GitHub.Tests/GitHub.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>

--- a/src/shared/GitHub.UI.Avalonia/GitHub.UI.Avalonia.csproj
+++ b/src/shared/GitHub.UI.Avalonia/GitHub.UI.Avalonia.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifiers>osx-x64;linux-x64</RuntimeIdentifiers>
     <RootNamespace>GitHub.UI</RootNamespace>
     <AssemblyName>GitHub.UI</AssemblyName>

--- a/src/shared/GitLab.Tests/GitLab.Tests.csproj
+++ b/src/shared/GitLab.Tests/GitLab.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>

--- a/src/shared/GitLab.UI.Avalonia/GitLab.UI.Avalonia.csproj
+++ b/src/shared/GitLab.UI.Avalonia/GitLab.UI.Avalonia.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifiers>osx-x64;linux-x64</RuntimeIdentifiers>
     <RootNamespace>GitLab.UI</RootNamespace>
     <AssemblyName>GitLab.UI</AssemblyName>

--- a/src/shared/Microsoft.AzureRepos.Tests/Microsoft.AzureRepos.Tests.csproj
+++ b/src/shared/Microsoft.AzureRepos.Tests/Microsoft.AzureRepos.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
This PR updates GCM to .NET 6, which is beneficial as it is an LTS and has support for Apple Silicon (which I plan on adding support in another PR)

This PR has been tested running through the provided "test" configuration in VS Code on macOS. Additionally, I did build, install and run to further test it out.