### PR TITLE
.azure-pipelines: install .NET 6.0 sdk for macOS signing

### DIFF
--- a/.azure-pipelines/templates/osx/pack.signed/step2-signpayload.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step2-signpayload.yml
@@ -15,6 +15,17 @@ steps:
       buildType: 'current'
       artifactName: 'tmp.macpayload_unsigned'
       downloadPath: '$(Build.StagingDirectory)\payload'
+  
+  - task: UseDotNet@2
+    displayName: Use .NET SDK 6.0.201
+    inputs:
+      packageType: sdk
+      version: 6.0.201
+
+  - task: NuGetToolInstaller@0
+    displayName: Install NuGet tool >=4.3.0
+    inputs:
+      versionSpec: '>=4.3.0'
 
   # Must use the NuGet & MSBuild toolchain here rather than `dotnet`
   # because the signing tasks target the netfx MSBuild runtime only.


### PR DESCRIPTION
Install the .NET 6.0 SDK and enforce a minimum NuGet version for macOS
signing workflow. This duplicates what we currently do in the Windows
workflow and fixes the .NET error observed in this attempted release
build:

https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=17051675&view=results

Passing test build with this change:

https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=17052160&view=results