### PR TITLE
Fix install from source Debian compile bug

### DIFF
--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -181,7 +181,7 @@ if [ $INSTALL_FROM_SOURCE = false ]; then
 
     # Build .deb
     INSTALL_TO="$DEBROOT/usr/local/share/gcm-core/"
-    LINK_TO="$DEBROOT/usr/bin/"
+    LINK_TO="$DEBROOT/usr/local/bin/"
     mkdir -p "$DEBROOT/DEBIAN" "$INSTALL_TO" "$LINK_TO" || exit 1
 
 # make the debian control file
@@ -201,8 +201,6 @@ Description: Cross Platform Git Credential Manager command line utility.
  including GitHub, BitBucket, and Azure DevOps.
  For more information see https://aka.ms/gcm
 EOF
-
-    dpkg-deb --build "$DEBROOT" "$DEBPKG" || exit 1
 else
     echo "Installing..."
 
@@ -216,6 +214,10 @@ mkdir -p "$INSTALL_TO" "$LINK_TO"
 
 # Copy all binaries and shared libraries to target installation location
 cp -R "$PAYLOAD"/* "$INSTALL_TO" || exit 1
+
+if [ $INSTALL_FROM_SOURCE = false ]; then
+    dpkg-deb --build "$DEBROOT" "$DEBPKG" || exit 1
+fi
 
 # Create symlink
 if [ ! -f "$LINK_TO/git-credential-manager-core" ]; then


### PR DESCRIPTION
Fixes #644

A Linux user reported an oddly small Debian package associated with the 2.0.692 release. This was caused by the refactoring of `build.sh` in #630. The fix is fairly straightforward - we have to ensure our binaries are copied to the expected location before attempting to create the package. This change implements that fix, and also fixes a component of the symlink path that was also mistakenly dropped in #630.

Here is the set of artifacts from before the fix was implemented, with the Debian package at an unlikely size of 940 B:

https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=17061102&view=artifacts&pathAsName=false&type=publishedArtifacts

Here is the set of artifacts from a test build I ran after the fix was implemented, with a more expected package size of 107 MB:

https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=17076015&view=artifacts&pathAsName=false&type=publishedArtifacts
