### PR TITLE
fixup! fixup! Add install from source script

### DIFF
--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -215,14 +215,14 @@ mkdir -p "$INSTALL_TO" "$LINK_TO"
 # Copy all binaries and shared libraries to target installation location
 cp -R "$PAYLOAD"/* "$INSTALL_TO" || exit 1
 
-if [ $INSTALL_FROM_SOURCE = false ]; then
-    dpkg-deb --build "$DEBROOT" "$DEBPKG" || exit 1
-fi
-
 # Create symlink
 if [ ! -f "$LINK_TO/git-credential-manager-core" ]; then
     ln -s -r "$INSTALL_TO/git-credential-manager-core" \
         "$LINK_TO/git-credential-manager-core" || exit 1
+fi
+
+if [ $INSTALL_FROM_SOURCE = false ]; then
+    dpkg-deb --build "$DEBROOT" "$DEBPKG" || exit 1
 fi
 
 echo $MESSAGE


### PR DESCRIPTION
While #648 led to the creation of a Debian package of the expected size, I realized during testing of this package that there was still a problem. After installing the package locally and running `git-credential-manager-core configure`, I saw the following error:

`git-credential-manager-core: command not found`

This is due to the fact that we need to create the symlink between `usr/local/bin/git-credential-manager-core` and `usr/local/share/git-credential-manager-core` _before_ we create the package. After applying this fix and building the package locally, the `git-credential-manager-core configure` command completed successfully.