### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+
+  # Enable version updates for GitHub ecosystem
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
#668 will add usage of a GitHub action (markdownlint) to the repo workflows. This PR adds dependabot so as to keep this an any other action up to date.

I am not familiar enough with nuget and dot net projects to know if it is worth adding nuget package-ecosystem (or others).

If someone in the know could comment here I will be happy to adjust as needed.
Info on dependabot usage can be seen here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates