### PR TITLE
Pass through $PATH to find dotnet

### DIFF
--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -106,9 +106,13 @@ else
     mkdir -p "$INSTALL_LOCATION"
 fi
 
+if [ -z "$DOTNET_ROOT" ]; then
+    DOTNET_ROOT="$(dirname $(which dotnet))"
+fi
+
 # Publish core application executables
 echo "Publishing core application..."
-dotnet publish "$GCM_SRC" \
+$DOTNET_ROOT/dotnet publish "$GCM_SRC" \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
@@ -117,7 +121,7 @@ dotnet publish "$GCM_SRC" \
 	--output="$(make_absolute "$PAYLOAD")" || exit 1
 
 echo "Publishing Bitbucket UI helper..."
-dotnet publish "$BITBUCKET_UI_SRC" \
+$DOTNET_ROOT/dotnet publish "$BITBUCKET_UI_SRC" \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
@@ -126,7 +130,7 @@ dotnet publish "$BITBUCKET_UI_SRC" \
 	--output="$(make_absolute "$PAYLOAD")" || exit 1
 
 echo "Publishing GitHub UI helper..."
-dotnet publish "$GITHUB_UI_SRC" \
+$DOTNET_ROOT/dotnet publish "$GITHUB_UI_SRC" \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
@@ -135,7 +139,7 @@ dotnet publish "$GITHUB_UI_SRC" \
 	--output="$(make_absolute "$PAYLOAD")" || exit 1
 
 echo "Publishing GitLab UI helper..."
-dotnet publish "$GITLAB_UI_SRC" \
+$DOTNET_ROOT/dotnet publish "$GITLAB_UI_SRC" \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \

--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -178,6 +178,10 @@ if [ "z$script_path" = "z$toplevel_path" ] || [ ! -f "$toplevel_path/Git-Credent
     test -d "$toplevel_path" || git clone https://github.com/GitCredentialManager/git-credential-manager
 fi
 
+if [ -z "$DOTNET_ROOT" ]; then
+    DOTNET_ROOT="$(dirname $(which dotnet))"
+fi
+
 cd "$toplevel_path"
-$sudo_cmd dotnet build ./src/linux/Packaging.Linux/Packaging.Linux.csproj -c Release -p:InstallFromSource=true
+$sudo_cmd env "PATH=$PATH" $DOTNET_ROOT/dotnet build ./src/linux/Packaging.Linux/Packaging.Linux.csproj -c Release -p:InstallFromSource=true
 add_to_PATH "/usr/local/bin"


### PR DESCRIPTION
This commit makes it easier to build on Linux from source. Related to #606, but
applies to x64 builds as well.

Signed-off-by: Easwar Hariharan <easwar.hariharan@microsoft.com>