### PR TITLE
Gitlab hostname only support.

### DIFF
--- a/src/shared/Core.Tests/UriExtensionsTests.cs
+++ b/src/shared/Core.Tests/UriExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace GitCredentialManager.Tests
         }
 
         [Theory]
-        [InlineData("http://com")]
+        [InlineData("http://hostname", "http://hostname")]
         [InlineData("http://example.com",
             "http://example.com")]
         [InlineData("http://foo.example.com",

--- a/src/shared/Core/UriExtensions.cs
+++ b/src/shared/Core/UriExtensions.cs
@@ -102,6 +102,16 @@ namespace GitCredentialManager
                 }
             }
 
+            // check whether the host specification contains of hostname only
+            // this usually means, the git hosting instance is part of your local
+            // network.
+            if (!(string.IsNullOrWhiteSpace(host) || string.IsNullOrEmpty(host)) &&
+                !host.Contains("."))
+            {
+                yield return $"{schemeAndDelim}{host}";
+                yield break;
+            }
+
             // Unfold the host by sub-domain, left-to-right
             while (!string.IsNullOrWhiteSpace(host))
             {


### PR DESCRIPTION
Closes #698 .

This merge request offers support for addressing git hosts by hostname only.

The overall idea of this implementation is: if a host uri does not contain any dots it has to be a host in the local network.
If thats the case the resulting credential scope is returned.

Otherwise the old scope determination algorithm applies.
UnitTest has been adapted. I am open for discussions or improvement suggestions.