### PR TITLE
Fix install from source validation

### DIFF
--- a/.github/workflows/validate-install-from-source.yml
+++ b/.github/workflows/validate-install-from-source.yml
@@ -23,6 +23,8 @@ jobs:
     container: ${{matrix.vector.image}}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Indicate full history so Nerdbank.GitVersioning works.
       - run: |
           if [ ${{matrix.vector.image}} == "centos" ]; then
             sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*


### PR DESCRIPTION
#705 exposed a previously-obfuscated issue in our `validate-install-from-source` pipeline. We were not cloning the repo with its full history, which broke `Nerdbank.GitVersioning` (see failure [here](https://github.com/GitCredentialManager/git-credential-manager/actions/runs/2346353840)). This change fixes the issue (check out [this successful test](https://github.com/ldennington/git-credential-manager/actions/runs/2346516061) run in my fork).