### PR TITLE
install-from-source: add instructions to uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,32 +93,6 @@ sudo /usr/local/share/gcm-core/uninstall.sh
 
 ### Linux
 
-#### Experimental: install from source helper script
-
-If you would like to help dogfood our new install from source helper script,
-run the following:
-
-1. To ensure `curl` is installed:
-
-   ```shell
-   curl --version
-   ```
-
-   If `curl` is not installed, please use your distribution's package manager
-   to install it.
-
-1. To download and run the script:
-
-   ```shell
-   curl -LO https://raw.githubusercontent.com/GitCredentialManager/git-credential-manager/main/src/linux/Packaging.Linux/install-from-source.sh &&
-   sh ./install-from-source.sh &&
-   git-credential-manager-core configure
-   ```
-
-   **Note:** You will be prompted to enter your credentials so that the script
-   can download GCM's dependencies using your distribution's package
-   manager.
-
 #### Ubuntu/Debian distributions
 
 Download the latest [.deb package](https://github.com/GitCredentialManager/git-credential-manager/releases/latest), and run the following:
@@ -142,6 +116,8 @@ sudo dpkg -r gcmcore
 
 #### Other distributions
 
+##### Option 1: Tarball
+
 Download the latest [tarball](https://github.com/GitCredentialManager/git-credential-manager/releases/latest), and run the following:
 
 ```shell
@@ -155,6 +131,33 @@ To uninstall:
 git-credential-manager-core unconfigure
 rm $(command -v git-credential-manager-core)
 ```
+
+#### Option 2: Install from source helper script
+
+1. Ensure `curl` is installed:
+
+   ```shell
+   curl --version
+   ```
+
+   If `curl` is not installed, please use your distribution's package manager
+   to install it.
+
+1. Download and run the script:
+
+   ```shell
+   curl -LO https://raw.githubusercontent.com/GitCredentialManager/git-credential-manager/main/src/linux/Packaging.Linux/install-from-source.sh &&
+   sh ./install-from-source.sh &&
+   git-credential-manager-core configure
+   ```
+
+   **Note:** You will be prompted to enter your credentials so that the script
+   can download GCM's dependencies using your distribution's package
+   manager.
+
+To uninstall:
+
+[Follow these instructions](docs/linux-fromsrc-uninstall.md) for your distribution.
 
 **Note:** all Linux distributions [require additional configuration](https://aka.ms/gcm/credstores) to use GCM.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -146,3 +146,7 @@ and pick "Revoke access".
 ![Revoke GCM OAuth app access](img/github-oauthapp-revoke.png)
 
 After revoking access, any tokens created by GCM will be invalidated and can no longer be used to access your repositories. The next time GCM attempts to access GitHub.com you will be prompted to consent again.
+
+### I used the install from source script to install GCM on my Linux distribution. Now how can I uninstall GCM and its dependencies?
+
+Please see full instructions [here](./linux-fromsrc-uninstall.md).

--- a/docs/linux-fromsrc-uninstall.md
+++ b/docs/linux-fromsrc-uninstall.md
@@ -1,0 +1,55 @@
+# Uninstalling after installing from source
+
+These instructions will guide you in removing GCM after running the [install from source script](../src/linux/Packaging.Linux/install-from-source.sh) on your Linux distribution.
+
+:siren: PROCEED WITH CAUTION :siren:
+
+For completeness, we provide uninstall instructions for _the GCM application, the GCM repo, and the maximum number of dependencies*_ for all distributions. This repo and these dependencies may or may not have already been present on your system when you ran the install from source script, and uninstalling them could impact other programs and/or your normal workflows. Please keep this in mind when following the instructions below.
+
+*Certain distributions require some dependencies of the script to function as expected, so we only include instructions to remove the non-required dependencies.
+
+## All distributions
+
+**Note:** If you ran the install from source script from a pre-existing clone of the `git-credential-manager` repo or outside of your `$HOME` directory, you will need to modify the final two commands below to point to the location of your pre-existing clone or the directory from which you ran the install from source script.
+
+```console
+git-credential-manager-core unconfigure &&
+sudo rm $(command -v git-credential-manager-core) &&
+sudo rm -rf /usr/local/share/gcm-core &&
+sudo rm -rf ~/git-credential-manager &&
+sudo rm ~/install-from-source.sh
+```
+
+## Debian/Ubuntu
+
+**Note:** If you had a pre-existing installation of dotnet that was not installed via `apt` or `apt-get` when you ran the install from source script, you will need to remove it using [these instructions](https://docs.microsoft.com/en-us/dotnet/core/install/remove-runtime-sdk-versions?pivots=os-linux#uninstall-net) and remove `dotnet-*` from the below command.
+
+```console
+sudo apt remove dotnet-* dpkg-dev apt-transport-https git curl wget
+```
+
+## Linux Mint
+
+**Note:** If you had a pre-existing installation of dotnet when you ran the install from source script that was not located at `~/.dotnet`, you will need to modify the first command below to point to the custom install location. If you would like to remove the specific version of dotnet that the script installed and keep other versions, you can do so with [these instructions](https://docs.microsoft.com/en-us/dotnet/core/install/remove-runtime-sdk-versions?pivots=os-linux#uninstall-net).
+
+```console
+sudo rm -rf ~/.dotnet &&
+sudo apt remove git curl
+```
+
+## Fedora/CentOS/RHEL
+
+**Note:** If you had a pre-existing installation of dotnet when you ran the install from source script that was not located at `~/.dotnet`, you will need to modify the first command below to point to the custom install location. If you would like to remove the specific version of dotnet that the script installed and keep other versions, you can do so with [these instructions](https://docs.microsoft.com/en-us/dotnet/core/install/remove-runtime-sdk-versions?pivots=os-linux#uninstall-net).
+
+```console
+sudo rm -rf ~/.dotnet
+```
+
+## Alpine
+
+**Note:** If you had a pre-existing installation of dotnet when you ran the install from source script that was not located at `~/.dotnet`, you will need to modify the first command below to point to the custom install location. If you would like to remove the specific version of dotnet that the script installed and keep other versions, you can do so with [these instructions](https://docs.microsoft.com/en-us/dotnet/core/install/remove-runtime-sdk-versions?pivots=os-linux#uninstall-net).
+
+```console
+sudo rm -rf ~/.dotnet &&
+sudo apk del icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib which bash coreutils gcompat git curl
+```


### PR DESCRIPTION
Add instructions for Linux users on supported distros to remove GCM
and its dependencies after installing from source. Additionally, remove
'experimental' moniker, given it's been available for over two months
with only [one issue](https://github.com/GitCredentialManager/git-credential-manager/issues/644) 😊.

Fixes #696 