### PR TITLE
Show Bitbucket Server/Data Center URL in UI and use better help links

### DIFF
--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketAuthenticationTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketAuthenticationTest.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using GitCredentialManager;
 using GitCredentialManager.Tests.Objects;
+using Moq;
 using Xunit;
 
 namespace Atlassian.Bitbucket.Tests
@@ -117,6 +121,114 @@ namespace Atlassian.Bitbucket.Tests
             Assert.True(result);
             Assert.Equal($"Your account has two-factor authentication enabled.{Environment.NewLine}" +
                                            $"To continue you must complete authentication in your web browser.{Environment.NewLine}", context.Terminal.Messages[0].Item1);
+        }
+
+        [Fact]
+        public async Task BitbucketAuthentication_GetCredentialsAsync_AllModes_NoUser_BBCloud_HelperCmdLine()
+        {
+            var targetUri = new Uri("https://bitbucket.org");
+
+            var helperPath = "/usr/bin/test-helper";
+            var expectedUserName = "jsquire";
+            var expectedPassword = "password";
+            var resultDict = new Dictionary<string, string>
+            {
+                ["username"] = expectedUserName,
+                ["password"] = expectedPassword
+            };
+
+            string expectedArgs = $"userpass --show-oauth";
+
+            var context = new TestCommandContext();
+            context.SessionManager.IsDesktopSession = true; // Enable OAuth and UI helper selection
+
+            var authMock = new Mock<BitbucketAuthentication>(context) { CallBase = true };
+            authMock.Setup(x => x.TryFindHelperExecutablePath(out helperPath))
+                .Returns(true);
+            authMock.Setup(x => x.InvokeHelperAsync(It.IsAny<string>(), It.IsAny<string>(), null, CancellationToken.None))
+                .ReturnsAsync(resultDict);
+
+            BitbucketAuthentication auth = authMock.Object;
+            CredentialsPromptResult result = await auth.GetCredentialsAsync(targetUri, null, AuthenticationModes.All);
+
+            Assert.Equal(AuthenticationModes.Basic, result.AuthenticationMode);
+            Assert.Equal(result.Credential.Account, expectedUserName);
+            Assert.Equal(result.Credential.Password, expectedPassword);
+
+            authMock.Verify(x => x.InvokeHelperAsync(helperPath, expectedArgs, null, CancellationToken.None),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task BitbucketAuthentication_GetCredentialsAsync_BasicOnly_User_BBCloud_HelperCmdLine()
+        {
+            var targetUri = new Uri("https://bitbucket.org");
+
+            var helperPath = "/usr/bin/test-helper";
+            var expectedUserName = "jsquire";
+            var expectedPassword = "password";
+            var resultDict = new Dictionary<string, string>
+            {
+                ["username"] = expectedUserName,
+                ["password"] = expectedPassword
+            };
+
+            string expectedArgs = $"userpass --username {expectedUserName}";
+
+            var context = new TestCommandContext();
+            context.SessionManager.IsDesktopSession = true; // Enable UI helper selection
+
+            var authMock = new Mock<BitbucketAuthentication>(context) { CallBase = true };
+            authMock.Setup(x => x.TryFindHelperExecutablePath(out helperPath))
+                .Returns(true);
+            authMock.Setup(x => x.InvokeHelperAsync(It.IsAny<string>(), It.IsAny<string>(), null, CancellationToken.None))
+                .ReturnsAsync(resultDict);
+
+            BitbucketAuthentication auth = authMock.Object;
+            CredentialsPromptResult result = await auth.GetCredentialsAsync(targetUri, expectedUserName, AuthenticationModes.Basic);
+
+            Assert.Equal(AuthenticationModes.Basic, result.AuthenticationMode);
+            Assert.Equal(result.Credential.Account, expectedUserName);
+            Assert.Equal(result.Credential.Password, expectedPassword);
+
+            authMock.Verify(x => x.InvokeHelperAsync(helperPath, expectedArgs, null, CancellationToken.None),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task BitbucketAuthentication_GetCredentialsAsync_AllModes_NoUser_BBServerDC_HelperCmdLine()
+        {
+            var targetUri = new Uri("https://example.com/bitbucket");
+
+            var helperPath = "/usr/bin/test-helper";
+            var expectedUserName = "jsquire";
+            var expectedPassword = "password";
+            var resultDict = new Dictionary<string, string>
+            {
+                ["username"] = expectedUserName,
+                ["password"] = expectedPassword
+            };
+
+            string expectedArgs = $"userpass --url {targetUri} --show-oauth";
+
+            var context = new TestCommandContext();
+            context.SessionManager.IsDesktopSession = true; // Enable OAuth and UI helper selection
+
+            var authMock = new Mock<BitbucketAuthentication>(context) { CallBase = true };
+            authMock.Setup(x => x.TryFindHelperExecutablePath(out helperPath))
+                .Returns(true);
+            authMock.Setup(x => x.InvokeHelperAsync(It.IsAny<string>(), It.IsAny<string>(), null, CancellationToken.None))
+                .ReturnsAsync(resultDict);
+
+            BitbucketAuthentication auth = authMock.Object;
+            CredentialsPromptResult result = await auth.GetCredentialsAsync(targetUri, null, AuthenticationModes.All);
+
+            Assert.Equal(AuthenticationModes.Basic, result.AuthenticationMode);
+            Assert.Equal(result.Credential.Account, expectedUserName);
+            Assert.Equal(result.Credential.Password, expectedPassword);
+
+            authMock.Verify(x => x.InvokeHelperAsync(helperPath, expectedArgs, null, CancellationToken.None),
+                Times.Once);
         }
     }
 }

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketHostProviderTest.cs
@@ -22,6 +22,58 @@ namespace Atlassian.Bitbucket.Tests
         private Mock<IBitbucketRestApi> bitbucketApi = new Mock<IBitbucketRestApi>(MockBehavior.Strict);
 
         [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("    ", false)]
+        [InlineData("bitbucket.org", true)]
+        [InlineData("BITBUCKET.ORG", true)]
+        [InlineData("BiTbUcKeT.OrG", true)]
+        [InlineData("bitbucket.example.com", false)]
+        [InlineData("bitbucket.example.org", false)]
+        [InlineData("bitbucket.org.com", false)]
+        [InlineData("bitbucket.org.org", false)]
+        public void BitbucketHostProvider_IsBitbucketOrg_StringHost(string str, bool expected)
+        {
+            bool actual = BitbucketHostProvider.IsBitbucketOrg(str);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("http://bitbucket.org", true)]
+        [InlineData("https://bitbucket.org", true)]
+        [InlineData("http://bitbucket.org/path", true)]
+        [InlineData("https://bitbucket.org/path", true)]
+        [InlineData("http://BITBUCKET.ORG", true)]
+        [InlineData("https://BITBUCKET.ORG", true)]
+        [InlineData("http://BITBUCKET.ORG/PATH", true)]
+        [InlineData("https://BITBUCKET.ORG/PATH", true)]
+        [InlineData("http://BiTbUcKeT.OrG", true)]
+        [InlineData("https://BiTbUcKeT.OrG", true)]
+        [InlineData("http://BiTbUcKeT.OrG/pAtH", true)]
+        [InlineData("https://BiTbUcKeT.OrG/pAtH", true)]
+        [InlineData("http://bitbucket.example.com", false)]
+        [InlineData("https://bitbucket.example.com", false)]
+        [InlineData("http://bitbucket.example.com/path", false)]
+        [InlineData("https://bitbucket.example.com/path", false)]
+        [InlineData("http://bitbucket.example.org", false)]
+        [InlineData("https://bitbucket.example.org", false)]
+        [InlineData("http://bitbucket.example.org/path", false)]
+        [InlineData("https://bitbucket.example.org/path", false)]
+        [InlineData("http://bitbucket.org.com", false)]
+        [InlineData("https://bitbucket.org.com", false)]
+        [InlineData("http://bitbucket.org.com/path", false)]
+        [InlineData("https://bitbucket.org.com/path", false)]
+        [InlineData("http://bitbucket.org.org", false)]
+        [InlineData("https://bitbucket.org.org", false)]
+        [InlineData("http://bitbucket.org.org/path", false)]
+        [InlineData("https://bitbucket.org.org/path", false)]
+        public void BitbucketHostProvider_IsBitbucketOrg_Uri(string str, bool expected)
+        {
+            bool actual = BitbucketHostProvider.IsBitbucketOrg(new Uri(str));
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
         [InlineData("https", null, false)]
         // We report that we support unencrypted HTTP here so that we can fail and
         // show a helpful error message in the call to `GenerateCredentialAsync` instead.

--- a/src/shared/Atlassian.Bitbucket.UI.Avalonia/Views/CredentialsView.axaml
+++ b/src/shared/Atlassian.Bitbucket.UI.Avalonia/Views/CredentialsView.axaml
@@ -23,6 +23,9 @@
         <StackPanel DockPanel.Dock="Top" Margin="0,0,0,30">
             <Image HorizontalAlignment="Center" Source="/Assets/atlassian-logo.png" />
             <TextBlock HorizontalAlignment="Center" Text="Log in to your account"/>
+            <TextBlock HorizontalAlignment="Center" Text="{Binding Url}"
+                       IsVisible="{Binding Url, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                       Margin="0,10,0,0"/>
         </StackPanel>
 
         <StackPanel Width="288">

--- a/src/shared/Atlassian.Bitbucket.UI/Commands/CredentialsCommand.cs
+++ b/src/shared/Atlassian.Bitbucket.UI/Commands/CredentialsCommand.cs
@@ -16,6 +16,10 @@ namespace Atlassian.Bitbucket.UI.Commands
             : base(context, "userpass", "Show authentication prompt.")
         {
             AddOption(
+                new Option<string>("--url", "Bitbucket Server or Data Center URL")
+            );
+
+            AddOption(
                 new Option<string>("--username", "Username or email.")
             );
 
@@ -23,13 +27,14 @@ namespace Atlassian.Bitbucket.UI.Commands
                 new Option("--show-oauth", "Show OAuth option.")
             );
 
-            Handler = CommandHandler.Create<string, bool>(ExecuteAsync);
+            Handler = CommandHandler.Create<Uri, string, bool>(ExecuteAsync);
         }
 
-        private async Task<int> ExecuteAsync(string userName, bool showOAuth)
+        private async Task<int> ExecuteAsync(Uri url, string userName, bool showOAuth)
         {
             var viewModel = new CredentialsViewModel(Context.Environment)
             {
+                Url = url,
                 UserName = userName,
                 ShowOAuth = showOAuth
             };

--- a/src/shared/Atlassian.Bitbucket.UI/Commands/OAuthCommand.cs
+++ b/src/shared/Atlassian.Bitbucket.UI/Commands/OAuthCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +15,10 @@ namespace Atlassian.Bitbucket.UI.Commands
         protected OAuthCommand(ICommandContext context)
             : base(context, "oauth", "Show OAuth required prompt.")
         {
+            AddOption(
+                new Option<string>("--url", "Bitbucket Server or Data Center URL")
+            );
+
             Handler = CommandHandler.Create(ExecuteAsync);
         }
 

--- a/src/shared/Atlassian.Bitbucket.UI/ViewModels/CredentialsViewModel.cs
+++ b/src/shared/Atlassian.Bitbucket.UI/ViewModels/CredentialsViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Windows.Input;
 using GitCredentialManager;
@@ -10,6 +11,7 @@ namespace Atlassian.Bitbucket.UI.ViewModels
     {
         private readonly IEnvironment _environment;
 
+        private Uri _url;
         private string _userName;
         private string _password;
         private bool _showOAuth;
@@ -64,12 +66,26 @@ namespace Atlassian.Bitbucket.UI.ViewModels
 
         private void ForgotPassword()
         {
-            BrowserUtils.OpenDefaultBrowser(_environment, "https://bitbucket.org/account/password/reset/");
+            Uri passwordResetUri = _url is null
+                ? new Uri(BitbucketConstants.HelpUrls.PasswordReset)
+                : new Uri(_url, BitbucketConstants.HelpUrls.DataCenterPasswordReset);
+
+            BrowserUtils.OpenDefaultBrowser(_environment, passwordResetUri);
         }
 
         private void SignUp()
         {
-            BrowserUtils.OpenDefaultBrowser(_environment, "https://bitbucket.org/account/signup/");
+            Uri signUpUri = _url is null
+                ? new Uri(BitbucketConstants.HelpUrls.SignUp)
+                : new Uri(_url, BitbucketConstants.HelpUrls.DataCenterLogin);
+
+            BrowserUtils.OpenDefaultBrowser(_environment, signUpUri);
+        }
+
+        public Uri Url
+        {
+            get => _url;
+            set => SetAndRaisePropertyChanged(ref _url, value);
         }
 
         public string UserName

--- a/src/shared/Atlassian.Bitbucket.UI/ViewModels/OAuthViewModel.cs
+++ b/src/shared/Atlassian.Bitbucket.UI/ViewModels/OAuthViewModel.cs
@@ -30,17 +30,18 @@ namespace Atlassian.Bitbucket.UI.ViewModels
 
         private void LearnMore()
         {
-            BrowserUtils.OpenDefaultBrowser(_environment, "https://confluence.atlassian.com/bitbucket/two-step-verification-777023203.html");
+            // 2FA is not supported on Server/DC so this prompt will never be seen outside of Bitbucket Cloud
+            BrowserUtils.OpenDefaultBrowser(_environment, BitbucketConstants.HelpUrls.TwoFactor);
         }
 
         private void ForgotPassword()
         {
-            BrowserUtils.OpenDefaultBrowser(_environment, "https://bitbucket.org/account/password/reset/");
+            BrowserUtils.OpenDefaultBrowser(_environment, BitbucketConstants.HelpUrls.PasswordReset);
         }
 
         private void SignUp()
         {
-            BrowserUtils.OpenDefaultBrowser(_environment, "https://bitbucket.org/account/signup/");
+            BrowserUtils.OpenDefaultBrowser(_environment, BitbucketConstants.HelpUrls.SignUp);
         }
 
         /// <summary>

--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -245,7 +245,7 @@ namespace Atlassian.Bitbucket
 
         #region Private Methods
 
-        private bool TryFindHelperExecutablePath(out string path)
+        protected internal virtual bool TryFindHelperExecutablePath(out string path)
         {
             return TryFindHelperExecutablePath(
                 BitbucketConstants.EnvironmentVariables.AuthenticationHelper,

--- a/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketAuthentication.cs
@@ -94,6 +94,11 @@ namespace Atlassian.Bitbucket
                 TryFindHelperExecutablePath(out string helperPath))
             {
                 var cmdArgs = new StringBuilder("userpass");
+                if (!BitbucketHostProvider.IsBitbucketOrg(targetUri))
+                {
+                    cmdArgs.AppendFormat(" --url {0}", QuoteCmdArg(targetUri.ToString()));
+                }
+
                 if (!string.IsNullOrWhiteSpace(userName))
                 {
                     cmdArgs.AppendFormat(" --username {0}", QuoteCmdArg(userName));

--- a/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketConstants.cs
@@ -49,6 +49,15 @@ namespace Atlassian.Bitbucket
             }
         }
 
+        public static class HelpUrls
+        {
+            public const string DataCenterPasswordReset = "/passwordreset";
+            public const string DataCenterLogin = "/login";
+            public const string PasswordReset = "https://bitbucket.org/account/password/reset/";
+            public const string SignUp = "https://bitbucket.org/account/signup/";
+            public const string TwoFactor = "https://support.atlassian.com/bitbucket-cloud/docs/enable-two-step-verification/";
+        }
+
         /// <summary>
         /// Supported authentication modes for Bitbucket.org
         /// </summary>

--- a/src/shared/Atlassian.Bitbucket/InternalsVisibleTo.cs
+++ b/src/shared/Atlassian.Bitbucket/InternalsVisibleTo.cs
@@ -1,5 +1,3 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Core.Tests")]
-[assembly: InternalsVisibleTo("GitHub.Tests")]
 [assembly: InternalsVisibleTo("Atlassian.Bitbucket.Tests")]

--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -25,7 +25,7 @@ namespace GitCredentialManager.Authentication
             return InvokeHelperAsync(path, args, null, CancellationToken.None);
         }
 
-        internal protected virtual async Task<IDictionary<string, string>> InvokeHelperAsync(string path, string args,
+        protected internal virtual async Task<IDictionary<string, string>> InvokeHelperAsync(string path, string args,
             IDictionary<string, string> standardInput, CancellationToken ct)
         {
             var procStartInfo = new ProcessStartInfo(path)


### PR DESCRIPTION
Update the Bitbucket credential UI to show the URL of the Bitbucket Server or Data Center instance, if we're talking to them.

Also fix up the help links to point to a host-relative location; not always to Bitbucket Cloud pages. Note that the OAuth prompt will never been shown for Server/DC since 2FA is not supported there.

This should help resolve some issues raised in #684

![image](https://user-images.githubusercontent.com/5658207/170364316-82fe4ba1-8894-4219-bf39-df70c50e3854.png)