### PR TITLE
Manually scan `$PATH` on POSIX systems 

### DIFF
--- a/src/shared/Core/Interop/Posix/PosixEnvironment.cs
+++ b/src/shared/Core/Interop/Posix/PosixEnvironment.cs
@@ -5,9 +5,14 @@ namespace GitCredentialManager.Interop.Posix
 {
     public class PosixEnvironment : EnvironmentBase
     {
-        public PosixEnvironment(IFileSystem fileSystem) : base(fileSystem)
+        public PosixEnvironment(IFileSystem fileSystem)
+            : this(fileSystem, GetCurrentVariables()) { }
+
+        internal PosixEnvironment(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
+            : base(fileSystem)
         {
-            Variables = GetCurrentVariables();
+            EnsureArgument.NotNull(variables, nameof(variables));
+            Variables = variables;
         }
 
         #region EnvironmentBase

--- a/src/shared/Core/Interop/Posix/PosixEnvironment.cs
+++ b/src/shared/Core/Interop/Posix/PosixEnvironment.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 
 namespace GitCredentialManager.Interop.Posix
 {
@@ -27,40 +25,6 @@ namespace GitCredentialManager.Interop.Posix
         protected override string[] SplitPathVariable(string value)
         {
             return value.Split(':');
-        }
-
-        public override bool TryLocateExecutable(string program, out string path)
-        {
-            // The "which" utility scans over the PATH and does not include the current working directory
-            // (unlike the equivalent "where.exe" on Windows), which is exactly what we want. Let's use it.
-            const string whichPath = "/usr/bin/which";
-            var psi = new ProcessStartInfo(whichPath, program)
-            {
-                UseShellExecute = false,
-                RedirectStandardOutput = true
-            };
-
-            using (var where = new Process {StartInfo = psi})
-            {
-                where.Start();
-                where.WaitForExit();
-
-                switch (where.ExitCode)
-                {
-                    case 0: // found
-                        string stdout = where.StandardOutput.ReadToEnd();
-                        string[] results = stdout.Split(new[] {'\n'}, StringSplitOptions.RemoveEmptyEntries);
-                        path = results.First();
-                        return true;
-
-                    case 1: // not found
-                        path = null;
-                        return false;
-
-                    default:
-                        throw new Exception($"Unknown error locating '{program}' using {whichPath}. Exit code: {where.ExitCode}.");
-                }
-            }
         }
 
         #endregion

--- a/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
+++ b/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
@@ -67,28 +67,6 @@ namespace GitCredentialManager.Interop.Windows
             }
         }
 
-        public override bool TryLocateExecutable(string program, out string path)
-        {
-            // Don't use "where.exe" on Windows as this includes the current working directory
-            // and we don't want to enumerate this location; only the PATH.
-            if (Variables.TryGetValue("PATH", out string pathValue))
-            {
-                string[] paths = SplitPathVariable(pathValue);
-                foreach (var basePath in paths)
-                {
-                    string candidatePath = Path.Combine(basePath, program);
-                    if (FileSystem.FileExists(candidatePath))
-                    {
-                        path = candidatePath;
-                        return true;
-                    }
-                }
-            }
-
-            path = null;
-            return false;
-        }
-
         public override Process CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
         {
             // If we're asked to start a WSL executable we must launch via the wsl.exe command tool


### PR DESCRIPTION
Because the `which` command is not always located in `/usr/bin` on all POSIX systems, we cannot directly call `/usr/bin/which` to do program location for us. Oh the irony..

We might be able to use `env` to locate `which`, but again the `env` utility isn't always found in the same place, so we're stuck.

Instead we now manually scan the `$PATH` variable directories looking for the program we need to find, in the same way we do on Windows (for different reasons).

This should also be slightly faster as you'd hope .NET's `String.Split` method and `lstat` calls are faster than `fork`/`exec`-ing another executable?

Fixes #671 