### PR TITLE
Remove windows from `credential-cache` in `credstores.md`

### DIFF
--- a/docs/credstores.md
+++ b/docs/credstores.md
@@ -178,7 +178,7 @@ TTY device path, as returned by the `tty` utility.
 
 ## Git's built-in [credential cache](https://git-scm.com/docs/git-credential-cache)
 
-**Available on:** _Windows, macOS, Linux_
+**Available on:** _macOS, Linux_
 
 ```shell
 export GCM_CREDENTIAL_STORE=cache

--- a/src/shared/Core/CredentialStore.cs
+++ b/src/shared/Core/CredentialStore.cs
@@ -152,8 +152,11 @@ namespace GitCredentialManager
                     Environment.NewLine, StoreNames.Gpg);
             }
 
-            sb.AppendFormat("  {1,-13} : Git's in-memory credential cache{0}",
-                Environment.NewLine, StoreNames.Cache);
+            if (!PlatformUtils.IsWindows())
+            {
+                sb.AppendFormat("  {1,-13} : Git's in-memory credential cache{0}",
+                    Environment.NewLine, StoreNames.Cache);
+            }
 
             sb.AppendFormat("  {1,-13} : store credentials in plain-text files (UNSECURE){0}",
                 Environment.NewLine, StoreNames.Plaintext);
@@ -286,6 +289,15 @@ namespace GitCredentialManager
 
         private void ValidateCredentialCache(out string options)
         {
+            if (PlatformUtils.IsWindows())
+            {
+                throw new Exception(
+                    $"Can not use the '{StoreNames.Cache}' credential store on Windows due to lack of UNIX socket support in Git for Windows." +
+                    Environment.NewLine +
+                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                );
+            }
+
             // allow for --timeout and other options
             if (!_context.Settings.TryGetSetting(
                 Constants.EnvironmentVariables.GcmCredCacheOptions,


### PR DESCRIPTION
Closes #723

At present, on Windows we cannot use `credential-cache`, so I removed Windows from `credential-cache` in `credstores.md`.
But instead, I added notes based on @dscho 's comments in #723 .