### PR TITLE
Ignore Homebrew Git shim

### DIFF
--- a/src/osx/Installer.Mac/uninstall.sh
+++ b/src/osx/Installer.Mac/uninstall.sh
@@ -12,7 +12,7 @@ fi
 
 # Unconfigure (as the current user)
 echo "Unconfiguring credential helper..."
-sudo -u `/usr/bin/logname` "$GCMBIN" unconfigure
+sudo -u `/usr/bin/logname` -E "$GCMBIN" unconfigure
 
 # Remove symlink
 if [ -L /usr/local/bin/git-credential-manager-core ]

--- a/src/shared/Core/CommandContext.cs
+++ b/src/shared/Core/CommandContext.cs
@@ -107,7 +107,7 @@ namespace GitCredentialManager
                 FileSystem        = new MacOSFileSystem();
                 SessionManager    = new MacOSSessionManager();
                 SystemPrompts     = new MacOSSystemPrompts();
-                Environment       = new PosixEnvironment(FileSystem);
+                Environment       = new MacOSEnvironment(FileSystem);
                 Terminal          = new MacOSTerminal(Trace);
                 string gitPath    = GetGitPath(Environment, FileSystem, Trace);
                 Git               = new GitProcess(

--- a/src/shared/Core/EnvironmentBase.cs
+++ b/src/shared/Core/EnvironmentBase.cs
@@ -104,7 +104,12 @@ namespace GitCredentialManager
             return new Process { StartInfo = psi };
         }
 
-        public bool TryLocateExecutable(string program, out string path)
+        public virtual bool TryLocateExecutable(string program, out string path)
+        {
+            return TryLocateExecutable(program, null, out path);
+        }
+
+        internal virtual bool TryLocateExecutable(string program, ICollection<string> pathsToIgnore, out string path)
         {
             // On UNIX-like systems we would normally use the "which" utility to locate a program,
             // but since distributions don't always place "which" in a consistent location we cannot
@@ -124,7 +129,8 @@ namespace GitCredentialManager
                 foreach (var basePath in paths)
                 {
                     string candidatePath = Path.Combine(basePath, program);
-                    if (FileSystem.FileExists(candidatePath))
+                    if (FileSystem.FileExists(candidatePath) && (pathsToIgnore is null ||
+                        !pathsToIgnore.Contains(candidatePath, StringComparer.OrdinalIgnoreCase)))
                     {
                         path = candidatePath;
                         return true;

--- a/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using GitCredentialManager.Interop.Posix;
+
+namespace GitCredentialManager.Interop.MacOS
+{
+    public class MacOSEnvironment : PosixEnvironment
+    {
+        private ICollection<string> _pathsToIgnore;
+
+        public MacOSEnvironment(IFileSystem fileSystem)
+            : base(fileSystem) { }
+
+        internal MacOSEnvironment(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
+            : base(fileSystem)
+        {
+            EnsureArgument.NotNull(variables, nameof(variables));
+            Variables = variables;
+        }
+
+        public override bool TryLocateExecutable(string program, out string path)
+        {
+            if (_pathsToIgnore is null)
+            {
+                _pathsToIgnore = new List<string>();
+                if (Variables.TryGetValue("HOMEBREW_PREFIX", out string homebrewPrefix))
+                {
+                    string homebrewGit = Path.Combine(homebrewPrefix, "Homebrew/Library/Homebrew/shims/shared/git");
+                    _pathsToIgnore.Add(homebrewGit);
+                }
+            }
+            return TryLocateExecutable(program, _pathsToIgnore, out path);
+        }
+    }
+}


### PR DESCRIPTION
Users running `brew uninstall` or `brew upgrade` currently see the following message (indicating that the operation wasn't fully successful):

```
Unconfiguring component 'Azure Repos provider'...
fatal: Failed to unset Git configuration entry 'credential.https://dev.azure.com.useHttpPath' [1]
git: This shim is internal and must be run via brew.
```

This is because GCM is finding the Homebrew Git shim on the PATH and calling it instead of the user's Git installation. Specifying that we should ignore the Homebrew shim when attempting to locate the Git executable on the PATH resolves the issue.

Fixes #676.