### PR TITLE
Revise and consolidate osx-arm64 commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
   osx-build:
     name: Build macOS
     runs-on: macos-latest
+    strategy:
+      matrix:
+        runtime: [ osx-x64, osx-arm64 ] 
     steps:
     - uses: actions/checkout@v3
       with:
@@ -27,7 +30,9 @@ jobs:
 
     - name: Build
       run: |
-        dotnet build --configuration=MacRelease
+        dotnet build src/osx/Installer.Mac/*.csproj \
+         --configuration=MacRelease --no-self-contained \
+         --runtime=${{ matrix.runtime }}
     
     - name: Run macOS unit tests
       run: |
@@ -35,7 +40,9 @@ jobs:
 
     - name: Lay out payload and symbols
       run: |
-        src/osx/Installer.Mac/layout.sh --configuration=MacRelease --output=payload --symbol-output=symbols
+        src/osx/Installer.Mac/layout.sh \
+         --configuration=MacRelease --output=payload \
+         --symbol-output=symbols --runtime=${{ matrix.runtime }}
 
     - name: Create keychain
       env:
@@ -58,7 +65,7 @@ jobs:
     - name: Upload macOS artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: tmp.osx-build
+        name: tmp.${{ matrix.runtime }}-build
         path: |
           payload
           symbols
@@ -67,6 +74,9 @@ jobs:
     name: Sign macOS payload
     # ESRP service requires signing to run on Windows
     runs-on: windows-latest
+    strategy:
+      matrix:
+        runtime: [ osx-x64, osx-arm64 ]
     needs: osx-build
     steps:
     - name: Check out repository
@@ -75,7 +85,7 @@ jobs:
     - name: Download payload
       uses: actions/download-artifact@v3
       with:
-        name: tmp.osx-build
+        name: tmp.${{ matrix.runtime }}-build
     
     - name: Zip unsigned payload
       shell: pwsh
@@ -109,7 +119,9 @@ jobs:
         APPLE_KEY_CODE: ${{ secrets.APPLE_KEY_CODE }}
         APPLE_SIGNING_OP_CODE: ${{ secrets.APPLE_SIGNING_OPERATION_CODE }}
       run: |
-        python .github\run_esrp_signing.py payload $env:APPLE_KEY_CODE $env:APPLE_SIGNING_OP_CODE --params 'Hardening' '--options=runtime'
+        python .github\run_esrp_signing.py payload `
+         $env:APPLE_KEY_CODE $env:APPLE_SIGNING_OP_CODE `
+         --params 'Hardening' '--options=runtime'
     
     - name: Unzip signed payload
       shell: pwsh
@@ -120,13 +132,16 @@ jobs:
     - name: Upload signed payload
       uses: actions/upload-artifact@v3
       with:
-        name: osx-payload-sign
+        name: ${{ matrix.runtime }}-payload-sign
         path: |
           signed
   
   osx-pack:
     name: Package macOS payload
     runs-on: macos-latest
+    strategy:
+      matrix:
+        runtime: [ osx-x64, osx-arm64 ] 
     needs: osx-payload-sign
     steps:
     - name: Check out repository
@@ -147,20 +162,24 @@ jobs:
     - name: Download signed payload
       uses: actions/download-artifact@v3
       with:
-        name: osx-payload-sign
+        name: ${{ matrix.runtime }}-payload-sign
     
     - name: Create component package
       run: |
-        src/osx/Installer.Mac/pack.sh --payload=payload --version=$GitBuildVersionSimple --output=components/com.microsoft.gitcredentialmanager.component.pkg
+        src/osx/Installer.Mac/pack.sh --payload=payload \
+         --version=$GitBuildVersionSimple \
+         --output=components/com.microsoft.gitcredentialmanager.component.pkg
     
     - name: Create product archive
       run: |
-        src/osx/Installer.Mac/dist.sh --package-path=components --version=$GitBuildVersionSimple --output=pkg/gcm-osx-x64-$GitBuildVersionSimple.pkg || exit 1
+        src/osx/Installer.Mac/dist.sh --package-path=components \
+         --version=$GitBuildVersionSimple --runtime=${{ matrix.runtime }} \
+         --output=pkg/gcm-${{ matrix.runtime }}-$GitBuildVersionSimple.pkg || exit 1
     
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: tmp.osx-pack
+        name: tmp.${{ matrix.runtime }}-pack
         path: |
           pkg
   
@@ -168,6 +187,9 @@ jobs:
     name: Sign and notarize macOS package
     # ESRP service requires signing to run on Windows
     runs-on: windows-latest
+    strategy:
+      matrix:
+        runtime: [ osx-x64, osx-arm64 ] 
     needs: osx-pack
     steps:
     - name: Check out repository
@@ -176,7 +198,7 @@ jobs:
     - name: Download unsigned package
       uses: actions/download-artifact@v3
       with:
-        name: tmp.osx-pack
+        name: tmp.${{ matrix.runtime }}-pack
         path: pkg
     
     - name: Zip unsigned package
@@ -236,7 +258,7 @@ jobs:
     - name: Publish signed package
       uses: actions/upload-artifact@v3
       with:
-        name: osx-sign
+        name: ${{ matrix.runtime }}-sign
         path: signed/*.pkg
 
 # ================================
@@ -468,8 +490,12 @@ jobs:
       - name: Archive macOS payload and symbols
         run: |
           mkdir osx-payload-and-symbols
-          tar -C osx-payload-sign -czf osx-payload-and-symbols/gcm-osx-x64-$GitBuildVersionSimple.tar.gz .
-          tar -C tmp.osx-build/symbols -czf osx-payload-and-symbols/gcm-osx-x64-$GitBuildVersionSimple-symbols.tar.gz .
+
+          tar -C osx-x64-payload-sign -czf osx-payload-and-symbols/gcm-osx-x64-$GitBuildVersionSimple.tar.gz .
+          tar -C tmp.osx-x64-build/symbols -czf osx-payload-and-symbols/gcm-osx-x64-$GitBuildVersionSimple-symbols.tar.gz .
+
+          tar -C osx-arm64-payload-sign -czf osx-payload-and-symbols/gcm-osx-arm64-$GitBuildVersionSimple.tar.gz .
+          tar -C tmp.osx-arm64-build/symbols -czf osx-payload-and-symbols/gcm-osx-arm64-$GitBuildVersionSimple-symbols.tar.gz .
 
       - name: Archive Windows payload and symbols
         shell: pwsh
@@ -527,7 +553,8 @@ jobs:
               uploadDirectoryToRelease('win-x86-payload-and-symbols'),
 
               // Upload macOS artifacts
-              uploadDirectoryToRelease('osx-sign'),
+              uploadDirectoryToRelease('osx-x64-sign'),
+              uploadDirectoryToRelease('osx-arm64-sign'),
               uploadDirectoryToRelease('osx-payload-and-symbols'),
 
               // Upload Linux artifacts

--- a/src/osx/Installer.Mac/Installer.Mac.csproj
+++ b/src/osx/Installer.Mac/Installer.Mac.csproj
@@ -21,8 +21,8 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <Target Name="CoreCompile" DependsOnTargets="GetBuildVersion" Condition="'$(OSPlatform)'=='osx'">
-    <Message Text="$(MSBuildProjectDirectory)\build.sh --configuration='$(Configuration)' --version='$(BuildVersionSimple)'" Importance="High" />
-    <Exec Command="$(MSBuildProjectDirectory)\build.sh --configuration='$(Configuration)' --version='$(BuildVersionSimple)'" />
+    <Message Text="$(MSBuildProjectDirectory)\build.sh --configuration='$(Configuration)' --version='$(BuildVersionSimple)' --runtime='$(RuntimeIdentifier)'" Importance="High" />
+    <Exec Command="$(MSBuildProjectDirectory)\build.sh --configuration='$(Configuration)' --version='$(BuildVersionSimple)' --runtime='$(RuntimeIdentifier)'" />
   </Target>
 
   <Target Name="CoreClean">

--- a/src/osx/Installer.Mac/build.sh
+++ b/src/osx/Installer.Mac/build.sh
@@ -22,6 +22,10 @@ case "$i" in
     CONFIGURATION="${i#*=}"
     shift # past argument=value
     ;;
+    --runtime=*)
+    RUNTIME="${i#*=}"
+    shift
+    ;;
     --version=*)
     VERSION="${i#*=}"
     shift # past argument=value
@@ -38,6 +42,21 @@ if [ -z "$VERSION" ]; then
     die "--version was not set"
 fi
 
+if [ -z "$RUNTIME" ]; then
+    TEST_RUNTIME=`uname -m`
+    case $TEST_RUNTIME in
+        "x86_64")
+            RUNTIME="osx-x64"
+            ;;
+        "arm64")
+            RUNTIME="osx-arm64"
+            ;;
+        *)
+            die "Unknown runtime '$TEST_RUNTIME'"
+            ;;
+    esac
+fi
+
 OUTDIR="$INSTALLER_OUT/pkg/$CONFIGURATION"
 PAYLOAD="$OUTDIR/payload"
 COMPONENTDIR="$OUTDIR/components"
@@ -45,8 +64,8 @@ COMPONENTOUT="$COMPONENTDIR/com.microsoft.gitcredentialmanager.component.pkg"
 DISTOUT="$OUTDIR/gcm-osx-x64-$VERSION.pkg"
 
 # Layout and pack
-"$INSTALLER_SRC/layout.sh" --configuration="$CONFIGURATION" --output="$PAYLOAD" || exit 1
+"$INSTALLER_SRC/layout.sh" --configuration="$CONFIGURATION" --output="$PAYLOAD" --runtime="$RUNTIME" || exit 1
 "$INSTALLER_SRC/pack.sh" --payload="$PAYLOAD" --version="$VERSION" --output="$COMPONENTOUT" || exit 1
-"$INSTALLER_SRC/dist.sh" --package-path="$COMPONENTDIR" --version="$VERSION" --output="$DISTOUT" || exit 1
+"$INSTALLER_SRC/dist.sh" --package-path="$COMPONENTDIR" --version="$VERSION" --output="$DISTOUT" --runtime="$RUNTIME" || exit 1
 
 echo "Build of Installer.Mac complete."

--- a/src/osx/Installer.Mac/dist.sh
+++ b/src/osx/Installer.Mac/dist.sh
@@ -11,7 +11,6 @@ SRC="$ROOT/src"
 OUT="$ROOT/out"
 INSTALLER_SRC="$SRC/osx/Installer.Mac"
 RESXPATH="$INSTALLER_SRC/resources"
-DISTPATH="$INSTALLER_SRC/distribution.xml"
 
 # Product information
 IDENTIFIER="com.microsoft.gitcredentialmanager.dist"
@@ -32,6 +31,10 @@ case "$i" in
     DISTOUT="${i#*=}"
     shift # past argument=value
     ;;
+    --runtime=*)
+    RUNTIME="${i#*=}"
+    shift
+    ;;
     *)
           # unknown option
     ;;
@@ -49,6 +52,28 @@ elif [ ! -d "$PACKAGEPATH" ]; then
 fi
 if [ -z "$DISTOUT" ]; then
     die "--output was not set"
+fi
+if [ -z "$RUNTIME" ]; then
+    TEST_RUNTIME=`uname -m`
+    case $TEST_RUNTIME in
+        "x86_64")
+            RUNTIME="osx-x64"
+            ;;
+        "arm64")
+            RUNTIME="osx-arm64"
+            ;;
+        *)
+            die "Unknown runtime '$TEST_RUNTIME'"
+            ;;
+    esac
+fi
+
+echo "Building for runtime '$RUNTIME'"
+
+if [ "$RUNTIME" == "osx-x64"]; then
+    DISTPATH="$INSTALLER_SRC/distribution.x64.xml"
+else
+    DISTPATH="$INSTALLER_SRC/distribution.arm64.xml"
 fi
 
 # Cleanup any old package

--- a/src/osx/Installer.Mac/distribution.arm64.xml
+++ b/src/osx/Installer.Mac/distribution.arm64.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<installer-gui-script minSpecVersion="1">
+    <title>Git Credential Manager</title>
+    <background file="background.png" mime-type="image/png" alignment="bottomleft" scaling="tofit" />
+    <options customize="never" hostArchitectures="arm64"/>
+    <welcome file="welcome.html" mime-type="text/html" />
+    <conclusion file="conclusion.html" mime-type="text/html" />
+    <license file="LICENSE" />
+    <volume-check>
+        <allowed-os-versions>
+            <os-version min="10.13" />
+        </allowed-os-versions>
+    </volume-check>
+    <pkg-ref id="gcmcore" />
+    <choices-outline>
+        <line choice="default" />
+    </choices-outline>
+    <choice id="default" visible="true" enabled="false" title="Git Credential Manager" description="Git Credential Manager application.">
+        <pkg-ref id="gcmcore">com.microsoft.gitcredentialmanager.component.pkg</pkg-ref>
+    </choice>
+</installer-gui-script>

--- a/src/osx/Installer.Mac/distribution.x64.xml
+++ b/src/osx/Installer.Mac/distribution.x64.xml
@@ -2,7 +2,7 @@
 <installer-gui-script minSpecVersion="1">
     <title>Git Credential Manager</title>
     <background file="background.png" mime-type="image/png" alignment="bottomleft" scaling="tofit" />
-    <options customize="never" />
+    <options customize="never" hostArchitectures="x86_64" />
     <welcome file="welcome.html" mime-type="text/html" />
     <conclusion file="conclusion.html" mime-type="text/html" />
     <license file="LICENSE" />

--- a/src/osx/Installer.Mac/layout.sh
+++ b/src/osx/Installer.Mac/layout.sh
@@ -27,7 +27,6 @@ GITLAB_UI_SRC="$SRC/shared/GitLab.UI.Avalonia"
 
 # Build parameters
 FRAMEWORK=net6.0
-RUNTIME=osx-x64
 
 # Parse script arguments
 for i in "$@"
@@ -41,6 +40,10 @@ case "$i" in
     PAYLOAD="${i#*=}"
     shift # past argument=value
     ;;
+    --runtime=*)
+    RUNTIME="${i#*=}"
+    shift # past argument=value
+    ;;
     --symbol-output=*)
     SYMBOLOUT="${i#*=}"
     ;;
@@ -49,6 +52,24 @@ case "$i" in
     ;;
 esac
 done
+
+# Determine a runtime if one was not provided
+if [ -z "$RUNTIME" ]; then
+    TEST_RUNTIME=`uname -m`
+    case $TEST_RUNTIME in
+        "x86_64")
+            RUNTIME="osx-x64"
+            ;;
+        "arm64")
+            RUNTIME="osx-arm64"
+            ;;
+        *)
+            die "Unknown runtime '$TEST_RUNTIME'"
+            ;;
+    esac
+fi
+
+echo "Building for runtime '$RUNTIME'"
 
 # Perform pre-execution checks
 CONFIGURATION="${CONFIGURATION:=Debug}"

--- a/src/shared/Atlassian.Bitbucket.Tests/Atlassian.Bitbucket.Tests.csproj
+++ b/src/shared/Atlassian.Bitbucket.Tests/Atlassian.Bitbucket.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/shared/Atlassian.Bitbucket.UI.Avalonia/Atlassian.Bitbucket.UI.Avalonia.csproj
+++ b/src/shared/Atlassian.Bitbucket.UI.Avalonia/Atlassian.Bitbucket.UI.Avalonia.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifiers>osx-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>osx-x64;linux-x64;osx-arm64</RuntimeIdentifiers>
     <RootNamespace>Atlassian.Bitbucket.UI</RootNamespace>
     <AssemblyName>Atlassian.Bitbucket.UI</AssemblyName>
   </PropertyGroup>

--- a/src/shared/Core.Tests/Core.Tests.csproj
+++ b/src/shared/Core.Tests/Core.Tests.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/shared/Core.UI.Avalonia/Core.UI.Avalonia.csproj
+++ b/src/shared/Core.UI.Avalonia/Core.UI.Avalonia.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.7" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.7" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.7" />
+    <PackageReference Include="Avalonia" Version="0.10.13" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.13" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net472;net6.0</TargetFrameworks>
-    <RuntimeIdentifiers>win-x86;osx-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;osx-x64;linux-x64;osx-arm64</RuntimeIdentifiers>
     <PlatformTarget Condition="'$(OSPlatform)'=='windows'">x86</PlatformTarget>
     <AssemblyName>git-credential-manager-core</AssemblyName>
     <RootNamespace>GitCredentialManager</RootNamespace>

--- a/src/shared/GitHub.Tests/GitHub.Tests.csproj
+++ b/src/shared/GitHub.Tests/GitHub.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/shared/GitHub.UI.Avalonia/GitHub.UI.Avalonia.csproj
+++ b/src/shared/GitHub.UI.Avalonia/GitHub.UI.Avalonia.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifiers>osx-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>osx-x64;linux-x64;osx-arm64</RuntimeIdentifiers>
     <RootNamespace>GitHub.UI</RootNamespace>
     <AssemblyName>GitHub.UI</AssemblyName>
   </PropertyGroup>

--- a/src/shared/GitLab.Tests/GitLab.Tests.csproj
+++ b/src/shared/GitLab.Tests/GitLab.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/shared/GitLab.UI.Avalonia/GitLab.UI.Avalonia.csproj
+++ b/src/shared/GitLab.UI.Avalonia/GitLab.UI.Avalonia.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifiers>osx-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>osx-x64;linux-x64;osx-arm64</RuntimeIdentifiers>
     <RootNamespace>GitLab.UI</RootNamespace>
     <AssemblyName>GitLab.UI</AssemblyName>
   </PropertyGroup>

--- a/src/shared/Microsoft.AzureRepos.Tests/Microsoft.AzureRepos.Tests.csproj
+++ b/src/shared/Microsoft.AzureRepos.Tests/Microsoft.AzureRepos.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />


### PR DESCRIPTION
This change revises the commits from #636 by:

1. Applying existing fixups.
2. Consolidating the series of commits to add `osx-arm64` support into two commits. The first commit lays the ground work for the changes by updating certain dependencies. The second commit implements `osx-arm64` support.