### PR TITLE
Avoid writing credentials when account & password have not changed

### DIFF
--- a/src/shared/Core/Interop/InteropUtils.cs
+++ b/src/shared/Core/Interop/InteropUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace GitCredentialManager.Interop
@@ -10,6 +11,22 @@ namespace GitCredentialManager.Interop
             var destination = new byte[count];
             Marshal.Copy(ptr, destination, 0, destination.Length);
             return destination;
+        }
+
+        public static bool AreEqual(byte[] bytes, IntPtr ptr, uint length)
+        {
+            if (bytes.Length == 0 && (ptr == IntPtr.Zero || length == 0))
+            {
+                return true;
+            }
+
+            if (bytes.Length != length)
+            {
+                return false;
+            }
+
+            byte[] ptrBytes = ToByteArray(ptr, length);
+            return bytes.SequenceEqual(ptrBytes);
         }
     }
 }

--- a/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
+++ b/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
@@ -114,6 +114,16 @@ namespace GitCredentialManager.Interop.Linux
             SecretValue* secretValue = null;
             GError *error = null;
 
+            // If there is an existing credential that matches the same account and password
+            // then don't bother writing out anything because they're the same!
+            ICredential existingCred = Get(service, account);
+            if (existingCred != null &&
+                StringComparer.Ordinal.Equals(existingCred.Account, account) &&
+                StringComparer.Ordinal.Equals(existingCred.Password, secret))
+            {
+                return;
+            }
+
             try
             {
                 SecretService* secService = GetSecretService();

--- a/src/shared/Core/Interop/MacOS/MacOSKeychain.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSKeychain.cs
@@ -103,7 +103,6 @@ namespace GitCredentialManager.Interop.MacOS
 
             string serviceName = CreateServiceName(service);
 
-
             uint serviceNameLength = (uint) serviceName.Length;
             uint accountLength = (uint) (account?.Length ?? 0);
 
@@ -112,12 +111,12 @@ namespace GitCredentialManager.Interop.MacOS
                 // Check if an entry already exists in the keychain
                 int findResult = SecKeychainFindGenericPassword(
                     IntPtr.Zero, serviceNameLength, serviceName, accountLength, account,
-                    out uint _, out passwordData, out itemRef);
+                    out uint passwordDataLength, out passwordData, out itemRef);
 
                 switch (findResult)
                 {
-                    // Update existing entry
-                    case OK:
+                    // Update existing entry only if the password/secret is different
+                    case OK when !InteropUtils.AreEqual(secretBytes, passwordData, passwordDataLength):
                         ThrowIfError(
                             SecKeychainItemModifyAttributesAndData(itemRef, IntPtr.Zero, (uint) secretBytes.Length, secretBytes),
                             "Could not update existing item"

--- a/src/shared/Core/Interop/Windows/Native/Advapi32.cs
+++ b/src/shared/Core/Interop/Windows/Native/Advapi32.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
 namespace GitCredentialManager.Interop.Windows.Native
@@ -93,5 +94,16 @@ namespace GitCredentialManager.Interop.Windows.Native
         public string TargetAlias;
         [MarshalAs(UnmanagedType.LPWStr)]
         public string UserName;
+
+        public string GetCredentialBlobAsString()
+        {
+            if (CredentialBlobSize != 0 && CredentialBlob != IntPtr.Zero)
+            {
+                byte[] passwordBytes = InteropUtils.ToByteArray(CredentialBlob, CredentialBlobSize);
+                return Encoding.Unicode.GetString(passwordBytes);
+            }
+
+            return null;
+        }
     }
 }

--- a/src/shared/Core/PlaintextCredentialStore.cs
+++ b/src/shared/Core/PlaintextCredentialStore.cs
@@ -33,6 +33,16 @@ namespace GitCredentialManager
             // Ensure the store root exists and permissions are set
             EnsureStoreRoot();
 
+            FileCredential existingCredential = Enumerate(service, account).FirstOrDefault();
+
+            // No need to update existing credential if nothing has changed
+            if (existingCredential != null &&
+                StringComparer.Ordinal.Equals(account, existingCredential.Account) &&
+                StringComparer.Ordinal.Equals(secret, existingCredential.Password))
+            {
+                return;
+            }
+
             string serviceSlug = CreateServiceSlug(service);
             string servicePath = Path.Combine(StoreRoot, serviceSlug);
 


### PR DESCRIPTION
Do not needlessly serialise or otherwise write out the credential again if nothing has changed from an existing stored credential.

This update is applied to all stores except "cache" because values are short lived/not persisted anyway.