### PR TITLE
docs: fix incorrect Ubuntu uninstall command

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ To uninstall:
 
 ```shell
 git-credential-manager-core unconfigure
-sudo dpkg -r gcm
+sudo dpkg -r gcmcore
 ```
 
 #### Other distributions


### PR DESCRIPTION
Fix the Ubuntu uninstall command which used the wrong package name.

Fixes #741 