### PR TITLE
Generate Windows application manifests for all executable projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,12 @@
     <RepoSrcPath>$(RepoPath)src\</RepoSrcPath>
     <RepoOutPath>$(RepoPath)out\</RepoOutPath>
     <RepoAssetsPath>$(RepoPath)assets\</RepoAssetsPath>
+
+    <!-- Identify projects that output an executable binary (not libraries) -->
+    <_IsExeProject Condition="'$(OutputType)' == 'Exe' OR '$(OutputType)' == 'WinExe'">true</_IsExeProject>
+
+    <!-- Automatically generate a Windows app manifest on Windows for exe projects -->
+    <GenerateWindowsAppManifest Condition="'$(GenerateWindowsAppManifest)' == '' AND '$(OSPlatform)' == 'windows' AND '$(_IsExeProject)' == 'true'">true</GenerateWindowsAppManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- This is the root Directory.Build.targets file -->
+
+  <!-- Load custom build tasks -->
+  <Import Project="$(RepoPath)build\GCM.tasks" />
+
+  <!-- Windows application manifest generation -->
+  <PropertyGroup Condition="'$(GenerateWindowsAppManifest)' != 'false'">
+    <ApplicationManifest>$(IntermediateOutputPath)app.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <!-- Generate the manifest file before we set the win32 manifest properties -->
+  <Target Name="GenerateWindowsAppManifest"
+          BeforeTargets="SetWin32ManifestProperties"
+          Condition="'$(GenerateWindowsAppManifest)' != 'false'"
+          Inputs="$(FileVersion);$(AssemblyName)"
+          Outputs="$(IntermediateOutputPath)app.manifest">
+    <GenerateWindowsAppManifest Version="$(FileVersion)"
+                                ApplicationName="$(AssemblyName)"
+                                OutputFile="$(IntermediateOutputPath)app.manifest"/>
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)app.manifest" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/build/GCM.MSBuild.csproj
+++ b/build/GCM.MSBuild.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/build/GCM.tasks
+++ b/build/GCM.tasks
@@ -1,0 +1,16 @@
+<Project>
+    <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Mono'">
+        <_TaskAssembly>$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll</_TaskAssembly>
+        <_TaskFactory>CodeTaskFactory</_TaskFactory>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(MSBuildRuntimeType)' != 'Mono'">
+        <_TaskAssembly>$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll</_TaskAssembly>
+        <_TaskFactory>RoslynCodeTaskFactory</_TaskFactory>
+    </PropertyGroup>
+
+    <UsingTask TaskName="GenerateWindowsAppManifest" TaskFactory="$(_TaskFactory)" AssemblyFile="$(_TaskAssembly)">
+        <Task>
+            <Code Type="Class" Source="$(MSBuildThisFileDirectory)GenerateWindowsAppManifest.cs" />
+        </Task>
+    </UsingTask>
+</Project>

--- a/build/GenerateWindowsAppManifest.cs
+++ b/build/GenerateWindowsAppManifest.cs
@@ -1,0 +1,51 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.IO;
+
+namespace GitCredentialManager.MSBuild
+{
+    public class GenerateWindowsAppManifest : Task
+    {
+        [Required]
+        public string Version { get; set; }
+
+        [Required]
+        public string ApplicationName { get; set; }
+
+        [Required]
+        public string OutputFile { get; set; }
+
+        public override bool Execute()
+        {
+            Log.LogMessage(MessageImportance.Normal, "Creating application manifest file for '{0}'...", ApplicationName);
+
+            string manifestDirectory = Path.GetDirectoryName(OutputFile);
+            if (!Directory.Exists(manifestDirectory))
+            {
+                Directory.CreateDirectory(manifestDirectory);
+            }
+
+            File.WriteAllText(
+                OutputFile,
+                $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<assembly manifestVersion=""1.0"" xmlns=""urn:schemas-microsoft-com:asm.v1"">
+  <assemblyIdentity version=""{Version}"" name=""{ApplicationName}""/>
+  <compatibility xmlns=""urn:schemas-microsoft-com:compatibility.v1"">
+    <application>
+      <!-- Windows 10 and Windows 11 -->
+      <supportedOS Id=""{{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}}""/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id=""{{1f676c76-80e1-4239-95bb-83d0f6d0da78}}""/>
+      <!-- Windows 8 -->
+      <supportedOS Id=""{{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}}""/>
+      <!-- Windows 7 -->
+      <supportedOS Id=""{{35138b9a-5d96-4fbd-8e2d-a2440225f93a}}""/>
+    </application>
+  </compatibility>
+</assembly>
+");
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Automatically generate the correct application manifest for Windows executable projects that we produce. The manifests are required on Windows systems newer then Windows 8 to correctly access versioning APIs that will otherwise always report "Windows 8", even on later versions.

The manifest we generate states we are compatible with all versions of Windows from 7 to 11 (inclusive).

**Example manifest:**

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
  <assemblyIdentity version="2.0.770.50703" name="git-credential-manager-core"></assemblyIdentity>
  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
    <application>
      <!-- Windows 10 and Windows 11 -->
      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"></supportedOS>
      <!-- Windows 8.1 -->
      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"></supportedOS>
      <!-- Windows 8 -->
      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"></supportedOS>
      <!-- Windows 7 -->
      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"></supportedOS>
    </application>
  </compatibility>
</assembly>
```

Fixes #749 