### PR TITLE
Use /usr/bin/env which instead of /usr/bin/which

### DIFF
--- a/src/shared/TestInfrastructure/GitTestUtilities.cs
+++ b/src/shared/TestInfrastructure/GitTestUtilities.cs
@@ -21,7 +21,7 @@ namespace GitCredentialManager.Tests
             }
             else
             {
-                psi = new ProcessStartInfo("/usr/bin/which", "git");
+                psi = new ProcessStartInfo("/usr/bin/env", "which git");
             }
 
             psi.RedirectStandardOutput = true;


### PR DESCRIPTION
It may cause trouble to hard-code `/usr/bin/which` anywhere, so for now, why not use `/usr/bin/env` to resolve which? See https://github.com/GitCredentialManager/git-credential-manager/pull/717 for example.

(In the long run it may cause trouble to use `which` at all since it's not POSIX standard and Debian is thinking of removing it. But then you could probably just ensure another package is installed first.)