### PR TITLE
Fix Mac x64 pkg

### DIFF
--- a/src/osx/Installer.Mac/dist.sh
+++ b/src/osx/Installer.Mac/dist.sh
@@ -70,7 +70,7 @@ fi
 
 echo "Building for runtime '$RUNTIME'"
 
-if [ "$RUNTIME" == "osx-x64"]; then
+if [ "$RUNTIME" == "osx-x64" ]; then
     DISTPATH="$INSTALLER_SRC/distribution.x64.xml"
 else
     DISTPATH="$INSTALLER_SRC/distribution.arm64.xml"


### PR DESCRIPTION
The dist.sh script has a typo in it, causing x64 pkgs to include the arm64.xml file instead.

This change fixes the typo, causing the script to produce a validate pkg again for x64 archs on Mac.

Should fix #771 