### PR TITLE
release: consume auto-rotated SSL certificate

### DIFF
--- a/.github/run_esrp_signing.py
+++ b/.github/run_esrp_signing.py
@@ -18,10 +18,6 @@ args = parser.parse_args()
 esrp_tool = os.path.join("esrp", "tools", "EsrpClient.exe")
 
 aad_id = os.environ['AZURE_AAD_ID'].strip()
-# We temporarily need two AAD IDs, as we're using an SSL certificate associated
-# with an older App Registration until we have the required hardware to approve
-# the new certificate in SSL Admin.
-aad_id_ssl = os.environ['AZURE_AAD_ID_SSL'].strip()
 workspace = os.environ['GITHUB_WORKSPACE'].strip()
 
 source_location = args.path
@@ -36,9 +32,10 @@ auth_json = {
     "TenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
     "ClientId": f"{aad_id}",
     "AuthCert": {
-            "SubjectName": f"CN={aad_id_ssl}.microsoft.com",
+            "SubjectName": f"CN={aad_id}.microsoft.com",
             "StoreLocation": "LocalMachine",
-            "StoreName": "My"
+            "StoreName": "My",
+            "SendX5c" : "true"
     },
     "RequestSigningCert": {
             "SubjectName": f"CN={aad_id}",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,6 @@ jobs:
       shell: pwsh
       env:
         AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
-        # We temporarily need two AAD IDs, as we're using an SSL certificate associated
-        # with an older App Registration until we have the required hardware to approve
-        # the new certificate in SSL Admin.
-        AZURE_AAD_ID_SSL: ${{ secrets.AZURE_AAD_ID_SSL }}
         APPLE_KEY_CODE: ${{ secrets.APPLE_KEY_CODE }}
         APPLE_SIGNING_OP_CODE: ${{ secrets.APPLE_SIGNING_OPERATION_CODE }}
       run: |
@@ -226,10 +222,6 @@ jobs:
       shell: pwsh
       env:
         AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
-        # We temporarily need two AAD IDs, as we're using an SSL certificate associated
-        # with an older App Registration until we have the required hardware to approve
-        # the new certificate in SSL Admin.
-        AZURE_AAD_ID_SSL: ${{ secrets.AZURE_AAD_ID_SSL }}
         APPLE_KEY_CODE: ${{ secrets.APPLE_KEY_CODE }}
         APPLE_SIGNING_OP_CODE: ${{ secrets.APPLE_SIGNING_OPERATION_CODE }}
       run: |
@@ -246,10 +238,6 @@ jobs:
       shell: pwsh
       env:
         AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
-        # We temporarily need two AAD IDs, as we're using an SSL certificate associated
-        # with an older App Registration until we have the required hardware to approve
-        # the new certificate in SSL Admin.
-        AZURE_AAD_ID_SSL: ${{ secrets.AZURE_AAD_ID_SSL }}
         APPLE_KEY_CODE: ${{ secrets.APPLE_KEY_CODE }}
         APPLE_NOTARIZATION_OP_CODE: ${{ secrets.APPLE_NOTARIZATION_OPERATION_CODE }}
       run: |
@@ -319,10 +307,6 @@ jobs:
       shell: pwsh
       env:
         AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
-        # We temporarily need two AAD IDs, as we're using an SSL certificate associated
-        # with an older App Registration until we have the required hardware to approve
-        # the new certificate in SSL Admin.
-        AZURE_AAD_ID_SSL: ${{ secrets.AZURE_AAD_ID_SSL }}
         WINDOWS_KEY_CODE: ${{ secrets.WINDOWS_KEY_CODE }}
         WINDOWS_OP_CODE: ${{ secrets.WINDOWS_OPERATION_CODE }}
       run: |
@@ -353,10 +337,6 @@ jobs:
       shell: pwsh
       env:
         AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
-        # We temporarily need two AAD IDs, as we're using an SSL certificate associated
-        # with an older App Registration until we have the required hardware to approve
-        # the new certificate in SSL Admin.
-        AZURE_AAD_ID_SSL: ${{ secrets.AZURE_AAD_ID_SSL }}
         WINDOWS_KEY_CODE: ${{ secrets.WINDOWS_KEY_CODE }}
         WINDOWS_OP_CODE: ${{ secrets.WINDOWS_OPERATION_CODE }}
       run: |
@@ -445,10 +425,6 @@ jobs:
       shell: pwsh
       env:
         AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
-        # We temporarily need two AAD IDs, as we're using an SSL certificate associated
-        # with an older App Registration until we have the required hardware to approve
-        # the new certificate in SSL Admin.
-        AZURE_AAD_ID_SSL: ${{ secrets.AZURE_AAD_ID_SSL }}
         LINUX_KEY_CODE: ${{ secrets.LINUX_KEY_CODE }}
         LINUX_OP_CODE: ${{ secrets.LINUX_OPERATION_CODE }}
       run: |


### PR DESCRIPTION
Update release workflows to consume new autorotated SSL certificate. There
are two main parts:

1. Add the "SendX5c" : "true" key value pair to the contents of our ESRP
Auth Json file. This allows us to use the new auto-rotating certificate
without having to upload/manage it from our App Registration.i

2. Remove the AZURE_AAD_ID_SSL secret/environment variable. The new
certificate was generated with our main AZURE_AAD_ID app registration, so
this extra ID is no longer needed.

You can find my successful test run with these changes [here](https://github.com/ldennington/git-credential-manager/actions/runs/2707333019).