### PR TITLE
macos arm64: Homebrew updates

### DIFF
--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -8,11 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Update Homebrew tap
-      uses: mjcheetham/update-homebrew@v1.1
+      uses: mjcheetham/update-homebrew@v1.2
       with:
         token: ${{ secrets.HOMEBREW_TOKEN }}
         tap: microsoft/git
         name: git-credential-manager-core
         type: cask
-        releaseAsset: gcm-osx-x64-(.*)\.pkg
-        alwaysUsePullRequest: true
+        releaseAsset: |
+          gcm-osx-x64-(.*)\.pkg
+          gcm-osx-arm64-(.*)\.pkg


### PR DESCRIPTION
Allow users to install/uninstall the new `arm64` package via Homebrew by updating the Homebrew release asset regex to separate runtime and version and to remove the PR requirement (which was tested with [these changes](https://github.com/mjcheetham/update-homebrew/pull/10) to the `update-homebrew` task).

Fixes #772