### PR TITLE
Use macos-latest image for CI builds

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-18.04, ubuntu-20.04, windows-2019, macos-latest]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The macos-10.15 image for CI builds is deprecated on GitHub Actions. We
should update this to a supported image.

Given we are actually running our release builds on macos-latest, we
should probably be running CI on the same image too!

Fixes #802