### PR TITLE
release: add installer validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,12 +438,80 @@ jobs:
           signed
 
 # ================================
+#           Validate
+# ================================
+  validate:
+    name: Validate installers
+    strategy:
+      matrix:
+        component:
+          - os: ubuntu-latest
+            artifact: linux-sign
+            command: git-credential-manager-core
+          - os: macos-latest
+            artifact: osx-x64-sign
+            command: git-credential-manager-core
+          - os: windows-latest
+            artifact: win-sign
+            # Even when a standalone GCM version is installed, GitHub actions
+            # runners still only recognize the version bundled with Git for
+            # Windows due to its placement on the PATH. For this reason, we use
+            # the full path to our installation to validate the Windows version.
+            command: "$PROGRAMFILES (x86)/Git Credential Manager/git-credential-manager-core.exe"
+    runs-on: ${{ matrix.component.os }}
+    needs: [ osx-sign, win-sign, linux-sign ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Indicate full history so Nerdbank.GitVersioning works.
+
+      - uses: dotnet/nbgv@master
+        with:
+          setCommonVars: true
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.component.artifact }}
+
+      - name: Install Windows
+        if: contains(matrix.component.os, 'windows')
+        shell: pwsh
+        run: |
+          $exePaths = Get-ChildItem -Path ./signed/*.exe | %{$_.FullName}
+          foreach ($exePath in $exePaths)
+          {
+            Start-Process -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART"
+          }
+
+      - name: Install Linux
+        if: contains(matrix.component.os, 'ubuntu')
+        run: |
+          debpath=$(find ./*.deb)
+          sudo apt install $debpath
+          "${{ matrix.component.command }}" configure
+
+      - name: Install macOS
+        if: contains(matrix.component.os, 'macos')
+        run: |
+          # Only validate x64, given arm64 agents are not available
+          pkgpath=$(find ./*.pkg)
+          sudo installer -pkg $pkgpath -target /
+
+      - name: Validate
+        shell: bash
+        run: |
+          "${{ matrix.component.command }}" --version | sed 's/+.*//' >actual
+          echo $GitBuildVersionSimple >expect
+          cmp expect actual || exit 1
+
+# ================================
 #             Publish
 # ================================
   create-github-release:
     name: Publish GitHub draft release
     runs-on: ubuntu-latest
-    needs: [ osx-sign, win-sign, linux-sign ]
+    needs: [ validate ]
     steps:      
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Add basic installer validation to release pipeline for Windows,
macOS (x64 only), and Linux (Debian package only). Validation runs the
installers/any necessary setup and `git-credential-manager-core
--version`.

Test run validating these changes can be found [here](https://github.com/ldennington/git-credential-manager/actions/runs/2757819748).