### PR TITLE
release: update Azure storage resource names

### DIFF
--- a/.github/set_up_esrp.ps1
+++ b/.github/set_up_esrp.ps1
@@ -1,5 +1,5 @@
 # Install ESRP client
-az storage blob download --file esrp.zip --account-key "$env:AZURE_STORAGE_KEY" --account-name gcmesrp --container microsoft-esrp-client --name microsoft.esrpclient.1.2.76.nupkg
+az storage blob download --file esrp.zip --account-key "$env:AZURE_STORAGE_KEY" --account-name esrpsigningstorage --container signing-resources --name microsoft.esrpclient.1.2.76.nupkg
 Expand-Archive -Path esrp.zip -DestinationPath .\esrp
 
 # Install certificates


### PR DESCRIPTION
The previous Azure resource architecture separated GCM and Microsoft Git
resources into different Resource Groups. This led to redundancy - we were
storing all our secrets, certificates, etc. in two places. These updates
reflect the consolidation of these resources into a new [esrp Resource
Group](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/ac604cc8-0d98-4033-8766-b4a1407dfe2f/resourceGroups/esrp/overview).

This change was validated with [this successful workflow](https://github.com/GitCredentialManager/git-credential-manager/actions/runs/2805824189).