### PR TITLE
uri: support ports and split queries/fragments from path

### DIFF
--- a/src/shared/Core.Tests/InputArgumentsTests.cs
+++ b/src/shared/Core.Tests/InputArgumentsTests.cs
@@ -220,6 +220,29 @@ namespace GitCredentialManager.Tests
             Assert.Equal(expectedUri, actualUri);
         }
 
+        [Theory]
+        [InlineData("foo?query=true")]
+        [InlineData("foo#fragment")]
+        [InlineData("foo?query=true#fragment")]
+        public void InputArguments_GetRemoteUri_PathQueryFragment_ReturnsCorrectUri(string path)
+        {
+            var expectedUri = new Uri($"https://example.com/{path}");
+
+            var dict = new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "example.com",
+                ["path"]     = path
+            };
+
+            var inputArgs = new InputArguments(dict);
+
+            Uri actualUri = inputArgs.GetRemoteUri();
+
+            Assert.NotNull(actualUri);
+            Assert.Equal(expectedUri, actualUri);
+        }
+
         [Fact]
         public void InputArguments_GetRemoteUri_IncludeUser_AuthorityPathUserInfo_ReturnsUriWithAll()
         {

--- a/src/shared/Core.Tests/UriExtensionsTests.cs
+++ b/src/shared/Core.Tests/UriExtensionsTests.cs
@@ -30,11 +30,10 @@ namespace GitCredentialManager.Tests
         [InlineData("http://hostname", "http://hostname")]
         [InlineData("http://example.com",
             "http://example.com")]
+        [InlineData("http://hostname:7990", "http://hostname:7990")]
         [InlineData("http://foo.example.com",
             "http://foo.example.com", "http://example.com")]
         [InlineData("http://example.com/foo",
-            "http://example.com/foo", "http://example.com")]
-        [InlineData("http://example.com/foo/",
             "http://example.com/foo", "http://example.com")]
         [InlineData("http://example.com/foo?query=true#fragment",
             "http://example.com/foo", "http://example.com")]

--- a/src/shared/Core/UriExtensions.cs
+++ b/src/shared/Core/UriExtensions.cs
@@ -88,12 +88,14 @@ namespace GitCredentialManager
 
             string schemeAndDelim = $"{uri.Scheme}{Uri.SchemeDelimiter}";
             string host = uri.Host.TrimEnd('/');
+            // If port is default, don't append
+            string port = uri.IsDefaultPort ? "" : $":{uri.Port}";
             string path = uri.AbsolutePath.Trim('/');
 
             // Unfold the path by component, right-to-left
             while (!string.IsNullOrWhiteSpace(path))
             {
-                yield return $"{schemeAndDelim}{host}/{path}";
+                yield return $"{schemeAndDelim}{host}{port}/{path}";
 
                 // Trim off the last path component
                 if (!TryTrimString(path, StringExtensions.TruncateFromLastIndexOf, '/', out path))
@@ -107,7 +109,7 @@ namespace GitCredentialManager
             if (!string.IsNullOrWhiteSpace(host) &&
                 !host.Contains("."))
             {
-                yield return $"{schemeAndDelim}{host}";
+                yield return $"{schemeAndDelim}{host}{port}";
                 // If we have reached this point, there are no more subdomains to unfold, so exit early.
                 yield break;
             }
@@ -117,7 +119,7 @@ namespace GitCredentialManager
             {
                 if (host.Contains(".")) // Do not emit just the TLD
                 {
-                    yield return $"{schemeAndDelim}{host}";
+                    yield return $"{schemeAndDelim}{host}{port}";
                 }
 
                 // Trim off the left-most sub-domain


### PR DESCRIPTION
GCM currently ignores ports in URIs. This means attempting to authenticate
to a URI with a port can lead to some unexpected behavior (e.g.
shortcutting the provider auto-detect process won't work, even if the
provider is set in config). This change adds support for ports by updating
GetGitConfigurationScopes() to recognize them.

This change also updates GetRemoteUri() to recognize paths with queries
and fragments, as that issue was uncovered during the implementation of
the GetGitConfigurationScopes() fix. Without it, input paths containing
queries and/or fragments get saved as part of Uri.Path, which converts the
query '?' and the fragment '#' to url encoding.

I validated these changes with unit tests for applicable scenarios and by
running a locally-compiled version of GCM with tracing enabled and the 
following config set:

`credential.http://localhost:7990/bitbucket.provider bitbucket`

Trace logs showed that the override was recognized and auto-detection
was skipped.

Fixes #608 
