### PR TITLE
install from source: use native feeds for Ubuntu 22.04

### DIFF
--- a/src/linux/Packaging.Linux/install-from-source.sh
+++ b/src/linux/Packaging.Linux/install-from-source.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-# halt execution immediately on failure
-# note there are some scenarios in which this will not exit;
-# see https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
-# for additional details
+# Halt execution immediately on failure.
+# Note there are some scenarios in which this will not exit; see
+# https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
+# for additional details.
 set -e
 
 is_ci=
@@ -11,13 +11,13 @@ for i in "$@"; do
     case "$i" in
         -y)
         is_ci=true
-        shift # past argument=value
+        shift # Past argument=value
         ;;
     esac
 done
 
-# in non-ci scenarios, advertise what we will be doing and
-# give user the option to exit
+# In non-ci scenarios, advertise what we will be doing and
+# give user the option to exit.
 if [ -z $is_ci ]; then
     echo "This script will download, compile, and install Git Credential Manager to:
 
@@ -47,7 +47,7 @@ install_shared_packages() {
 
     local shared_packages="git curl"
     for package in $shared_packages; do
-        # ensure we don't stomp on existing installations
+        # Ensure we don't stomp on existing installations.
         if [ ! -z $(which $package) ]; then
             continue
         fi
@@ -66,8 +66,8 @@ ensure_dotnet_installed() {
         chmod +x ./dotnet-install.sh
         bash -c "./dotnet-install.sh"
 
-        # since we have to run the dotnet install script with bash, dotnet isn't added
-        # to the process PATH, so we manually add it here
+        # Since we have to run the dotnet install script with bash, dotnet isn't
+        # added to the process PATH, so we manually add it here.
         cd ~
         export DOTNET_ROOT=$(pwd)/.dotnet
         add_to_PATH $DOTNET_ROOT
@@ -75,10 +75,10 @@ ensure_dotnet_installed() {
 }
 
 verify_existing_dotnet_installation() {
-    # get initial pieces of installed sdk version(s)
+    # Get initial pieces of installed sdk version(s).
     sdks=$(dotnet --list-sdks | cut -c 1-3)
 
-    # if we have a supported version installed, return
+    # If we have a supported version installed, return.
     supported_dotnet_versions="6.0"
     for v in $supported_dotnet_versions; do
         if [ $(echo $sdks | grep "$v") ]; then
@@ -90,7 +90,7 @@ verify_existing_dotnet_installation() {
 add_to_PATH () {
   for directory; do
     if [ ! -d "$directory" ]; then
-        continue; # skip nonexistent directory
+        continue; # Skip nonexistent directory.
     fi
     case ":$PATH:" in
         *":$directory:"*)
@@ -112,8 +112,8 @@ apt_install() {
 
 sudo_cmd=
 
-# if the user isn't root, we need to use `sudo` for certain commands
-# (e.g. installing packages)
+# If the user isn't root, we need to use `sudo` for certain commands
+# (e.g. installing packages).
 if [ -z "$sudo_cmd" ]; then
     if [ `id -u` != 0 ]; then
         sudo_cmd=sudo
@@ -127,7 +127,7 @@ case "$distribution" in
         $sudo_cmd apt update
         install_shared_packages apt install
 
-        # install dotnet packages and dependencies if needed
+        # Install dotnet packages and dependencies if needed.
         if [ -z "$(verify_existing_dotnet_installation)" ]; then
             # First try to use native feeds (Ubuntu 22.04 and later).
             if ! apt_install dotnet6; then
@@ -154,7 +154,7 @@ case "$distribution" in
         $sudo_cmd apt update
         install_shared_packages apt install
 
-        # install dotnet packages and dependencies
+        # Install dotnet packages and dependencies.
         $sudo_cmd apt install libc6 libgcc1 libgssapi-krb5-2 libssl1.1 libstdc++6 zlib1g libicu66 -y
         ensure_dotnet_installed
     ;;
@@ -162,7 +162,7 @@ case "$distribution" in
         $sudo_cmd dnf update -y
         install_shared_packages dnf install
 
-        # install dotnet/gcm dependencies
+        # Install dotnet/GCM dependencies.
         $sudo_cmd dnf install krb5-libs libicu openssl-libs zlib findutils which bash -y
 
         ensure_dotnet_installed
@@ -171,7 +171,7 @@ case "$distribution" in
         $sudo_cmd apk update
         install_shared_packages apk add
 
-        # install dotnet/gcm dependencies
+        # Install dotnet/GCM dependencies.
         $sudo_cmd apk add icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib which bash coreutils gcompat
 
         ensure_dotnet_installed
@@ -182,7 +182,7 @@ case "$distribution" in
     ;;
 esac
 
-# detect if the script is part of a full source checkout or standalone instead
+# Detect if the script is part of a full source checkout or standalone instead.
 script_path="$(cd "$(dirname "$0")" && pwd)"
 toplevel_path="${script_path%/src/linux/Packaging.Linux}"
 if [ "z$script_path" = "z$toplevel_path" ] || [ ! -f "$toplevel_path/Git-Credential-Manager.sln" ]; then


### PR DESCRIPTION
The dotnet team recently added support for installing natively from Jammy feeds on
Ubuntu:

https://github.com/dotnet/core/issues/7699

This caused our current installation to fail, as it caused conflicts with
the packages.microsoft.com feed we use in the install from source script
for Debian/Ubuntu.

This change modifies the Debian/Ubuntu dotnet install process to install from
Jammy feeds for users on Ubuntu 22.04 and greater while continuing to use
the packages.microsoft.com feed for Debian and older Ubuntu versions.

Here is a successful run of the validation workflow with these changes: https://github.com/ldennington/git-credential-manager/actions/runs/2884331734

Fixes #841