### PR TITLE
Package GitHub.UI as .NET tool

### DIFF
--- a/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
+++ b/src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj
@@ -12,6 +12,13 @@
     <IsTestProject>false</IsTestProject>
     <LangVersion>latest</LangVersion>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+    <PackAsTool>true</PackAsTool>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <ProjectUrl>https://github.com/GitCredentialManager/git-credential-manager</ProjectUrl>
+    <Title>Git Credential Manager</Title>
+    <RepositoryUrl>https://github.com/GitCredentialManager/git-credential-manager.git</RepositoryUrl>
+    <Description>Git Credential Manager is a secure Git credential helper providing multi-factor authentication support for Azure DevOps, Azure DevOps Server, GitHub, Bitbucket, and GitLab.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,6 +31,7 @@
 
   <ItemGroup>
     <Content Include="NOTICE" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../../README.md" Pack="true" PackagePath="/"/>
   </ItemGroup>
 
 </Project>

--- a/src/shared/GitHub.UI.Avalonia/GitHub.UI.Avalonia.csproj
+++ b/src/shared/GitHub.UI.Avalonia/GitHub.UI.Avalonia.csproj
@@ -6,6 +6,8 @@
     <RuntimeIdentifiers>osx-x64;linux-x64;osx-arm64</RuntimeIdentifiers>
     <RootNamespace>GitHub.UI</RootNamespace>
     <AssemblyName>GitHub.UI</AssemblyName>
+    <PackAsTool>true</PackAsTool>
+    <PackageId>git-credential-manager-github-ui</PackageId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Similar to #821

I was also able to package, install and use GitHub.UI making a similar change, although I had to set config variable `githubHelper` to help git-credential-manager-core find it, because of an assembly location complication -- both are installed to `$HOME/.dotnet/tools` but these are shims pointing to  a larger binary in a package-specific location, eg. `$HOME/.dotnet.tools/.store/git-credential-manager-core/2.0.798-g57a5791f02/git-credential-manager-core` , so the two binaries can't find each other.


```
dotnet pack --output out/nupkg src/shared/GitHub.UI.Avalonia/
dotnet tool install --global --add-source ./out/nupkg git-credential-manager-github-ui --prerelease
```

```
> which GitHub.UI
/home/matthickford/.dotnet/tools/GitHub.UI
> GitHub.UI --version
2.0.798+57a5791f02
```

The installed GitHub.UI package is also surprisingly big compared to the other package

```
172M    ./.store/github.ui
4.7M    ./.store/git-credential-manager-core
```

On investigation the install contains binary dependencies for other platforms, which seems unnecessary.

```
896K    ./github.ui/2.0.798-g57a5791f02/tools/net6.0/any/runtimes/win-x64/native/libHarfBuzzSharp.dll
8.5M    ./github.ui/2.0.798-g57a5791f02/tools/net6.0/any/runtimes/win-x64/native/libSkiaSharp.dll
9.4M    ./github.ui/2.0.798-g57a5791f02/tools/net6.0/any/runtimes/win-x64/native
9.4M    ./github.ui/2.0.798-g57a5791f02/tools/net6.0/any/runtimes/win-x64
788K    ./github.ui/2.0.798-g57a5791f02/tools/net6.0/any/runtimes/win-x86/native/libHarfBuzzSharp.dll
7.1M    ./github.ui/2.0.798-g57a5791f02/tools/net6.0/any/runtimes/win-x86/native/libSkiaSharp.dll
```