### PR TITLE
release: access Azure Storage Account with login credentials 

### DIFF
--- a/.github/set_up_esrp.ps1
+++ b/.github/set_up_esrp.ps1
@@ -1,5 +1,5 @@
 # Install ESRP client
-az storage blob download --file esrp.zip --account-key "$env:AZURE_STORAGE_KEY" --account-name esrpsigningstorage --container signing-resources --name microsoft.esrpclient.1.2.76.nupkg
+az storage blob download --file esrp.zip --auth-mode login --account-name esrpsigningstorage --container signing-resources --name microsoft.esrpclient.1.2.76.nupkg
 Expand-Archive -Path esrp.zip -DestinationPath .\esrp
 
 # Install certificates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,6 @@ jobs:
     - name: Set up ESRP client
       shell: pwsh
       env:
-        AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         AZURE_VAULT: ${{ secrets.AZURE_VAULT }}
         AUTH_CERT: ${{ secrets.AZURE_VAULT_AUTH_CERT_NAME }}
         REQUEST_SIGNING_CERT: ${{ secrets.AZURE_VAULT_REQUEST_SIGNING_CERT_NAME }}
@@ -211,7 +210,6 @@ jobs:
     - name: Set up ESRP client
       shell: pwsh
       env:
-        AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         AZURE_VAULT: ${{ secrets.AZURE_VAULT }}
         AUTH_CERT: ${{ secrets.AZURE_VAULT_AUTH_CERT_NAME }}
         REQUEST_SIGNING_CERT: ${{ secrets.AZURE_VAULT_REQUEST_SIGNING_CERT_NAME }}
@@ -296,7 +294,6 @@ jobs:
     - name: Set up ESRP client
       shell: pwsh
       env:
-        AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         AZURE_VAULT: ${{ secrets.AZURE_VAULT }}
         AUTH_CERT: ${{ secrets.AZURE_VAULT_AUTH_CERT_NAME }}
         REQUEST_SIGNING_CERT: ${{ secrets.AZURE_VAULT_REQUEST_SIGNING_CERT_NAME }}
@@ -414,7 +411,6 @@ jobs:
     - name: Set up ESRP client
       shell: pwsh
       env:
-        AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         AZURE_VAULT: ${{ secrets.AZURE_VAULT }}
         AUTH_CERT: ${{ secrets.AZURE_VAULT_AUTH_CERT_NAME }}
         REQUEST_SIGNING_CERT: ${{ secrets.AZURE_VAULT_REQUEST_SIGNING_CERT_NAME }}


### PR DESCRIPTION
Use `--auth-mode login` command to access ESRP Azure Storage Account instead of AZURE_STORAGE_KEY. This allows us to reuse the git-fundamentals-esrp service principal login credentials we're already using for other resources and is a more secure mode of access than using the storage key.

This update was tested with [this abbreviated release workflow](https://github.com/ldennington/git-credential-manager/runs/8045792801?check_suite_focus=true).