### PR TITLE
Added check mark for x86 support on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Windows Integrated Authentication (NTLM/Kerberos) support|&#10003;|_N/A_|_N/A_
 Basic HTTP authentication support|&#10003;|&#10003;|&#10003;
 Proxy support|&#10003;|&#10003;|&#10003;
 `amd64` support|&#10003;|&#10003;|&#10003;
-`x86` support|&#10003;|_N/A_|&#10007;
+`x86` support|&#10003;|&#10003;|&#10007;
 `arm64` support|best effort|&#10003;|best effort, no packages
 `armhf` support|_N/A_|_N/A_|best effort, no packages
 


### PR DESCRIPTION
There are gcm-osx-x64-2.0.785.* assets in https://github.com/GitCredentialManager/git-credential-manager/releases/tag/v2.0.785 and the gcm-osx-x64-2.0.785.pkg installed fine and worked for me on my Intel MacBook Pro (`uname -m` shows `x86_64`).