### PR TITLE
release: package gcm as dotnet tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -600,3 +600,29 @@ jobs:
               uploadDirectoryToRelease('linux-sign'),
               uploadDirectoryToRelease('linux-build/tar')
             ]);
+
+  create-dotnet-tool:
+    name: Publish dotnet tool
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # Indicate full history so Nerdbank.GitVersioning works.
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.201
+
+    - uses: dotnet/nbgv@master
+      with:
+        setCommonVars: true
+
+    - name: Package tool
+      run: |
+        src/shared/DotnetTool/pack-tool.sh
+
+    - name: Publish tool
+      run: |
+        dotnet nuget push ./out/nupkg/*.nupkg \
+          --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/src/shared/Atlassian.Bitbucket.Tests/BitbucketAuthenticationTest.cs
+++ b/src/shared/Atlassian.Bitbucket.Tests/BitbucketAuthenticationTest.cs
@@ -113,7 +113,8 @@ namespace Atlassian.Bitbucket.Tests
         {
             var targetUri = new Uri("https://bitbucket.org");
 
-            var helperPath = "/usr/bin/test-helper";
+            var command = "/usr/bin/test-helper";
+            var args = "";
             var expectedUserName = "jsquire";
             var expectedPassword = "password";
             var resultDict = new Dictionary<string, string>
@@ -128,7 +129,7 @@ namespace Atlassian.Bitbucket.Tests
             context.SessionManager.IsDesktopSession = true; // Enable OAuth and UI helper selection
 
             var authMock = new Mock<BitbucketAuthentication>(context) { CallBase = true };
-            authMock.Setup(x => x.TryFindHelperExecutablePath(out helperPath))
+            authMock.Setup(x => x.TryFindHelperCommand(out command, out args))
                 .Returns(true);
             authMock.Setup(x => x.InvokeHelperAsync(It.IsAny<string>(), It.IsAny<string>(), null, CancellationToken.None))
                 .ReturnsAsync(resultDict);
@@ -140,7 +141,7 @@ namespace Atlassian.Bitbucket.Tests
             Assert.Equal(result.Credential.Account, expectedUserName);
             Assert.Equal(result.Credential.Password, expectedPassword);
 
-            authMock.Verify(x => x.InvokeHelperAsync(helperPath, expectedArgs, null, CancellationToken.None),
+            authMock.Verify(x => x.InvokeHelperAsync(command, expectedArgs, null, CancellationToken.None),
                 Times.Once);
         }
 
@@ -149,7 +150,8 @@ namespace Atlassian.Bitbucket.Tests
         {
             var targetUri = new Uri("https://bitbucket.org");
 
-            var helperPath = "/usr/bin/test-helper";
+            var command = "/usr/bin/test-helper";
+            var args = "";
             var expectedUserName = "jsquire";
             var expectedPassword = "password";
             var resultDict = new Dictionary<string, string>
@@ -164,7 +166,7 @@ namespace Atlassian.Bitbucket.Tests
             context.SessionManager.IsDesktopSession = true; // Enable UI helper selection
 
             var authMock = new Mock<BitbucketAuthentication>(context) { CallBase = true };
-            authMock.Setup(x => x.TryFindHelperExecutablePath(out helperPath))
+            authMock.Setup(x => x.TryFindHelperCommand(out command, out args))
                 .Returns(true);
             authMock.Setup(x => x.InvokeHelperAsync(It.IsAny<string>(), It.IsAny<string>(), null, CancellationToken.None))
                 .ReturnsAsync(resultDict);
@@ -176,7 +178,7 @@ namespace Atlassian.Bitbucket.Tests
             Assert.Equal(result.Credential.Account, expectedUserName);
             Assert.Equal(result.Credential.Password, expectedPassword);
 
-            authMock.Verify(x => x.InvokeHelperAsync(helperPath, expectedArgs, null, CancellationToken.None),
+            authMock.Verify(x => x.InvokeHelperAsync(command, expectedArgs, null, CancellationToken.None),
                 Times.Once);
         }
 
@@ -185,7 +187,8 @@ namespace Atlassian.Bitbucket.Tests
         {
             var targetUri = new Uri("https://example.com/bitbucket");
 
-            var helperPath = "/usr/bin/test-helper";
+            var command = "/usr/bin/test-helper";
+            var args = "";
             var expectedUserName = "jsquire";
             var expectedPassword = "password";
             var resultDict = new Dictionary<string, string>
@@ -200,7 +203,7 @@ namespace Atlassian.Bitbucket.Tests
             context.SessionManager.IsDesktopSession = true; // Enable OAuth and UI helper selection
 
             var authMock = new Mock<BitbucketAuthentication>(context) { CallBase = true };
-            authMock.Setup(x => x.TryFindHelperExecutablePath(out helperPath))
+            authMock.Setup(x => x.TryFindHelperCommand(out command, out args))
                 .Returns(true);
             authMock.Setup(x => x.InvokeHelperAsync(It.IsAny<string>(), It.IsAny<string>(), null, CancellationToken.None))
                 .ReturnsAsync(resultDict);
@@ -212,7 +215,7 @@ namespace Atlassian.Bitbucket.Tests
             Assert.Equal(result.Credential.Account, expectedUserName);
             Assert.Equal(result.Credential.Password, expectedPassword);
 
-            authMock.Verify(x => x.InvokeHelperAsync(helperPath, expectedArgs, null, CancellationToken.None),
+            authMock.Verify(x => x.InvokeHelperAsync(command, expectedArgs, null, CancellationToken.None),
                 Times.Once);
         }
     }

--- a/src/shared/DotnetTool/DotnetTool.csproj
+++ b/src/shared/DotnetTool/DotnetTool.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.Build.NoTargets/3.5.6">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <PackAsTool>true</PackAsTool>
+    <NuSpecFile>dotnet-tool.nuspec</NuSpecFile>
+    <!-- Inject correct properties into NuSpec -->
+    <NuspecProperties>
+      version=$(PackageVersion);
+      publishDir=$(PublishDir);
+    </NuspecProperties>
+    <NoBuild>true</NoBuild>
+    <OutputPath>../../../out/nupkg</OutputPath>
+  </PropertyGroup>
+</Project>

--- a/src/shared/DotnetTool/DotnetToolSettings.xml
+++ b/src/shared/DotnetTool/DotnetToolSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<DotNetCliTool Version="1">
+  <Commands>
+    <Command Name="git-credential-manager-core" EntryPoint="git-credential-manager-core.dll" Runner="dotnet" Version="6.0" />
+  </Commands>
+</DotNetCliTool>

--- a/src/shared/DotnetTool/dotnet-tool.nuspec
+++ b/src/shared/DotnetTool/dotnet-tool.nuspec
@@ -1,0 +1,15 @@
+
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+    <metadata>
+        <id>GitCredentialManager.Cli</id>
+        <version>$version$</version>
+        <description>Secure, cross-platform Git credential storage with authentication to Azure Repos, GitHub, and other popular Git hosting services.</description>
+        <authors>Git Credential Manager</authors>
+        <packageTypes>
+            <packageType name="DotnetTool" />
+        </packageTypes>
+  </metadata>
+  <files>
+    <file src="$publishdir$" target="tools/net6.0/any" />
+  </files>
+</package>

--- a/src/shared/DotnetTool/pack-tool.sh
+++ b/src/shared/DotnetTool/pack-tool.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+die () {
+    echo "$*" >&2
+    exit 1
+}
+
+make_absolute () {
+    case "$1" in
+    /*)
+        echo "$1"
+        ;;
+    *)
+        echo "$PWD/$1"
+        ;;
+    esac
+}
+
+#####################################################################
+# Lay out
+#####################################################################
+echo "Laying out files for dotnet tool..."
+# Parse script arguments
+for i in "$@"
+do
+case "$i" in
+    --configuration=*)
+    CONFIGURATION="${i#*=}"
+    shift # past argument=value
+    ;;
+    --version=*)
+    VERSION="${i#*=}"
+    shift # past argument=value
+    ;;
+    *)
+          # unknown option
+    ;;
+esac
+done
+
+if [ -z "$VERSION" ]; then
+    VERSION="$GitBuildVersionSimple"
+fi
+
+# Directories
+THISDIR="$( cd "$(dirname "$0")" ; pwd -P )"
+ROOT="$( cd "$THISDIR"/../../.. ; pwd -P )"
+SRC="$ROOT/src"
+OUT="$ROOT/out"
+GCM_SRC="$SRC/shared/Git-Credential-Manager"
+BITBUCKET_UI_SRC="$SRC/shared/Atlassian.Bitbucket.UI.Avalonia"
+GITHUB_UI_SRC="$SRC/shared/GitHub.UI.Avalonia"
+GITLAB_UI_SRC="$SRC/shared/GitLab.UI.Avalonia"
+DOTNET_TOOL="shared/DotnetTool"
+PROJ_OUT="$OUT/$DOTNET_TOOL"
+
+PACKAGE="$ROOT/nuget"
+CONFIGURATION="${CONFIGURATION:=Release}"
+
+# Build parameters
+FRAMEWORK=net6.0
+
+# Outputs
+PAYLOAD="$PROJ_OUT/payload/$CONFIGURATION"
+SYMBOLOUT="$PROJ_OUT/payload.sym/$CONFIGURATION"
+
+# Cleanup payload directory
+if [ -d "$PAYLOAD" ]; then
+    echo "Cleaning existing payload directory '$PAYLOAD'..."
+    rm -rf "$PAYLOAD"
+fi
+
+# Cleanup symbol directory
+if [ -d "$SYMBOLOUT" ]; then
+    echo "Cleaning existing symbols directory '$SYMBOLOUT'..."
+    rm -rf "$SYMBOLOUT"
+fi
+
+# Cleanup package directory
+if [ -d "$PACKAGE" ]; then
+    echo "Cleaning existing package directory '$PACKAGE'..."
+    rm -rf "$PACKAGE"
+fi
+
+# Ensure directories exist
+mkdir -p "$PAYLOAD" "$SYMBOLOUT" "$PACKAGE"
+
+if [ -z "$DOTNET_ROOT" ]; then
+    DOTNET_ROOT="$(dirname $(which dotnet))"
+fi
+
+# Publish core application executables
+echo "Publishing core application..."
+$DOTNET_ROOT/dotnet publish "$GCM_SRC" \
+	--configuration="$CONFIGURATION" \
+	--framework="$FRAMEWORK" \
+	--output="$(make_absolute "$PAYLOAD")" \
+    -p:UseAppHost=false || exit 1
+
+echo "Publishing Bitbucket UI helper..."
+$DOTNET_ROOT/dotnet publish "$BITBUCKET_UI_SRC" \
+	--configuration="$CONFIGURATION" \
+	--framework="$FRAMEWORK" \
+	--output="$(make_absolute "$PAYLOAD")" \
+    -p:UseAppHost=false || exit 1
+
+echo "Publishing GitHub UI helper..."
+$DOTNET_ROOT/dotnet publish "$GITHUB_UI_SRC" \
+	--configuration="$CONFIGURATION" \
+	--framework="$FRAMEWORK" \
+	--output="$(make_absolute "$PAYLOAD")" \
+    -p:UseAppHost=false || exit 1
+
+echo "Publishing GitLab UI helper..."
+$DOTNET_ROOT/dotnet publish "$GITLAB_UI_SRC" \
+	--configuration="$CONFIGURATION" \
+	--framework="$FRAMEWORK" \
+	--output="$(make_absolute "$PAYLOAD")" \
+    -p:UseAppHost=false || exit 1
+
+# Collect symbols
+echo "Collecting managed symbols..."
+mv "$PAYLOAD"/*.pdb "$SYMBOLOUT" || exit 1
+
+echo "Build complete."
+
+#####################################################################
+# Pack dotnet tool
+#####################################################################
+echo "Creating dotnet tool package..."
+
+mkdir -p "$PACKAGE" || exit 1
+echo "Laying out files..."
+cp -r "$SRC/$DOTNET_TOOL/DotnetToolSettings.xml" \
+    "$PAYLOAD/." \
+    "$PACKAGE/"
+
+dotnet pack "$SRC/$DOTNET_TOOL/DotnetTool.csproj" /p:PackageVersion="$VERSION" /p:PublishDir="$PACKAGE/"
+
+echo "Dotnet tool pack complete."

--- a/src/shared/GitLab/GitLabAuthentication.cs
+++ b/src/shared/GitLab/GitLabAuthentication.cs
@@ -68,21 +68,22 @@ namespace GitLab
             }
 
             if (Context.Settings.IsGuiPromptsEnabled && Context.SessionManager.IsDesktopSession &&
-                TryFindHelperExecutablePath(out string helperPath))
+                TryFindHelperCommand(out string helperCommand, out string args))
             {
-                var cmdArgs = new StringBuilder("prompt");
+                var promptArgs = new StringBuilder(args);
+                promptArgs.Append("prompt");
                 if (!string.IsNullOrWhiteSpace(userName))
                 {
-                    cmdArgs.AppendFormat(" --username {0}", QuoteCmdArg(userName));
+                    promptArgs.AppendFormat(" --username {0}", QuoteCmdArg(userName));
                 }
 
-                cmdArgs.AppendFormat(" --url {0}", QuoteCmdArg(targetUri.ToString()));
+                promptArgs.AppendFormat(" --url {0}", QuoteCmdArg(targetUri.ToString()));
 
-                if ((modes & AuthenticationModes.Basic) != 0)   cmdArgs.Append(" --basic");
-                if ((modes & AuthenticationModes.Browser) != 0) cmdArgs.Append(" --browser");
-                if ((modes & AuthenticationModes.Pat) != 0)     cmdArgs.Append(" --pat");
+                if ((modes & AuthenticationModes.Basic) != 0)   promptArgs.Append(" --basic");
+                if ((modes & AuthenticationModes.Browser) != 0) promptArgs.Append(" --browser");
+                if ((modes & AuthenticationModes.Pat) != 0)     promptArgs.Append(" --pat");
 
-                IDictionary<string, string> resultDict = await InvokeHelperAsync(helperPath, cmdArgs.ToString());
+                IDictionary<string, string> resultDict = await InvokeHelperAsync(helperCommand, promptArgs.ToString());
 
                 if (!resultDict.TryGetValue("mode", out string responseMode))
                 {
@@ -226,13 +227,14 @@ namespace GitLab
             return await oauthClient.GetTokenByRefreshTokenAsync(refreshToken, CancellationToken.None);
         }
 
-        private bool TryFindHelperExecutablePath(out string path)
+        private bool TryFindHelperCommand(out string command, out string args)
         {
-            return TryFindHelperExecutablePath(
+            return TryFindHelperCommand(
                 GitLabConstants.EnvironmentVariables.AuthenticationHelper,
                 GitLabConstants.GitConfiguration.Credential.AuthenticationHelper,
                 GitLabConstants.DefaultAuthenticationHelper,
-                out path);
+                out command,
+                out args);
         }
 
         private HttpClient _httpClient;


### PR DESCRIPTION
Package GCM as a dotnet tool and publish it to NuGet.org in release pipeline.

**Note 1:** The pipeline is currently set up to publish to my fork of GCM using a GitHub Packages Registry. Here are the instructions to dogfood from this registry:

1. If you have GCM installed, uninstall it (you can find instructions for your distro/install method [here](https://github.com/GitCredentialManager/git-credential-manager#linux)).
2. If you have not already installed dotnet, [do so](https://learn.microsoft.com/en-us/dotnet/core/install/linux).
4. Run the following:
```
export PATH="$PATH:~/.dotnet/tools"
dotnet tool install --global GitCredentialManager.Cli --add-source https://apiint.nugettest.org/v3/index.json
```
5. If you have not already configured a credential store, follow [these instructions](https://github.com/GitCredentialManager/git-credential-manager/blob/main/docs/credstores.md#credential-stores) to do so.

**Note 2:** We use a custom NuSpec file because, unfortunately, using `Content` in the `.csproj` to copy files would not overwrite the `DotnetToolSettings.xml` file. See https://github.com/NuGet/Home/issues/9902 for details.

Fixes #820