### PR TITLE
Updates RFC links to authoritative URL

### DIFF
--- a/docs/azrepos-users-and-tokens.md
+++ b/docs/azrepos-users-and-tokens.md
@@ -222,4 +222,4 @@ fabrikam:
 [credential-azreposCredentialType]: configuration.md#credentialazreposcredentialtype
 [gcm-azrepos-credential-type]: environment.md#GCM_AZREPOS_CREDENTIALTYPE
 [azure-devops-api]: https://docs.microsoft.com/en-gb/rest/api/azure/devops/tokens/pats
-[rfc3986-s321]: https://tools.ietf.org/html/rfc3986#section-3.2.1
+[rfc3986-s321]: https://www.rfc-editor.org/rfc/rfc3986#section-3.2.1

--- a/docs/hostprovider.md
+++ b/docs/hostprovider.md
@@ -347,5 +347,5 @@ take, but implementors SHOULD attempt to follow existing practices and styles.
 [github-dotnet-cli]: https://github.com/dotnet/command-line-api
 [hostprovider-base-class]: #26-hostprovider-base-class
 [references]: #references
-[rfc-2119]: https://tools.ietf.org/html/rfc2119
-[rfc-6749]: https://tools.ietf.org/html/rfc6749
+[rfc-2119]: https://www.rfc-editor.org/rfc/rfc2119
+[rfc-6749]: https://www.rfc-editor.org/rfc/rfc6749

--- a/docs/netconfig.md
+++ b/docs/netconfig.md
@@ -195,9 +195,9 @@ proxy root certificates.
 [configuration]: configuration.md
 [git-http-proxy]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpproxy
 [git-remote-name-proxy]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-remoteltnamegtproxy
-[rfc-3986-321]: https://tools.ietf.org/html/rfc3986#section-3.2.1
-[rfc-3986-22]: https://tools.ietf.org/html/rfc3986#section-2.2
-[rfc-3986-21]: https://tools.ietf.org/html/rfc3986#section-2.1
+[rfc-3986-321]: https://www.rfc-editor.org/rfc/rfc3986#section-3.2.1
+[rfc-3986-22]: https://www.rfc-editor.org/rfc/rfc3986#section-2.2
+[rfc-3986-21]: https://www.rfc-editor.org/rfc/rfc3986#section-2.1
 [curl-proxy-env-vars]: https://everything.curl.dev/usingcurl/proxies#proxy-environment-variables
 [other-proxy-options]: #other-proxy-options
 [curlopt-noproxy]: https://curl.se/libcurl/c/CURLOPT_NOPROXY.html

--- a/src/shared/Core/UriExtensions.cs
+++ b/src/shared/Core/UriExtensions.cs
@@ -48,7 +48,7 @@ namespace GitCredentialManager
                 return false;
             }
 
-            /* According to RFC 3986 section 3.2.1 (https://tools.ietf.org/html/rfc3986#section-3.2.1)
+            /* According to RFC 3986 section 3.2.1 (https://www.rfc-editor.org/rfc/rfc3986#section-3.2.1)
              * the user information component of a URI should look like:
              *
              *     url-encode(username):url-encode(password)

--- a/src/shared/GitHub.Tests/GitHubRestApiTests.cs
+++ b/src/shared/GitHub.Tests/GitHubRestApiTests.cs
@@ -350,7 +350,7 @@ namespace GitHub.Tests
 
             var expectedRequestUri = new Uri("https://api.github.com/authorizations");
 
-            // https://tools.ietf.org/html/rfc2324#section-2.3.2
+            // https://www.rfc-editor.org/rfc/rfc2324#section-2.3.2
             const HttpStatusCode httpIAmATeaPot = (HttpStatusCode) 418;
             var httpResponse = new HttpResponseMessage(httpIAmATeaPot)
             {


### PR DESCRIPTION
The current URLs use an outdated source.

The rfc-editor.org site is stated to be the authoritative source, see paragraph 3 on https://www.ietf.org/standards/rfcs/.

The redirection used at the existing URL cause the later versions of the link checker to fail for the instances in the documentation and so part of the reason that #840 needed to be closed without merging, see: https://github.com/GitCredentialManager/git-credential-manager/actions/runs/2863387781/jobs/4540421391. 

However, instances in the source code comments have also been updated.