### PR TITLE
dotnet tool: rename package

### DIFF
--- a/src/shared/DotnetTool/dotnet-tool.nuspec
+++ b/src/shared/DotnetTool/dotnet-tool.nuspec
@@ -1,10 +1,10 @@
 
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
-        <id>GitCredentialManager.Cli</id>
+        <id>git-credential-manager</id>
         <version>$version$</version>
         <description>Secure, cross-platform Git credential storage with authentication to Azure Repos, GitHub, and other popular Git hosting services.</description>
-        <authors>Git Credential Manager</authors>
+        <authors>git-credential-manager</authors>
         <packageTypes>
             <packageType name="DotnetTool" />
         </packageTypes>


### PR DESCRIPTION
Change the name of the dotnet tool package from GitCredentialManager.Cli to git-credential-manager. The reason for this change is that we were able to transfer ownership of this package (which was previously owned by JetBrains) to the git-credential-manager organization on NuGet.org. There should not be any customer impact related to this change, as the GitCredentialManager.Cli package had yet to be published.