### PR TITLE
Update markdownlint-cli2-action to 7.0.0

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -20,9 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
-      - uses: DavidAnson/markdownlint-cli2-action@d199b6e1b89360c71e0c21eac02f7965faf07ba6
+      - uses: DavidAnson/markdownlint-cli2-action@e3969ef4ed874458f4b66d4631f78fff7717012c
         with:
-          globs: "**/*.md"
+          globs: |
+            "**/*.md"
+            "!.github/ISSUE_TEMPLATE"
 
   check-links:
     name: Check for broken links

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -837,7 +837,6 @@ export GCM_AZREPOS_CREDENTIALTYPE="oauth"
 [credential-authority]: configuration.md#credentialauthority-deprecated
 [credential-autodetecttimeout]: configuration.md#credentialautodetecttimeout
 [credential-azrepos-credential-type]: configuration.md#azreposcredentialtype
-[credential-bitbucketalwaysrefreshcredentials]: configuration.md#bitbucketAlwaysRefreshCredentials
 [credential-bitbucketauthmodes]: configuration.md#credentialbitbucketAuthModes
 [credential-cacheoptions]: configuration.md#credentialcacheoptions
 [credential-credentialstore]: configuration.md#credentialcredentialstore
@@ -857,7 +856,7 @@ export GCM_AZREPOS_CREDENTIALTYPE="oauth"
 [freedesktop-ss]: https://specifications.freedesktop.org/secret-service/
 [gcm]: usage.md
 [gcm-interactive]: #gcm_interactive
-[gcm-credential-store]: #GCM_CREDENTIAL_STORE
+[gcm-credential-store]: #gcm_credential_store
 [gcm-dpapi-store-path]: #gcm_dpapi_store_path
 [gcm-plaintext-store-path]: #gcm_plaintext_store_path
 [gcm-msauth-usebroker]: #gcm_msauth_usebroker-experimental


### PR DESCRIPTION
This required fixing some newly found lint issues.

Additionally some issues are in files (workflow templates) that are structured in such a way that do not easily allow correction, so I have adjusted the linter configuration to ignore these files for now. They could instead be corrected in a later commit.