### PR TITLE
windows: add missing DllImport attribute to LocalFree

### DIFF
--- a/src/shared/Core/Interop/Windows/Native/Kernel32.cs
+++ b/src/shared/Core/Interop/Windows/Native/Kernel32.cs
@@ -249,6 +249,7 @@ namespace GitCredentialManager.Interop.Windows.Native
         /// <para/>
         /// To get extended error information, call GetLastError.
         /// </returns>
+        [DllImport(LibraryName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern IntPtr LocalFree(IntPtr ptr);
     }
 


### PR DESCRIPTION
Accidentally left off the `[DllImport]` attribute when adding this `extern`.. now it'll actually point to the correct function in the DLL.