### PR TITLE
build: fix/speed-up build graph dependencies

### DIFF
--- a/src/linux/Packaging.Linux/Packaging.Linux.csproj
+++ b/src/linux/Packaging.Linux/Packaging.Linux.csproj
@@ -17,6 +17,10 @@
 
   <ItemGroup>
     <ProjectReference Include="../../shared/Git-Credential-Manager/Git-Credential-Manager.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../../shared/Atlassian.Bitbucket.UI.Avalonia/Atlassian.Bitbucket.UI.Avalonia.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../../shared/GitHub.UI.Avalonia/GitHub.UI.Avalonia.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../../shared/GitLab.UI.Avalonia/GitLab.UI.Avalonia.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../../shared/Core.UI.Avalonia/Core.UI.Avalonia.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <!-- Implicit SDK targets import (so we can override the default targets below) -->

--- a/src/osx/Installer.Mac/Installer.Mac.csproj
+++ b/src/osx/Installer.Mac/Installer.Mac.csproj
@@ -13,8 +13,10 @@
 
   <ItemGroup>
     <ProjectReference Include="../../shared/Git-Credential-Manager/Git-Credential-Manager.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="../../shared/Atlassian.Bitbucket.UI/Atlassian.Bitbucket.UI.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="../../shared/GitHub.UI/GitHub.UI.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../../shared/Atlassian.Bitbucket.UI.Avalonia/Atlassian.Bitbucket.UI.Avalonia.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../../shared/GitHub.UI.Avalonia/GitHub.UI.Avalonia.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../../shared/GitLab.UI.Avalonia/GitLab.UI.Avalonia.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../../shared/Core.UI.Avalonia/Core.UI.Avalonia.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <!-- Implicit SDK targets import (so we can override the default targets below) -->

--- a/src/osx/Installer.Mac/layout.sh
+++ b/src/osx/Installer.Mac/layout.sh
@@ -97,8 +97,6 @@ cp "$INSTALLER_SRC/uninstall.sh" "$PAYLOAD" || exit 1
 # Publish core application executables
 echo "Publishing core application..."
 dotnet publish "$GCM_SRC" \
-	--no-restore \
-	-m:1 \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
@@ -107,8 +105,6 @@ dotnet publish "$GCM_SRC" \
 
 echo "Publishing core UI helper..."
 dotnet publish "$GCM_UI_SRC" \
-	--no-restore \
-	-m:1 \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
@@ -117,8 +113,6 @@ dotnet publish "$GCM_UI_SRC" \
 
 echo "Publishing Bitbucket UI helper..."
 dotnet publish "$BITBUCKET_UI_SRC" \
-	--no-restore \
-	-m:1 \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
@@ -127,8 +121,6 @@ dotnet publish "$BITBUCKET_UI_SRC" \
 
 echo "Publishing GitHub UI helper..."
 dotnet publish "$GITHUB_UI_SRC" \
-	--no-restore \
-	-m:1 \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \
@@ -137,8 +129,6 @@ dotnet publish "$GITHUB_UI_SRC" \
 
 echo "Publishing GitLab UI helper..."
 dotnet publish "$GITLAB_UI_SRC" \
-	--no-restore \
-	-m:1 \
 	--configuration="$CONFIGURATION" \
 	--framework="$FRAMEWORK" \
 	--runtime="$RUNTIME" \

--- a/src/windows/Installer.Windows/Installer.Windows.csproj
+++ b/src/windows/Installer.Windows/Installer.Windows.csproj
@@ -10,6 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../shared/Git-Credential-Manager/Git-Credential-Manager.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../Atlassian.Bitbucket.UI.Windows/Atlassian.Bitbucket.UI.Windows.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../GitHub.UI.Windows/GitHub.UI.Windows.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../GitLab.UI.Windows/GitLab.UI.Windows.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../Core.UI.Windows/Core.UI.Windows.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="Setup.iss" />
   </ItemGroup>
 

--- a/src/windows/Installer.Windows/layout.ps1
+++ b/src/windows/Installer.Windows/layout.ps1
@@ -41,7 +41,7 @@ mkdir -p "$PAYLOAD","$SYMBOLS"
 # Publish core application executables
 Write-Output "Publishing core application..."
 dotnet publish "$GCM_SRC" `
-    --framework net472 `
+	--framework net472 `
 	--configuration "$CONFIGURATION" `
 	--runtime win-x86 `
 	--output "$PAYLOAD"


### PR DESCRIPTION
When building the entire solution, we need to ensure the various "Installer.<OS>" and "Packaging.<OS>" projects are not built at the same time as other projects, especially on Windows, where we may hit file locking problems.

The installer projects call a build script internally that calls a `dotnet publish` on various projects. By making the installer projects reference (but not consume) the dependent projects we ensure MSBuild won't build them until the end, and prevent file access errors.

At the same time, we can probably remove the "-m:1" flags that tell MSBuild to only build one project at a time.