### PR TITLE
WSL documentation updated

### DIFF
--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -22,7 +22,7 @@ _Inside your WSL installation_, run the following command to set GCM as the Git
 credential helper:
 
 ```shell
-git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
+git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager-core.exe"
 ```
 
 If you intend to use Azure DevOps you must _also_ set the following Git
@@ -44,7 +44,7 @@ _Inside your WSL installation_, run the following command to set GCM as the Git
 credential helper:
 
 ```shell
-git config --global credential.helper "/mnt/c/Program\ Files\ \(x86\)/Git\ Credential\ Manager/git-credential-manager.exe"
+git config --global credential.helper "/mnt/c/Program\ Files\ \(x86\)/Git\ Credential\ Manager/git-credential-manager-core.exe"
 
 # For Azure DevOps support only
 git config --global credential.https://dev.azure.com.useHttpPath true


### PR DESCRIPTION
After installation of the Git-2.38.1-64-bit.exe I've noticed the instruction for WSL is no longer up-to-date.

The latest Git Credential Manager binary name is `git-credential-manager-core.exe`. See attached screenshot:

![image](https://user-images.githubusercontent.com/910461/197858124-e960ce38-67cd-4e5b-a480-582f60403a11.png)
