### PR TITLE
Fix docs/x.md relative links

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -231,10 +231,10 @@ dotnet tool uninstall -g git-credential-manager
 
 [dotnet-supported-distributions]: https://learn.microsoft.com/en-us/dotnet/core/install/linux
 [dotnet-tool]: https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools
-[gcm-credstores]: docs/credstores.md
-[gcm-wsl]: docs/wsl.md
+[gcm-credstores]: /docs/credstores.md
+[gcm-wsl]: /docs/wsl.md
 [git-for-windows]: https://gitforwindows.org/
 [git-for-windows-screenshot]: https://user-images.githubusercontent.com/5658207/140082529-1ac133c1-0922-4a24-af03-067e27b3988b.png
 [latest-release]: https://github.com/GitCredentialManager/git-credential-manager/releases/latest
-[linux-uninstall]: docs/linux-fromsrc-uninstall.md
+[linux-uninstall]: /docs/linux-fromsrc-uninstall.md
 [ms-wsl]: https://aka.ms/wsl#


### PR DESCRIPTION
Some link references were broken, e.g. `[gcm-wsl]: docs/wsl.md` led to `.../docs/docs/wsl.md` (note 2 `docs` in path) This PR fixes those links to properly point to `.../docs/x.md` (1 `docs` in path)