### PR TITLE
Fix command-line instructions for .deb install

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -77,13 +77,13 @@ Download the latest [.deb package][latest-release], and run the following:
 
 ```shell
 sudo dpkg -i <path-to-package>
-git-credential-manager configure
+git credential-manager-store configure
 ```
 
 #### Uninstall
 
 ```shell
-git-credential-manager unconfigure
+git credential-manager-store unconfigure
 sudo dpkg -r gcmcore
 ```
 


### PR DESCRIPTION
The installation instructions for .deb are incorrect. 

Currently the instructions for .deb installation are to use `git-credential-manager configure`. However, the command line `git-credential-manager configure` returns `git-credential-manager: command not found`. 

Using `git credential-manager` (no dash) returns
```
git: 'credential-manager' is not a git command. See 'git --help'.

The most similar command is
	credential-manager-core
```

Using `git credential-manager-core` works correctly as expected. This PR updates the installation instructions to use `git credential-manager-core`.

Note: I only verified this for the debian package and so this PR only changes those instructions. The instructions for "Tarball" and "Install from source helper script" also use the probably incorrect `git-credential-manager` command.