### PR TITLE
diagnose: always use IHttpClientFactory for diagnose

### DIFF
--- a/src/shared/Core/Diagnostics/NetworkingDiagnostic.cs
+++ b/src/shared/Core/Diagnostics/NetworkingDiagnostic.cs
@@ -25,23 +25,11 @@ namespace GitCredentialManager.Diagnostics
 
         protected override async Task<bool> RunInternalAsync(StringBuilder log, IList<string> additionalFiles)
         {
-            log.AppendLine("Checking basic networking and HTTP stack...");
+            log.AppendLine("Checking networking and HTTP stack...");
             log.Append("Creating HTTP client...");
-            using var rawHttpClient = new HttpClient();
+            using var httpClient = _httpFactory.CreateClient();
             log.AppendLine(" OK");
 
-            if (!await RunTestAsync(log, rawHttpClient)) return false;
-
-            log.AppendLine("Testing with IHttpClientFactory created HTTP client...");
-            log.Append("Creating HTTP client...");
-            using var contextHttpClient = _httpFactory.CreateClient();
-            log.AppendLine(" OK");
-
-            return await RunTestAsync(log, rawHttpClient);
-        }
-
-        private static async Task<bool> RunTestAsync(StringBuilder log, HttpClient httpClient)
-        {
             bool hasNetwork = NetworkInterface.GetIsNetworkAvailable();
             log.AppendLine($"IsNetworkAvailable: {hasNetwork}");
 


### PR DESCRIPTION
The Network diagnostic currently makes two passes of the tests, one using a 'raw' `HttpClient` and another using one created by the product `HttpClientFactory`.

However, we've not actually been using the factory-built client in the tests! Furthermore, the raw HTTP client will not exercise test correctly if the machine is behind a corporate proxy, so let's just drop that option.

Fixes #927