### PR TITLE
release: remove automatic workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: release
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ release ]
 
 jobs:
 # ================================


### PR DESCRIPTION
Remove the trigger to automatically run the release workflow when changes are merged to the release branch. This will give us better control over our release process and allow us to make changes to the branch if needed without running the workflow.