### PR TITLE
docs: Update README docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ GCM replaces both the .NET Framework-based
 
 ## Install
 
-See [installation instructions][install] for your operating system.
+See the [installation instructions][install] for the current version of GCM for
+install options for your operating system.
 
 ## Current status
 
@@ -119,24 +120,24 @@ When using GitHub logos, please be sure to follow the
 [bitbucket]: https://bitbucket.org
 [bitbucket-ssh]: https://confluence.atlassian.com/bitbucket/ssh-keys-935365775.html
 [build-status-badge]: https://github.com/GitCredentialManager/git-credential-manager/actions/workflows/continuous-integration.yml/badge.svg
-[docs-index]: docs/README.md
+[docs-index]: https://github.com/GitCredentialManager/git-credential-manager/blob/release/docs/README.md
 [dotnet]: https://dotnet.microsoft.com
 [git-credential-helper]: https://git-scm.com/docs/gitcredentials
 [gcm]: https://github.com/GitCredentialManager/git-credential-manager
 [gcm-coc]: CODE_OF_CONDUCT.md
 [gcm-commit-12294990]: https://github.com/git/git/commit/12294990c90e043862be9eb7eb22c3784b526340
 [gcm-contributing]: CONTRIBUTING.md
-[gcm-credstores]: docs/credstores.md
+[gcm-credstores]: https://github.com/GitCredentialManager/git-credential-manager/blob/release/docs/credstores.md
 [gcm-for-mac-and-linux]: https://github.com/microsoft/Git-Credential-Manager-for-Mac-and-Linux
 [gcm-for-windows]: https://github.com/microsoft/Git-Credential-Manager-for-Windows
-[gcm-http-proxy]: docs/netconfig.md#http-proxy
+[gcm-http-proxy]: https://github.com/GitCredentialManager/git-credential-manager/blob/release/docs/netconfig.md#http-proxy
 [gcm-license]: LICENSE
-[gcm-usage]: docs/usage.md
-[gcm-windows-broker]: docs/windows-broker.md
+[gcm-usage]: https://github.com/GitCredentialManager/git-credential-manager/blob/release/docs/usage.md
+[gcm-windows-broker]: https://github.com/GitCredentialManager/git-credential-manager/blob/release/docs/windows-broker.md
 [git-tools-credential-storage]: https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
 [github]: https://github.com
 [github-ssh]: https://help.github.com/en/articles/connecting-to-github-with-ssh
 [github-logos]: https://github.com/logos
-[install]: docs/install.md
+[install]: https://github.com/GitCredentialManager/git-credential-manager/blob/release/docs/install.md
 [ms-package-repos]: https://packages.microsoft.com/repos/
 [workflow-status]: https://github.com/GitCredentialManager/git-credential-manager/actions/workflows/continuous-integration.yml


### PR DESCRIPTION
Update README docs links to point at release branch. The goal of this change is to avoid confusing users when we merge major changes (e.g. the executable rename, the dotnet tool install option, etc.) to main but have not yet released them. With this update, the documentation should align with the latest release.