### PR TITLE
Fix problems with application path and installation directory resolution

### DIFF
--- a/build/GCM.MSBuild.csproj
+++ b/build/GCM.MSBuild.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 

--- a/src/shared/Atlassian.Bitbucket.UI.Avalonia/Program.cs
+++ b/src/shared/Atlassian.Bitbucket.UI.Avalonia/Program.cs
@@ -46,7 +46,8 @@ namespace Atlassian.Bitbucket.UI
             string[] args = (string[]) o;
 
             string appPath = ApplicationBase.GetEntryApplicationPath();
-            using (var context = new CommandContext(appPath))
+            string installDir = ApplicationBase.GetInstallationDirectory();
+            using (var context = new CommandContext(appPath, installDir))
             using (var app = new HelperApplication(context))
             {
                 app.RegisterCommand(new CredentialsCommandImpl(context));

--- a/src/shared/Atlassian.Bitbucket.UI/Atlassian.Bitbucket.UI.csproj
+++ b/src/shared/Atlassian.Bitbucket.UI/Atlassian.Bitbucket.UI.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
     <RootNamespace>Atlassian.Bitbucket.UI</RootNamespace>
     <AssemblyName>Atlassian.Bitbucket.UI.Shared</AssemblyName>
   </PropertyGroup>

--- a/src/shared/Atlassian.Bitbucket/Atlassian.Bitbucket.csproj
+++ b/src/shared/Atlassian.Bitbucket/Atlassian.Bitbucket.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
     <AssemblyName>Atlassian.Bitbucket</AssemblyName>
     <RootNamespace>Atlassian.Bitbucket</RootNamespace>
     <IsTestProject>false</IsTestProject>

--- a/src/shared/Core.Tests/Interop/Linux/LinuxFileSystemTests.cs
+++ b/src/shared/Core.Tests/Interop/Linux/LinuxFileSystemTests.cs
@@ -1,0 +1,90 @@
+using System.IO;
+using GitCredentialManager.Interop.Linux;
+using Xunit;
+using static GitCredentialManager.Tests.TestUtils;
+
+namespace GitCredentialManager.Tests.Interop.Linux
+{
+    public class LinuxFileSystemTests
+    {
+        [PlatformFact(Platforms.Linux)]
+        public static void LinuxFileSystem_IsSamePath_SamePath_ReturnsTrue()
+        {
+            var fs = new LinuxFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA = CreateFile(baseDir, "a.file");
+
+            Assert.True(fs.IsSamePath(fileA, fileA));
+        }
+
+        [PlatformFact(Platforms.Linux)]
+        public static void LinuxFileSystem_IsSamePath_DifferentFile_ReturnsFalse()
+        {
+            var fs = new LinuxFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA = CreateFile(baseDir, "a.file");
+            string fileB = CreateFile(baseDir, "b.file");
+
+            Assert.False(fs.IsSamePath(fileA, fileB));
+            Assert.False(fs.IsSamePath(fileB, fileA));
+        }
+
+        [PlatformFact(Platforms.Linux)]
+        public static void LinuxFileSystem_IsSamePath_SameFileDifferentCase_ReturnsFalse()
+        {
+            var fs = new LinuxFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA1 = CreateFile(baseDir, "a.file");
+            string fileA2 = Path.Combine(baseDir, "A.file");
+
+            Assert.False(fs.IsSamePath(fileA1, fileA2));
+            Assert.False(fs.IsSamePath(fileA2, fileA1));
+        }
+
+        [PlatformFact(Platforms.Linux)]
+        public static void LinuxFileSystem_IsSamePath_SameFileDifferentPathNormalization_ReturnsTrue()
+        {
+            var fs = new LinuxFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string subDir = CreateDirectory(baseDir, "subDir1", "subDir2");
+            string fileA1 = CreateFile(baseDir, "a.file");
+            string fileA2 = Path.Combine(subDir, "..", "..", "a.file");
+
+            Assert.True(fs.IsSamePath(fileA1, fileA2));
+            Assert.True(fs.IsSamePath(fileA2, fileA1));
+        }
+
+        [PlatformFact(Platforms.Linux)]
+        public static void LinuxFileSystem_IsSamePath_SameFileViaSymlink_ReturnsTrue()
+        {
+            var fs = new LinuxFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA1 = CreateFile(baseDir, "a.file");
+            string fileA2 = CreateFileSymlink(baseDir, "a.link", fileA1);
+
+            Assert.True(fs.IsSamePath(fileA1, fileA2));
+            Assert.True(fs.IsSamePath(fileA2, fileA1));
+        }
+
+        [PlatformFact(Platforms.Linux)]
+        public static void LinuxFileSystem_IsSamePath_SameFileRelativePath_ReturnsTrue()
+        {
+            var fs = new LinuxFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA1 = CreateFile(baseDir, "a.file");
+            string fileA2 = "./a.file";
+
+            using (ChangeDirectory(baseDir))
+            {
+                Assert.True(fs.IsSamePath(fileA1, fileA2));
+                Assert.True(fs.IsSamePath(fileA2, fileA1));
+            }
+        }
+    }
+}

--- a/src/shared/Core.Tests/Interop/MacOS/MacOSFileSystemTests.cs
+++ b/src/shared/Core.Tests/Interop/MacOS/MacOSFileSystemTests.cs
@@ -1,0 +1,90 @@
+using System.IO;
+using GitCredentialManager.Interop.MacOS;
+using Xunit;
+using static GitCredentialManager.Tests.TestUtils;
+
+namespace GitCredentialManager.Tests.Interop.MacOS
+{
+    public class MacOSFileSystemTests
+    {
+        [PlatformFact(Platforms.MacOS)]
+        public static void MacOSFileSystem_IsSamePath_SamePath_ReturnsTrue()
+        {
+            var fs = new MacOSFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA = CreateFile(baseDir, "a.file");
+
+            Assert.True(fs.IsSamePath(fileA, fileA));
+        }
+
+        [PlatformFact(Platforms.MacOS)]
+        public static void MacOSFileSystem_IsSamePath_DifferentFile_ReturnsFalse()
+        {
+            var fs = new MacOSFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA = CreateFile(baseDir, "a.file");
+            string fileB = CreateFile(baseDir, "b.file");
+
+            Assert.False(fs.IsSamePath(fileA, fileB));
+            Assert.False(fs.IsSamePath(fileB, fileA));
+        }
+
+        [PlatformFact(Platforms.MacOS)]
+        public static void MacOSFileSystem_IsSamePath_SameFileDifferentCase_ReturnsTrue()
+        {
+            var fs = new MacOSFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA1 = CreateFile(baseDir, "a.file");
+            string fileA2 = Path.Combine(baseDir, "A.file");
+
+            Assert.True(fs.IsSamePath(fileA1, fileA2));
+            Assert.True(fs.IsSamePath(fileA2, fileA1));
+        }
+
+        [PlatformFact(Platforms.MacOS)]
+        public static void MacOSFileSystem_IsSamePath_SameFileDifferentPathNormalization_ReturnsTrue()
+        {
+            var fs = new MacOSFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string subDir = CreateDirectory(baseDir, "subDir1", "subDir2");
+            string fileA1 = CreateFile(baseDir, "a.file");
+            string fileA2 = Path.Combine(subDir, "..", "..", "a.file");
+
+            Assert.True(fs.IsSamePath(fileA1, fileA2));
+            Assert.True(fs.IsSamePath(fileA2, fileA1));
+        }
+
+        [PlatformFact(Platforms.MacOS)]
+        public static void MacOSFileSystem_IsSamePath_SameFileViaSymlink_ReturnsTrue()
+        {
+            var fs = new MacOSFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA1 = CreateFile(baseDir, "a.file");
+            string fileA2 = CreateFileSymlink(baseDir, "a.link", fileA1);
+
+            Assert.True(fs.IsSamePath(fileA1, fileA2));
+            Assert.True(fs.IsSamePath(fileA2, fileA1));
+        }
+
+        [PlatformFact(Platforms.MacOS)]
+        public static void MacOSFileSystem_IsSamePath_SameFileRelativePath_ReturnsTrue()
+        {
+            var fs = new MacOSFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA1 = CreateFile(baseDir, "a.file");
+            string fileA2 = "./a.file";
+
+            using (ChangeDirectory(baseDir))
+            {
+                Assert.True(fs.IsSamePath(fileA1, fileA2));
+                Assert.True(fs.IsSamePath(fileA2, fileA1));
+            }
+        }
+    }
+}

--- a/src/shared/Core.Tests/Interop/Posix/PosixFileSystemTests.cs
+++ b/src/shared/Core.Tests/Interop/Posix/PosixFileSystemTests.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using GitCredentialManager.Interop.Posix;
+using Xunit;
+using static GitCredentialManager.Tests.TestUtils;
+
+namespace GitCredentialManager.Tests.Interop.Posix
+{
+    public class PosixFileSystemTests
+    {
+        [PlatformFact(Platforms.Posix)]
+        public void PosixFileSystem_ResolveSymlinks_FileLinks()
+        {
+            string baseDir = GetTempDirectory();
+            string realPath = CreateFile(baseDir, "realFile.txt");
+            string linkPath = CreateFileSymlink(baseDir, "linkFile.txt", realPath);
+
+            string actual = PosixFileSystem.ResolveSymbolicLinks(linkPath);
+
+            Assert.Equal(realPath, actual);
+        }
+
+        [PlatformFact(Platforms.Posix)]
+        public void PosixFileSystem_ResolveSymlinks_DirectoryLinks()
+        {
+            //
+            // Create a real file inside of a directory that is a symlink
+            // to another directory.
+            //
+            //     /tmp/{uuid}/linkDir/ -> /tmp/{uuid}/realDir/
+            //
+            string baseDir = GetTempDirectory();
+            string realDir = CreateDirectory(baseDir, "realDir");
+            string linkDir = CreateDirectorySymlink(baseDir, "linkDir", realDir);
+            string filePath = CreateFile(linkDir, "file.txt");
+
+            string actual = PosixFileSystem.ResolveSymbolicLinks(filePath);
+
+            string expected = Path.Combine(realDir, "file.txt");
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/shared/Core.Tests/Interop/Windows/WindowsFileSystemTests.cs
+++ b/src/shared/Core.Tests/Interop/Windows/WindowsFileSystemTests.cs
@@ -1,0 +1,77 @@
+using System.IO;
+using GitCredentialManager.Interop.Windows;
+using Xunit;
+using static GitCredentialManager.Tests.TestUtils;
+
+namespace GitCredentialManager.Tests.Interop.Windows
+{
+    public class WindowsFileSystemTests
+    {
+        [PlatformFact(Platforms.Windows)]
+        public static void WindowsFileSystem_IsSamePath_SamePath_ReturnsTrue()
+        {
+            var fs = new WindowsFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA = CreateFile(baseDir, "a.file");
+
+            Assert.True(fs.IsSamePath(fileA, fileA));
+        }
+
+        [PlatformFact(Platforms.Windows)]
+        public static void WindowsFileSystem_IsSamePath_DifferentFile_ReturnsFalse()
+        {
+            var fs = new WindowsFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA = CreateFile(baseDir, "a.file");
+            string fileB = CreateFile(baseDir, "b.file");
+
+            Assert.False(fs.IsSamePath(fileA, fileB));
+            Assert.False(fs.IsSamePath(fileB, fileA));
+        }
+
+        [PlatformFact(Platforms.Windows)]
+        public static void WindowsFileSystem_IsSamePath_SameFileDifferentCase_ReturnsTrue()
+        {
+            var fs = new WindowsFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA1 = CreateFile(baseDir, "a.file");
+            string fileA2 = Path.Combine(baseDir, "A.file");
+
+            Assert.True(fs.IsSamePath(fileA1, fileA2));
+            Assert.True(fs.IsSamePath(fileA2, fileA1));
+        }
+
+        [PlatformFact(Platforms.Windows)]
+        public static void WindowsFileSystem_IsSamePath_SameFileDifferentPathNormalization_ReturnsTrue()
+        {
+            var fs = new WindowsFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string subDir = CreateDirectory(baseDir, "subDir1", "subDir2");
+            string fileA1 = CreateFile(baseDir, "a.file");
+            string fileA2 = Path.Combine(subDir, "..", "..", "a.file");
+
+            Assert.True(fs.IsSamePath(fileA1, fileA2));
+            Assert.True(fs.IsSamePath(fileA2, fileA1));
+        }
+
+        [PlatformFact(Platforms.Windows)]
+        public static void WindowsFileSystem_IsSamePath_SameFileRelativePath_ReturnsTrue()
+        {
+            var fs = new WindowsFileSystem();
+
+            string baseDir = GetTempDirectory();
+            string fileA1 = CreateFile(baseDir, "a.file");
+            string fileA2 = @".\a.file";
+
+            using (ChangeDirectory(baseDir))
+            {
+                Assert.True(fs.IsSamePath(fileA1, fileA2));
+                Assert.True(fs.IsSamePath(fileA2, fileA1));
+            }
+        }
+    }
+}

--- a/src/shared/Core.UI/Core.UI.csproj
+++ b/src/shared/Core.UI/Core.UI.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
     <AssemblyName>gcmcoreui</AssemblyName>
     <RootNamespace>GitCredentialManager.UI</RootNamespace>
   </PropertyGroup>

--- a/src/shared/Core/Application.cs
+++ b/src/shared/Core/Application.cs
@@ -97,6 +97,7 @@ namespace GitCredentialManager
             Context.Trace.WriteLine($"Platform: {info.OperatingSystemType} ({info.CpuArchitecture})");
             Context.Trace.WriteLine($"OSVersion: {info.OperatingSystemVersion}");
             Context.Trace.WriteLine($"AppPath: {Context.ApplicationPath}");
+            Context.Trace.WriteLine($"InstallDir: {Context.InstallationDirectory}");
             Context.Trace.WriteLine($"Arguments: {string.Join(" ", args)}");
 
             var parser = new CommandLineBuilder(rootCommand)
@@ -252,23 +253,11 @@ namespace GitCredentialManager
                 }
 
                 // Clear app entry
-                config.UnsetAll(configLevel, helperKey, Regex.Escape(appPath));
+                string appEntryValue = currentValues[appIndex];
+                config.UnsetAll(configLevel, helperKey, Regex.Escape(appEntryValue));
             }
 
             return Task.CompletedTask;
-        }
-
-        private string GetGitConfigAppName()
-        {
-            const string gitCredentialPrefix = "git-credential-";
-
-            string appName = Path.GetFileNameWithoutExtension(Context.ApplicationPath);
-            if (appName != null && appName.StartsWith(gitCredentialPrefix, StringComparison.OrdinalIgnoreCase))
-            {
-                return appName.Substring(gitCredentialPrefix.Length);
-            }
-
-            return Context.ApplicationPath;
         }
 
         private string GetGitConfigAppPath()

--- a/src/shared/Core/ApplicationBase.cs
+++ b/src/shared/Core/ApplicationBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -83,18 +84,14 @@ namespace GitCredentialManager
 
         public static string GetEntryApplicationPath()
         {
-            string argv0 = PlatformUtils.GetNativeArgv0()
-                           ?? Process.GetCurrentProcess().MainModule?.FileName
-                           ?? Environment.GetCommandLineArgs()[0];
+            return PlatformUtils.GetNativeArgv0() ??
+                   Process.GetCurrentProcess().MainModule?.FileName ??
+                   Environment.GetCommandLineArgs()[0];
+        }
 
-            if (Path.IsPathRooted(argv0))
-            {
-                return argv0;
-            }
-
-            return Path.GetFullPath(
-                Path.Combine(Environment.CurrentDirectory, argv0)
-            );
+        public static string GetInstallationDirectory()
+        {
+            return Path.GetDirectoryName(Environment.GetCommandLineArgs()[0]);
         }
 
         /// <summary>

--- a/src/shared/Core/ApplicationBase.cs
+++ b/src/shared/Core/ApplicationBase.cs
@@ -84,7 +84,7 @@ namespace GitCredentialManager
 
         public static string GetEntryApplicationPath()
         {
-            return PlatformUtils.GetNativeArgv0() ??
+            return PlatformUtils.GetNativeEntryPath() ??
                    Process.GetCurrentProcess().MainModule?.FileName ??
                    Environment.GetCommandLineArgs()[0];
         }

--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -166,7 +166,7 @@ namespace GitCredentialManager.Authentication
             //
             // Search the installation directory for an in-box helper
             //
-            string appDir = Path.GetDirectoryName(Context.ApplicationPath);
+            string appDir = Context.InstallationDirectory;
             string inBoxExePath = Path.Combine(appDir, PlatformUtils.IsWindows() ? $"{helperName}.exe" : helperName);
             string inBoxDllPath = Path.Combine(appDir, $"{helperName}.dll");
 

--- a/src/shared/Core/CommandContext.cs
+++ b/src/shared/Core/CommandContext.cs
@@ -18,6 +18,11 @@ namespace GitCredentialManager
         string ApplicationPath { get; }
 
         /// <summary>
+        /// Absolute path to the Git Credential Manager installation directory.
+        /// </summary>
+        string InstallationDirectory { get; }
+
+        /// <summary>
         /// Settings and configuration for Git Credential Manager.
         /// </summary>
         ISettings Settings { get; }
@@ -73,11 +78,13 @@ namespace GitCredentialManager
     /// </summary>
     public class CommandContext : DisposableObject, ICommandContext
     {
-        public CommandContext(string appPath)
+        public CommandContext(string appPath, string installDir)
         {
             EnsureArgument.NotNullOrWhiteSpace(appPath, nameof (appPath));
 
             ApplicationPath = appPath;
+            InstallationDirectory = installDir;
+
             Streams = new StandardStreams();
             Trace   = new Trace();
 
@@ -171,6 +178,8 @@ namespace GitCredentialManager
         #region ICommandContext
 
         public string ApplicationPath { get; }
+
+        public string InstallationDirectory { get; }
 
         public ISettings Settings { get; }
 

--- a/src/shared/Core/Commands/DiagnoseCommand.cs
+++ b/src/shared/Core/Commands/DiagnoseCommand.cs
@@ -83,7 +83,8 @@ namespace GitCredentialManager.Commands
             using var fullLog = new StreamWriter(logFilePath, append: false, Encoding.UTF8);
             fullLog.WriteLine("Diagnose log at {0:s}Z", DateTime.UtcNow);
             fullLog.WriteLine();
-            fullLog.WriteLine($"Executable: {_context.ApplicationPath}");
+            fullLog.WriteLine($"AppPath: {_context.ApplicationPath}");
+            fullLog.WriteLine($"InstallDir: {_context.InstallationDirectory}");
             fullLog.WriteLine(
                 TryGetAssemblyVersion(out string version)
                     ? $"Version: {version}"

--- a/src/shared/Core/Core.csproj
+++ b/src/shared/Core/Core.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
     <AssemblyName>gcmcore</AssemblyName>
     <RootNamespace>GitCredentialManager</RootNamespace>
     <IsTestProject>false</IsTestProject>

--- a/src/shared/Core/Interop/Linux/LinuxFileSystem.cs
+++ b/src/shared/Core/Interop/Linux/LinuxFileSystem.cs
@@ -8,8 +8,18 @@ namespace GitCredentialManager.Interop.Linux
     {
         public override bool IsSamePath(string a, string b)
         {
-            a = Path.GetFileName(a);
-            b = Path.GetFileName(b);
+            if (string.IsNullOrWhiteSpace(a) || string.IsNullOrWhiteSpace(b))
+            {
+                return false;
+            }
+
+            // Normalize paths
+            a = Path.GetFullPath(a);
+            b = Path.GetFullPath(b);
+
+            // Resolve symbolic links
+            a = ResolveSymbolicLinks(a);
+            b = ResolveSymbolicLinks(b);
 
             return StringComparer.Ordinal.Equals(a, b);
         }

--- a/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
+++ b/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
@@ -65,7 +65,7 @@ namespace GitCredentialManager.Interop.Linux
                     throw new InteropException("Failed to search for credentials", code, new Exception(message));
                 }
 
-                if (results != null && results->data != null)
+                if (results != null && results->data != IntPtr.Zero)
                 {
                     SecretItem* item = (SecretItem*) results->data;
 

--- a/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs
+++ b/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs
@@ -8,11 +8,21 @@ namespace GitCredentialManager.Interop.MacOS
     {
         public override bool IsSamePath(string a, string b)
         {
-            a = Path.GetFileName(a);
-            b = Path.GetFileName(b);
+            if (string.IsNullOrWhiteSpace(a) || string.IsNullOrWhiteSpace(b))
+            {
+                return false;
+            }
 
-            // TODO: resolve symlinks
-            // TODO: check if APFS/HFS+ is in case-sensitive mode
+            // Normalize paths
+            a = Path.GetFullPath(a);
+            b = Path.GetFullPath(b);
+
+            // Resolve symbolic links
+            a = ResolveSymbolicLinks(a);
+            b = ResolveSymbolicLinks(b);
+
+            // TODO: determine if file system is case-sensitive
+            // By default HFS+/APFS is NOT case-sensitive...
             return StringComparer.OrdinalIgnoreCase.Equals(a, b);
         }
     }

--- a/src/shared/Core/Interop/MacOS/Native/LibC.cs
+++ b/src/shared/Core/Interop/MacOS/Native/LibC.cs
@@ -8,9 +8,6 @@ namespace GitCredentialManager.Interop.MacOS.Native
         private const string LibCLib = "libc";
 
         [DllImport(LibCLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr _NSGetArgv();
-
-        [DllImport(LibCLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr _NSGetProgname();
+        public static extern int _NSGetExecutablePath(IntPtr buf, out int bufsize);
     }
 }

--- a/src/shared/Core/Interop/Posix/Native/Unistd.cs
+++ b/src/shared/Core/Interop/Posix/Native/Unistd.cs
@@ -1,5 +1,4 @@
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace GitCredentialManager.Interop.Posix.Native
 {

--- a/src/shared/Core/Interop/Posix/PosixFileSystem.cs
+++ b/src/shared/Core/Interop/Posix/PosixFileSystem.cs
@@ -1,7 +1,76 @@
+using System;
+using System.IO;
 
 namespace GitCredentialManager.Interop.Posix
 {
     public abstract class PosixFileSystem : FileSystem
     {
+        /// <summary>
+        /// Recursively resolve a symbolic link.
+        /// </summary>
+        /// <param name="path">Path to resolve.</param>
+        /// <returns>Resolved symlink, or original path if not a link.</returns>
+        /// <exception cref="ArgumentException">Path is not absolute.</exception>
+        protected internal static string ResolveSymbolicLinks(string path)
+        {
+#if NETFRAMEWORK
+            // Support for symlinks only exists in .NET 6+.
+            // Since we're still targeting .NET Framework on Windows it
+            // doesn't matter if we don't resolve symlinks for POSIX here
+            // (unless we're running on Mono.. but why do that?)
+            return path;
+#else
+            if (!Path.IsPathRooted(path))
+            {
+                throw new ArgumentException("Path must be absolute", nameof(path));
+            }
+
+            // If the file or directory doesn't actually exist we cannot resolve
+            // any symlinks, so just return the original input path.
+            if (!File.Exists(path) && !Directory.Exists(path))
+            {
+                return path;
+            }
+
+            // If the file is a symlink then resolve it!
+            string realPath = TryResolveFileLink(path, out string resolvedFile)
+                ? resolvedFile
+                : path;
+
+            // Work backwards from the file name resolving directories symlinks
+            string partialPath = Path.GetFileName(realPath);
+            string dirPath = Path.GetDirectoryName(realPath);
+            while (dirPath != null)
+            {
+                // Try to resolve directory symlinks
+                if (TryResolveDirectoryLink(dirPath, out string resolvedDir))
+                {
+                    dirPath = resolvedDir;
+                }
+
+                string dirName = Path.GetFileName(dirPath);
+                partialPath = Path.Combine(dirName, partialPath);
+                dirPath = Path.GetDirectoryName(dirPath);
+            }
+
+            return Path.Combine("/", partialPath);
+#endif
+        }
+
+#if !NETFRAMEWORK
+        private static bool TryResolveFileLink(string path, out string target)
+        {
+            FileSystemInfo fsi = File.ResolveLinkTarget(path, true);
+            target = fsi?.FullName;
+            return fsi != null;
+        }
+
+        private static bool TryResolveDirectoryLink(string path, out string target)
+        {
+            FileSystemInfo fsi = Directory.ResolveLinkTarget(path, true);
+            target = fsi?.FullName;
+            return fsi != null;
+        }
+#endif
     }
 }

--- a/src/shared/Core/Interop/Windows/WindowsFileSystem.cs
+++ b/src/shared/Core/Interop/Windows/WindowsFileSystem.cs
@@ -7,8 +7,16 @@ namespace GitCredentialManager.Interop.Windows
     {
         public override bool IsSamePath(string a, string b)
         {
-            a = Path.GetFileName(a);
-            b = Path.GetFileName(b);
+            if (string.IsNullOrWhiteSpace(a) || string.IsNullOrWhiteSpace(b))
+            {
+                return false;
+            }
+
+            a = Path.GetFullPath(a);
+            b = Path.GetFullPath(b);
+
+            // Note: we do not resolve or handle symlinks on Windows
+            // because they require administrator permissions to even create!
 
             return StringComparer.OrdinalIgnoreCase.Equals(a, b);
         }

--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -70,7 +70,7 @@ namespace GitCredentialManager
         {
 #if NETFRAMEWORK
             return Environment.OSVersion.Platform == PlatformID.MacOSX;
-#elif NETSTANDARD
+#else
             return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 #endif
         }
@@ -83,7 +83,7 @@ namespace GitCredentialManager
         {
 #if NETFRAMEWORK
             return Environment.OSVersion.Platform == PlatformID.Win32NT;
-#elif NETSTANDARD
+#else
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 #endif
         }
@@ -96,7 +96,7 @@ namespace GitCredentialManager
         {
 #if NETFRAMEWORK
             return Environment.OSVersion.Platform == PlatformID.Unix;
-#elif NETSTANDARD
+#else
             return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 #endif
         }
@@ -309,7 +309,7 @@ namespace GitCredentialManager
         {
 #if NETFRAMEWORK
             return Environment.Is64BitOperatingSystem ? "x86-64" : "x86";
-#elif NETSTANDARD
+#else
             switch (RuntimeInformation.OSArchitecture)
             {
                 case Architecture.Arm:
@@ -330,7 +330,7 @@ namespace GitCredentialManager
         {
 #if NETFRAMEWORK
             return $".NET Framework {Environment.Version}";
-#elif NETSTANDARD
+#else
             return RuntimeInformation.FrameworkDescription;
 #endif
         }

--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -176,30 +176,34 @@ namespace GitCredentialManager
             return false;
         }
 
-        #region Platform argv[0] Utils
+        #region Platform Entry Path Utils
 
-        public static string GetNativeArgv0()
+        /// <summary>
+        /// Get the native entry executable absolute path.
+        /// </summary>
+        /// <returns>Entry absolute path or null if there was an error.</returns>
+        public static string GetNativeEntryPath()
         {
             try
             {
                 if (IsWindows())
                 {
-                    return GetWindowsArgv0();
+                    return GetWindowsEntryPath();
                 }
 
                 if (IsMacOS())
                 {
-                    return GetMacOSArgv0();
+                    return GetMacOSEntryPath();
                 }
 
                 if (IsLinux())
                 {
-                    return GetLinuxArgv0();
+                    return GetLinuxEntryPath();
                 }
             }
             catch
             {
-                // If there are any issues getting the native argv[0]
+                // If there are any issues getting the native entry path
                 // we should not throw, and certainly not crash!
                 // Just return null instead.
             }
@@ -207,21 +211,78 @@ namespace GitCredentialManager
             return null;
         }
 
-        private static string GetLinuxArgv0()
+        private static string GetLinuxEntryPath()
         {
+            // Try to extract our native argv[0] from the original cmdline
             string cmdline = File.ReadAllText("/proc/self/cmdline");
-            return cmdline.Split('\0')[0];
+            string argv0 = cmdline.Split('\0')[0];
+
+            // argv[0] is an absolute file path
+            if (Path.IsPathRooted(argv0))
+            {
+                return argv0;
+            }
+
+            string path = Path.GetFullPath(
+                Path.Combine(Environment.CurrentDirectory, argv0)
+            );
+
+            // argv[0] is relative to current directory (./app) or a relative
+            // name resolved from the current directory (subdir/app).
+            // Note that we do NOT want to consider the case when it is just
+            // a simple filename (argv[0] == "app") because that would actually
+            // have been resolved from the $PATH instead (handled below)!
+            if ((argv0.StartsWith("./") || argv0.IndexOf('/') > 0) && File.Exists(path))
+            {
+                return path;
+            }
+
+            // argv[0] is a name that was resolved from the $PATH
+            string pathVar = Environment.GetEnvironmentVariable("PATH");
+            if (pathVar != null)
+            {
+                string[] paths = pathVar.Split(':');
+                foreach (string pathBase in paths)
+                {
+                    path = Path.Combine(pathBase, argv0);
+                    if (File.Exists(path))
+                    {
+                        return path;
+                    }
+                }
+            }
+
+#if NETFRAMEWORK
+            return null;
+#else
+            //
+            // We cannot determine the absolute file path from argv[0]
+            // (how we were launched), so let's now try to extract the
+            // fully resolved executable path from /proc/self/exe.
+            // Note that this means we may miss if we've been invoked
+            // via a symlink, but it's better than nothing at this point!
+            //
+            FileSystemInfo fsi = File.ResolveLinkTarget("/proc/self/exe", returnFinalTarget: false);
+            return fsi?.FullName;
+#endif
         }
 
-        private static string GetMacOSArgv0()
+        private static string GetMacOSEntryPath()
         {
-            IntPtr ptr = Interop.MacOS.Native.LibC._NSGetArgv();
-            IntPtr argvPtr = Marshal.ReadIntPtr(ptr);
-            IntPtr argv0Ptr = Marshal.ReadIntPtr(argvPtr);
-            return Marshal.PtrToStringAnsi(argv0Ptr);
+            // Determine buffer size by passing NULL initially
+            Interop.MacOS.Native.LibC._NSGetExecutablePath(IntPtr.Zero, out int size);
+
+            IntPtr bufPtr = Marshal.AllocHGlobal(size);
+            int result = Interop.MacOS.Native.LibC._NSGetExecutablePath(bufPtr, out size);
+
+            // buf is null-byte terminated
+            string name = result == 0 ? Marshal.PtrToStringAuto(bufPtr) : null;
+            Marshal.FreeHGlobal(bufPtr);
+
+            return name;
         }
 
-        private static string GetWindowsArgv0()
+        private static string GetWindowsEntryPath()
         {
             IntPtr argvPtr = Interop.Windows.Native.Shell32.CommandLineToArgvW(
                 Interop.Windows.Native.Kernel32.GetCommandLine(), out _);

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
@@ -43,7 +43,8 @@ namespace GitCredentialManager.UI
             string[] args = (string[]) o;
 
             string appPath = ApplicationBase.GetEntryApplicationPath();
-            using (var context = new CommandContext(appPath))
+            string installDir = ApplicationBase.GetInstallationDirectory();
+            using (var context = new CommandContext(appPath, installDir))
             using (var app = new HelperApplication(context))
             {
                 app.RegisterCommand(new CredentialsCommandImpl(context));

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -12,7 +12,8 @@ namespace GitCredentialManager
         public static void Main(string[] args)
         {
             string appPath = ApplicationBase.GetEntryApplicationPath();
-            using (var context = new CommandContext(appPath))
+            string installDir = ApplicationBase.GetInstallationDirectory();
+            using (var context = new CommandContext(appPath, installDir))
             using (var app = new Application(context))
             {
                 // Workaround for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2560

--- a/src/shared/GitHub.UI.Avalonia/Program.cs
+++ b/src/shared/GitHub.UI.Avalonia/Program.cs
@@ -45,7 +45,8 @@ namespace GitHub.UI
             string[] args = (string[]) o;
 
             string appPath = ApplicationBase.GetEntryApplicationPath();
-            using (var context = new CommandContext(appPath))
+            string installDir = ApplicationBase.GetInstallationDirectory();
+            using (var context = new CommandContext(appPath, installDir))
             using (var app = new HelperApplication(context))
             {
                 app.RegisterCommand(new CredentialsCommandImpl(context));

--- a/src/shared/GitHub.UI/GitHub.UI.csproj
+++ b/src/shared/GitHub.UI/GitHub.UI.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
     <RootNamespace>GitHub.UI</RootNamespace>
     <AssemblyName>GitHub.UI.Shared</AssemblyName>
   </PropertyGroup>

--- a/src/shared/GitHub/GitHub.csproj
+++ b/src/shared/GitHub/GitHub.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
     <AssemblyName>GitHub</AssemblyName>
     <RootNamespace>GitHub</RootNamespace>
     <IsTestProject>false</IsTestProject>

--- a/src/shared/GitLab.UI.Avalonia/Program.cs
+++ b/src/shared/GitLab.UI.Avalonia/Program.cs
@@ -45,7 +45,8 @@ namespace GitLab.UI
             string[] args = (string[]) o;
 
             string appPath = ApplicationBase.GetEntryApplicationPath();
-            using (var context = new CommandContext(appPath))
+            string installDir = ApplicationBase.GetInstallationDirectory();
+            using (var context = new CommandContext(appPath, installDir))
             using (var app = new HelperApplication(context))
             {
                 app.RegisterCommand(new CredentialsCommandImpl(context));

--- a/src/shared/GitLab.UI/GitLab.UI.csproj
+++ b/src/shared/GitLab.UI/GitLab.UI.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
     <RootNamespace>GitLab.UI</RootNamespace>
     <AssemblyName>GitLab.UI.Shared</AssemblyName>
   </PropertyGroup>

--- a/src/shared/GitLab/GitLab.csproj
+++ b/src/shared/GitLab/GitLab.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
     <AssemblyName>GitLab</AssemblyName>
     <RootNamespace>GitLab</RootNamespace>
     <IsTestProject>false</IsTestProject>

--- a/src/shared/Microsoft.AzureRepos/Microsoft.AzureRepos.csproj
+++ b/src/shared/Microsoft.AzureRepos/Microsoft.AzureRepos.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
     <AssemblyName>Microsoft.AzureRepos</AssemblyName>
     <RootNamespace>Microsoft.AzureRepos</RootNamespace>
     <IsTestProject>false</IsTestProject>

--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
-using System.Text;
 
 namespace GitCredentialManager.Tests.Objects
 {
@@ -13,6 +10,8 @@ namespace GitCredentialManager.Tests.Objects
             AppPath = PlatformUtils.IsWindows()
                 ? @"C:\Program Files\Git Credential Manager Core\git-credential-manager.exe"
                 : "/usr/local/bin/git-credential-manager";
+
+            InstallDir = Path.GetDirectoryName(AppPath);
 
             Streams = new TestStandardStreams();
             Terminal = new TestTerminal();
@@ -28,6 +27,7 @@ namespace GitCredentialManager.Tests.Objects
         }
 
         public string AppPath { get; set; }
+        public string InstallDir { get; set; }
         public TestSettings Settings { get; set; }
         public TestStandardStreams Streams { get; set; }
         public TestTerminal Terminal { get; set; }
@@ -42,6 +42,8 @@ namespace GitCredentialManager.Tests.Objects
         #region ICommandContext
 
         string ICommandContext.ApplicationPath => AppPath;
+
+        string ICommandContext.InstallationDirectory => InstallDir;
 
         IStandardStreams ICommandContext.Streams => Streams;
 

--- a/src/shared/TestInfrastructure/TestInfrastructure.csproj
+++ b/src/shared/TestInfrastructure/TestInfrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>GitCredentialManager.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>

--- a/src/shared/TestInfrastructure/TestUtils.cs
+++ b/src/shared/TestInfrastructure/TestUtils.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+
+namespace GitCredentialManager.Tests
+{
+    public static class TestUtils
+    {
+        public static IDisposable ChangeDirectory(string path)
+        {
+            var cookie = new ChangeDirectoryCookie(Environment.CurrentDirectory);
+            Environment.CurrentDirectory = path;
+            return cookie;
+        }
+
+        private class ChangeDirectoryCookie : IDisposable
+        {
+            private readonly string _oldPath;
+            public ChangeDirectoryCookie(string oldPath) => _oldPath = oldPath;
+            public void Dispose() => Environment.CurrentDirectory = _oldPath;
+        }
+
+        private static string JoinPaths(string basePath, params string[] names)
+        {
+            string path = basePath;
+            foreach (string name in names)
+            {
+                path = Path.Combine(path, name);
+            }
+            return path;
+        }
+
+        public static string CreateFileSymlink(string baseDir, string linkName, string targetPath)
+        {
+            string linkPath = Path.Combine(baseDir, linkName);
+            FileSystemInfo fsi = File.CreateSymbolicLink(linkPath, targetPath);
+            return fsi.FullName;
+        }
+
+        public static string CreateDirectorySymlink(string baseDir, string linkName, string targetPath)
+        {
+            string linkPath = Path.Combine(baseDir, linkName);
+            FileSystemInfo fsi = Directory.CreateSymbolicLink(linkPath, targetPath);
+            return fsi.FullName;
+        }
+
+        public static string CreateFile(string baseDir, params string[] names)
+        {
+            string path = JoinPaths(baseDir, names);
+            string parentDir = Path.GetDirectoryName(path);
+            if (parentDir != null) Directory.CreateDirectory(parentDir);
+            File.Create(path);
+            return path;
+        }
+
+        public static string CreateDirectory(string baseDir, params string[] names)
+        {
+            string path = JoinPaths(baseDir, names);
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        public static string GetTempDirectory(bool create = true)
+        {
+            // Note that on macOS, Path.GetTempPath() returns a path
+            // under /var that is actually a directory symlink to /private/var.
+            // We should return a manually resolved path instead to ensure
+            // callers can do path comparisons and computations that may resolve
+            // symlinks.
+            string tempDir = PlatformUtils.IsMacOS()
+                ? "/private/tmp"
+                : Path.GetTempPath();
+
+            string unique = GetUuid(8);
+            string path = Path.Combine(tempDir, unique);
+            if (create) Directory.CreateDirectory(path);
+            return path;
+        }
+
+        public static string GetUuid(int length = -1)
+        {
+            string uuid = Guid.NewGuid().ToString("N");
+
+            if (length <= 0 || length > uuid.Length)
+            {
+                return uuid;
+            }
+
+            return uuid.Substring(0, length);
+        }
+    }
+}

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
@@ -12,7 +12,8 @@ namespace Atlassian.Bitbucket.UI
         public static async Task Main(string[] args)
         {
             string appPath = ApplicationBase.GetEntryApplicationPath();
-            using (var context = new CommandContext(appPath))
+            string installDir = ApplicationBase.GetInstallationDirectory();
+            using (var context = new CommandContext(appPath, installDir))
             using (var app = new HelperApplication(context))
             {
                 if (args.Length == 0)

--- a/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
@@ -2,8 +2,6 @@
 using System.Threading.Tasks;
 using GitCredentialManager.UI.Commands;
 using GitCredentialManager.UI.Controls;
-using GitCredentialManager;
-using GitCredentialManager.UI;
 
 namespace GitCredentialManager.UI
 {
@@ -12,7 +10,8 @@ namespace GitCredentialManager.UI
         public static async Task Main(string[] args)
         {
             string appPath = ApplicationBase.GetEntryApplicationPath();
-            using (var context = new CommandContext(appPath))
+            string installDir = ApplicationBase.GetInstallationDirectory();
+            using (var context = new CommandContext(appPath, installDir))
             using (var app = new HelperApplication(context))
             {
                 if (args.Length == 0)

--- a/src/windows/GitHub.UI.Windows/Program.cs
+++ b/src/windows/GitHub.UI.Windows/Program.cs
@@ -12,7 +12,8 @@ namespace GitHub.UI
         public static async Task Main(string[] args)
         {
             string appPath = ApplicationBase.GetEntryApplicationPath();
-            using (var context = new CommandContext(appPath))
+            string installDir = ApplicationBase.GetInstallationDirectory();
+            using (var context = new CommandContext(appPath, installDir))
             using (var app = new HelperApplication(context))
             {
                 if (args.Length == 0)

--- a/src/windows/GitLab.UI.Windows/Program.cs
+++ b/src/windows/GitLab.UI.Windows/Program.cs
@@ -12,7 +12,8 @@ namespace GitLab.UI
         public static async Task Main(string[] args)
         {
             string appPath = ApplicationBase.GetEntryApplicationPath();
-            using (var context = new CommandContext(appPath))
+            string installDir = ApplicationBase.GetInstallationDirectory();
+            using (var context = new CommandContext(appPath, installDir))
             using (var app = new HelperApplication(context))
             {
                 if (args.Length == 0)


### PR DESCRIPTION
When we introduced the rename warning in #551, there was broken logic for resolving the actual invoked program name on Mac and Linux.

**Windows**
We continue to use `CommandLineToArgvW(GetCommandLine(), ..)` to return the _absolute, full path_ to the entry executable.

**macOS**
Switch from `_NSGetArgv()` to `_NSGetExecutablePath(..)` which, like the Windows APIs above, returns the full path to the entry executable (or symlink).

**Linux**
As there is no equivalent to `CommandLineToArgvW` or `_NSGetExecutablePath` here, we instead do some path computation based on the form of `argv[0]` that we get from `/proc/self/cmdline`.
- If the value is an absolute path, just use that.
- If the value is relative to the current directory (`./name`) then combine this with the current directory.
- If the value contains a directory separator (`dir/name`) then also resolve this from the current directory.
- Otherwise, this `argv[0]` value must have been a file name (`name`) resolved from the `$PATH`.

If we still don't manage to resolve from the `$PATH`, try and resolve the symlink `/proc/self/exe` that points to the executable image that was loaded from disk. Note that we may miss any intermediate link names here, but it's better than nothing.

---

In addition, we also never tested the .NET Tool scenario after updating the `ICommandContext.ApplicationPath` to use the entry executable name, whereas previously this was computed from the .NET assembly path.

Introduce a separate concept, the `InstallationDirectory` that always points to the home of the core assemblies. This is used for resolving things like in-box UI helpers.