### PR TITLE
Ensure certificate validation works on Mac/Linux

### DIFF
--- a/src/shared/Core/HttpClientFactory.cs
+++ b/src/shared/Core/HttpClientFactory.cs
@@ -85,7 +85,7 @@ namespace GitCredentialManager
 
 #if NETFRAMEWORK
                 ServicePointManager.ServerCertificateValidationCallback = (req, cert, chain, errors) => true;
-#elif NETSTANDARD
+#else
                 handler.ServerCertificateCustomValidationCallback = (req, cert, chain, errors) => true;
 #endif
             }
@@ -174,7 +174,7 @@ namespace GitCredentialManager
                         return validationCallback(cert2, chain, errors);
                     }
                 };
-#elif NETSTANDARD
+#else
                 handler.ServerCertificateCustomValidationCallback = (_, cert, chain, errors) => validationCallback(cert, chain, errors);
 #endif
             }


### PR DESCRIPTION
In 65cead2b5caa we removed the .NET Standard target in favour of a direct .NET 6 target, however we missed this conditional compilation symbol referrering to `NETSTANDARD`.