### PR TITLE
homebrew: update install location for arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
     - name: Create component package
       run: |
         src/osx/Installer.Mac/pack.sh --payload=payload \
-         --version=$GitBuildVersionSimple \
+         --version=$GitBuildVersionSimple --runtime=${{ matrix.runtime }} \
          --output=components/com.microsoft.gitcredentialmanager.component.pkg
     
     - name: Create product archive

--- a/src/osx/Installer.Mac/build.sh
+++ b/src/osx/Installer.Mac/build.sh
@@ -65,7 +65,7 @@ DISTOUT="$OUTDIR/gcm-$RUNTIME-$VERSION.pkg"
 
 # Layout and pack
 "$INSTALLER_SRC/layout.sh" --configuration="$CONFIGURATION" --output="$PAYLOAD" --runtime="$RUNTIME" || exit 1
-"$INSTALLER_SRC/pack.sh" --payload="$PAYLOAD" --version="$VERSION" --output="$COMPONENTOUT" || exit 1
+"$INSTALLER_SRC/pack.sh" --payload="$PAYLOAD" --version="$VERSION" --output="$COMPONENTOUT" --runtime="$RUNTIME" || exit 1
 "$INSTALLER_SRC/dist.sh" --package-path="$COMPONENTDIR" --version="$VERSION" --output="$DISTOUT" --runtime="$RUNTIME" || exit 1
 
 echo "Build of Installer.Mac complete."

--- a/src/osx/Installer.Mac/pack.sh
+++ b/src/osx/Installer.Mac/pack.sh
@@ -13,7 +13,6 @@ INSTALLER_SRC="$SRC/osx/Installer.Mac"
 
 # Product information
 IDENTIFIER="com.microsoft.gitcredentialmanager"
-INSTALL_LOCATION="/usr/local/share/gcm-core"
 
 # Parse script arguments
 for i in "$@"
@@ -31,11 +30,33 @@ case "$i" in
     PKGOUT="${i#*=}"
     shift # past argument=value
     ;;
+    --runtime=*)
+    RUNTIME="${i#*=}"
+    shift # past argument=value
+    ;;
     *)
           # unknown option
     ;;
 esac
 done
+
+if [ -z "$RUNTIME" ]; then
+    die "--runtime was not set"
+fi
+
+case "$RUNTIME" in
+    "osx-x64")
+        PREFIX="/usr/local"
+        ;;
+    "osx-arm64")
+        PREFIX="/opt/homebrew"
+        ;;
+    *)
+        die "Unknown runtime '$RUNTIME'"
+        ;;
+esac
+
+INSTALL_LOCATION="$PREFIX/share/gcm-core"
 
 # Perform pre-execution checks
 if [ -z "$VERSION" ]; then


### PR DESCRIPTION
Homebrew updated the install location for Apple Silicon machines to
`/opt/homebrew` (instead of `/usr/local`). Pass runtime information to pack.sh
to determine when this new prefix should be used and update the install
location accordingly.