### PR TITLE
Fix various problems with install path and app path variables

### DIFF
--- a/src/shared/Core/ApplicationBase.cs
+++ b/src/shared/Core/ApplicationBase.cs
@@ -91,7 +91,7 @@ namespace GitCredentialManager
 
         public static string GetInstallationDirectory()
         {
-            return Path.GetDirectoryName(Environment.GetCommandLineArgs()[0]);
+            return AppContext.BaseDirectory;
         }
 
         /// <summary>

--- a/src/shared/Core/Authentication/AuthenticationBase.cs
+++ b/src/shared/Core/Authentication/AuthenticationBase.cs
@@ -140,6 +140,11 @@ namespace GitCredentialManager.Authentication
 
                 Context.Trace.WriteLine($"UI helper override specified: '{helperName}'.");
             }
+            else if (string.IsNullOrWhiteSpace(defaultValue))
+            {
+                Context.Trace.WriteLine("No default UI supplied.");
+                return false;
+            }
             else
             {
                 Context.Trace.WriteLine($"Using default UI helper: '{defaultValue}'.");

--- a/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
+++ b/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
@@ -22,7 +22,10 @@ namespace GitCredentialManager.Interop.Windows
 
         protected override string[] SplitPathVariable(string value)
         {
-            return value.Split(';');
+            // Ensure we don't return empty values here - callers may use this as the base
+            // path for `Path.Combine(..)`, for which an empty value means 'current directory'.
+            // We only ever want to use the current directory for path resolution explicitly.
+            return value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         public override void AddDirectoryToPath(string directoryPath, EnvironmentVariableTarget target)

--- a/src/shared/Core/PlatformUtils.cs
+++ b/src/shared/Core/PlatformUtils.cs
@@ -289,7 +289,11 @@ namespace GitCredentialManager
             IntPtr argv0Ptr = Marshal.ReadIntPtr(argvPtr);
             string argv0 = Marshal.PtrToStringAuto(argv0Ptr);
             Interop.Windows.Native.Kernel32.LocalFree(argvPtr);
-            return argv0;
+
+            // If this isn't absolute then we should return null to prevent any
+            // caller that expect only an absolute path from mis-using this result.
+            // They will have to fall-back to other mechanisms for getting the entry path.
+            return Path.IsPathRooted(argv0) ? argv0 : null;
         }
 
         #endregion

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -43,16 +43,24 @@ namespace GitCredentialManager
                 //
                 // On UNIX systems we do the same check, except instead of a copy we use a symlink.
                 //
-                string oldName = PlatformUtils.IsWindows()
-                    ? "git-credential-manager-core.exe"
-                    : "git-credential-manager-core";
 
-                if (appPath?.EndsWith(oldName, StringComparison.OrdinalIgnoreCase) ?? false)
+                if (!string.IsNullOrWhiteSpace(appPath))
                 {
-                    context.Streams.Error.WriteLine(
-                        "warning: git-credential-manager-core was renamed to git-credential-manager");
-                    context.Streams.Error.WriteLine(
-                        $"warning: see {Constants.HelpUrls.GcmExecRename} for more information");
+                    // Trim any (.exe) file extension if we're on Windows
+                    // Note that in some circumstances (like being called by Git when config is set
+                    // to just `helper = manager-core`) we don't always have ".exe" at the end.
+                    if (PlatformUtils.IsWindows() && appPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                    {
+                        appPath = appPath.Substring(0, appPath.Length - 4);
+                    }
+
+                    if (appPath.EndsWith("git-credential-manager-core", StringComparison.OrdinalIgnoreCase))
+                    {
+                        context.Streams.Error.WriteLine(
+                            "warning: git-credential-manager-core was renamed to git-credential-manager");
+                        context.Streams.Error.WriteLine(
+                            $"warning: see {Constants.HelpUrls.GcmExecRename} for more information");
+                    }
                 }
 
                 // Register all supported host providers at the normal priority.


### PR DESCRIPTION
Fix **several** bugs in how we compute the app path and install dir on Windows.

In some cases we can still get a relative/non-absolute path to the entry executable. If we get a filename/non-path from the native API calls then return null and fallback to using process/module image resolution instead. For .NET Framework on Windows, this is OK. We will want to revisit this on .NET (Core) on Windows, if and when we get around to that...

Bug number *two*.. for the install dir, on Windows, when invoked as a partial name (e.g., `manager`) our command line argv[0] is just a file name, not a full file path! We incorrectly assumed that `Environment.GetCommandLineArgs()[0]` was always absolute!
We should instead use `AppContext.BaseDirectory` that, in all circumstances tested, all on TFMs and OSs, all publish options, and as a .NET tool... returns the expected full, absolute path to the installation directory.

Bug number **three** is in the old-name warning detection that only presents on Windows when bundled with Git for Windows, and when configured using the shorthand config `credential.helper=manager-core`. In this scenario, our argv[0] is missing the ".exe" extension (that's actually present in the file name of course) because ... mingw reasons.
Instead of matching "git-credential-manager-core.exe" on Windows, just strip ".exe" if present on Windows, and always match "git-credential-manager-core" on all platforms.

Whilst fixing these three bugs, I also spotted two other potential edge cases that should be fixed..

1. Ensure that we don't return empty `PATH` values on Windows when splitting. It's common that on Windows the `PATH` can be inadvertently modified such that an empty value is included, and this can lead to weird resolution of executables using the current directory.
Thanks for @dscho for spotting this possible issue! This sort of accidental "current directory" resolution is often a cause of security issues - after careful testing, this ends up **not being possible to trigger**, but we should guard for it explicitly to be safe in the future!

3. If there is no hard-coded UI helper, we should gracefully handle the lookup by returning false, rather than crashing due to a argument exception when passing `null` or an empty string to a `System.IO.Path` API.