### PR TITLE
docs: fix debian uninstall instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -84,7 +84,7 @@ git-credential-manager configure
 
 ```shell
 git-credential-manager unconfigure
-sudo dpkg -r gcmcore
+sudo dpkg -r gcm
 ```
 
 ---


### PR DESCRIPTION
Update Debian package uninstall instructions to reflect re-name of GCM Core to GCM.