### PR TITLE
release: correct nupkg path for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -795,5 +795,5 @@ jobs:
 
       - name: Publish .NET tool to nuget.org
         run: |
-          dotnet nuget push dotnet-tool-sign/signed/*.nupkg \
+          dotnet nuget push dotnet-tool-sign/*.nupkg \
             --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
When we began signing the .NET tool in 80cc677, we did not update the path used for publishing to nuget.org. Fixing with this change.