### PR TITLE
secret service: fix error creating credential

### DIFF
--- a/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
+++ b/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
@@ -291,7 +291,6 @@ namespace GitCredentialManager.Interop.Linux
                 if (accountKeyPtr != IntPtr.Zero) Marshal.FreeHGlobal(accountKeyPtr);
                 if (serviceKeyPtr != IntPtr.Zero) Marshal.FreeHGlobal(serviceKeyPtr);
                 if (value != null) secret_value_unref(value);
-                if (passwordPtr != IntPtr.Zero) secret_password_free(passwordPtr);
                 if (error != null) g_error_free(error);
             }
         }


### PR DESCRIPTION
Multiple Linux users have reported that they are unable to use Secret Service as their credential store, as GCM throws the following error:

sec_free: Assertion `cell->requested > 0' failed.

The root cause is that we're using the libsecret secret_value_get function to obtain secret data, then attempting to free the string with secret_password_free. It appears that secret_password_free is only meant to be used to free nonpageable memory [1], however. Removing this call fixes the issue, as verified with a successful git-credential-manager diagnose (which was previously failing with the above error).

[1] secret_password_free manpage
https://www.manpagez.com/html/libsecret-1/libsecret-1-0.18.6/libsecret-Password-storage.php#secret-password-free

Fixes #793 