### PR TITLE
docs(install): fix link to the ".NET tool" section

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -64,7 +64,7 @@ sudo /usr/local/share/gcm-core/uninstall.sh
 
 ### .NET tool :star:
 
-See the [.NET tool](#.NET-tool) section below for instructions on this
+See the [.NET tool](#net-tool) section below for instructions on this
 installation method.
 
 ---


### PR DESCRIPTION
Something I noticed today, while looking for a way to install Git Credential Manager for Windows/ARM64.