### PR TITLE
release: fix tarball signing and Debian compression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,7 +384,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: tmp.linux-build
+        name: linux-build
         path: |
           linux-build
 
@@ -399,7 +399,11 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v3
       with:
-        name: tmp.linux-build
+        name: linux-build
+    
+    - name: Remove symbols
+      run: |
+        rm tar/*symbols*
 
     - uses: azure/login@v1
       with:
@@ -423,6 +427,12 @@ jobs:
       run: |
         python .github/run_esrp_signing.py deb $env:LINUX_KEY_CODE $env:LINUX_OP_CODE
         python .github/run_esrp_signing.py tar $env:LINUX_KEY_CODE $env:LINUX_OP_CODE
+    
+    - name: Re-name tarball signature file
+      shell: bash
+      run: |
+        signaturepath=$(find signed/*.tar.gz)
+        mv "$signaturepath" "${signaturepath%.tar.gz}.asc"
 
     - name: Upload signed tarball and Debian package
       uses: actions/upload-artifact@v3
@@ -624,9 +634,15 @@ jobs:
           - os: ubuntu-latest
             artifact: linux-sign
             command: git-credential-manager
+            description: debian
+          - os: ubuntu-latest
+            artifact: linux-build
+            command: git-credential-manager
+            description: tarball
           - os: macos-latest
             artifact: osx-x64-sign
             command: git-credential-manager
+            description: osx-x64
           - os: windows-latest
             artifact: win-sign
             # Even when a standalone GCM version is installed, GitHub actions
@@ -634,9 +650,11 @@ jobs:
             # Windows due to its placement on the PATH. For this reason, we use
             # the full path to our installation to validate the Windows version.
             command: "$PROGRAMFILES (x86)/Git Credential Manager/git-credential-manager.exe"
+            description: windows
           - os: ubuntu-latest
             artifact: dotnet-tool-sign
             command: git-credential-manager
+            description: dotnet-tool
     runs-on: ${{ matrix.component.os }}
     needs: [ osx-sign, win-sign, linux-sign, dotnet-tool-sign ]
     steps:
@@ -654,7 +672,7 @@ jobs:
           name: ${{ matrix.component.artifact }}
 
       - name: Install Windows
-        if: contains(matrix.component.os, 'windows')
+        if: contains(matrix.component.description, 'windows')
         shell: pwsh
         run: |
           $exePaths = Get-ChildItem -Path ./signed/*.exe | %{$_.FullName}
@@ -663,22 +681,30 @@ jobs:
             Start-Process -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART"
           }
 
-      - name: Install Linux
-        if: contains(matrix.component.os, 'ubuntu') && contains(matrix.component.artifact, 'linux')
+      - name: Install Linux (Debian package)
+        if: contains(matrix.component.description, 'debian')
         run: |
           debpath=$(find ./*.deb)
           sudo apt install $debpath
           "${{ matrix.component.command }}" configure
+      
+      - name: Install Linux (tarball)
+        if: contains(matrix.component.description, 'tarball')
+        run: |
+          # Ensure we find only the source tarball, not the symbols
+          tarpath=$(find ./tar -name '*[[:digit:]].tar.gz')
+          tar -xvf $tarpath -C /usr/local/bin
+          "${{ matrix.component.command }}" configure
 
       - name: Install macOS
-        if: contains(matrix.component.os, 'macos')
+        if: contains(matrix.component.description, 'osx-x64')
         run: |
           # Only validate x64, given arm64 agents are not available
           pkgpath=$(find ./*.pkg)
           sudo installer -pkg $pkgpath -target /
       
       - name: Install .NET tool
-        if: contains(matrix.component.os, 'ubuntu') && contains(matrix.component.artifact, 'dotnet-tool')
+        if: contains(matrix.component.description, 'dotnet-tool')
         run: |
           nupkgpath=$(find ./*.nupkg)
           dotnet tool install -g --add-source $(dirname "$nupkgpath") git-credential-manager
@@ -787,6 +813,7 @@ jobs:
               uploadDirectoryToRelease('osx-payload-and-symbols'),
 
               // Upload Linux artifacts
+              uploadDirectoryToRelease('linux-build/tar'),
               uploadDirectoryToRelease('linux-sign'),
 
               // Upload .NET tool package

--- a/src/linux/Packaging.Linux/pack.sh
+++ b/src/linux/Packaging.Linux/pack.sh
@@ -12,10 +12,6 @@ OUT="$ROOT/out"
 PROJ_OUT="$OUT/linux/Packaging.Linux"
 INSTALLER_SRC="$SRC/osx/Installer.Mac"
 
-# Product information
-IDENTIFIER="com.microsoft.gitcredentialmanager"
-INSTALL_LOCATION="/usr/local/share/gcm-core"
-
 # Parse script arguments
 for i in "$@"
 do
@@ -51,6 +47,10 @@ fi
 
 ARCH="`dpkg-architecture -q DEB_HOST_ARCH`"
 
+if test -z "$ARCH"; then
+    die "Could not determine host architecture!"
+fi
+
 TAROUT="$PROJ_OUT/$CONFIGURATION/tar/"
 TARBALL="$TAROUT/gcm-linux_$ARCH.$VERSION.tar.gz"
 SYMTARBALL="$TAROUT/gcm-linux_$ARCH.$VERSION-symbols.tar.gz"
@@ -59,10 +59,6 @@ DEBOUT="$PROJ_OUT/$CONFIGURATION/deb"
 DEBROOT="$DEBOUT/root"
 DEBPKG="$DEBOUT/gcm-linux_$ARCH.$VERSION.deb"
 mkdir -p "$DEBROOT"
-
-if test -z "$ARCH"; then
-    die "Could not determine host architecture!"
-fi
 
 # Set full read, write, execute permissions for owner and just read and execute permissions for group and other
 echo "Setting file permissions..."
@@ -114,8 +110,6 @@ Description: Cross Platform Git Credential Manager command line utility.
  For more information see https://aka.ms/gcm
 EOF
 
-mkdir -p "$INSTALL_TO" "$LINK_TO"
-
 # Copy all binaries and shared libraries to target installation location
 cp -R "$PAYLOAD"/* "$INSTALL_TO" || exit 1
 
@@ -131,6 +125,6 @@ if [ ! -f "$LINK_TO/git-credential-manager-core" ]; then
         "$LINK_TO/git-credential-manager-core" || exit 1
 fi
 
-dpkg-deb --build "$DEBROOT" "$DEBPKG" || exit 1
+dpkg-deb -Zxz --build "$DEBROOT" "$DEBPKG" || exit 1
 
 echo $MESSAGE


### PR DESCRIPTION
While we added PGP signatures for tarballs in 7baac73, we did not notice
that, while ESRP returns a file with the tar.gz extension, it is actually
the signature file, not the tarball itself. Correct with this change and
validate tarball moving forward so it doesn't happen again!

Additionally, a user reported in #997 that the latest GCM Debian package
didn't work on Debian distributions. It appears that the version of dpkg
that ships with Debian [does not support zstd compression](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=892664). Enforcing xz
compression resolves the issue.
    
Finally, this provided an opportunity to clean up some unused variables in
pack.sh for Linux and to ensure we check the architecture is found before
attemping to use the ARCH variable.

These changes were validated with [this successful test run](https://github.com/ldennington/git-credential-manager/actions/runs/3795232469) in my fork.