### PR TITLE
docs: standardize gitlab documentation

### DIFF
--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -16,7 +16,7 @@ _Unselect_ the 'Confidential' option. Set the 'read_repository' and
 1. Copy the application secret and configure
 `git config --global credential.https://gitlab.example.com.gitLabDevClientSecret
 <APPLICATION_SECRET>`
-1. Configure authentication modes to include 'browser'
+1. Optional if you want to force OAuth:
 `git config --global credential.https://gitlab.example.com.gitLabAuthModes browser`
 1. For good measure, configure
 `git config --global credential.https://gitlab.example.com.provider gitlab`.

--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -12,12 +12,12 @@ or instance level. Specify a name and use a redirect URI of `http://127.0.0.1/`.
 _Unselect_ the 'Confidential' option. Set the 'read_repository' and
 'write_repository' scopes.
 1. Copy the application ID and configure
-`git config --global credential.https://gitlab.example.com.GitLabDevClientId <APPLICATION_ID>`
+`git config --global credential.https://gitlab.example.com.gitLabDevClientId <APPLICATION_ID>`
 1. Copy the application secret and configure
-`git config --global credential.https://gitlab.example.com.GitLabDevClientSecret
+`git config --global credential.https://gitlab.example.com.gitLabDevClientSecret
 <APPLICATION_SECRET>`
 1. Configure authentication modes to include 'browser'
-`git config --global credential.https://gitlab.example.com.GitLabAuthModes browser`
+`git config --global credential.https://gitlab.example.com.gitLabAuthModes browser`
 1. For good measure, configure
 `git config --global credential.https://gitlab.example.com.provider gitlab`.
 This may be necessary to recognise the domain as a GitLab instance.
@@ -27,8 +27,8 @@ This may be necessary to recognise the domain as a GitLab instance.
 ### Clearing config
 
 ```console
-    git config --global --unset-all credential.https://gitlab.example.com.GitLabDevClientId
-    git config --global --unset-all credential.https://gitlab.example.com.GitLabDevClientSecret
+    git config --global --unset-all credential.https://gitlab.example.com.gitLabDevClientId
+    git config --global --unset-all credential.https://gitlab.example.com.gitLabDevClientSecret
     git config --global --unset-all credential.https://gitlab.example.com.provider
 ```
 
@@ -39,23 +39,23 @@ instances, provided by community member [hickford](https://github.com/hickford/)
 
 ```console
 # https://gitlab.freedesktop.org/
-git config --global credential.https://gitlab.freedesktop.org.gitlabdevclientid 6503d8c5a27187628440d44e0352833a2b49bce540c546c22a3378c8f5b74d45
-git config --global credential.https://gitlab.freedesktop.org.gitlabdevclientsecret 2ae9343a034ff1baadaef1e7ce3197776b00746a02ddf0323bb34aca8bff6dc1
+git config --global credential.https://gitlab.freedesktop.org.gitLabDevClientId 6503d8c5a27187628440d44e0352833a2b49bce540c546c22a3378c8f5b74d45
+git config --global credential.https://gitlab.freedesktop.org.gitLabDevClientSecret 2ae9343a034ff1baadaef1e7ce3197776b00746a02ddf0323bb34aca8bff6dc1
 # https://gitlab.gnome.org/
-git config --global credential.https://gitlab.gnome.org.gitlabdevclientid adf21361d32eddc87bf6baf8366f242dfe07a7d4335b46e8e101303364ccc470
-git config --global credential.https://gitlab.gnome.org.gitlabdevclientsecret cdca4678f64e5b0be9febc0d5e7aab0d81d27696d7adb1cf8022ccefd0a58fc0
+git config --global credential.https://gitlab.gnome.org.gitLabDevClientId adf21361d32eddc87bf6baf8366f242dfe07a7d4335b46e8e101303364ccc470
+git config --global credential.https://gitlab.gnome.org.gitLabDevClientSecret cdca4678f64e5b0be9febc0d5e7aab0d81d27696d7adb1cf8022ccefd0a58fc0
 # https://invent.kde.org/
-git config --global credential.https://invent.kde.org.gitlabdevclientid cd7cb4342c7cd83d8c2fcc22c87320f88d0bde14984432ffca07ee24d0bf0699
-git config --global credential.https://invent.kde.org.gitlabdevclientsecret 9cc8440b280c792ac429b3615ae1c8e0702e6b2479056f899d314f05afd94211
+git config --global credential.https://invent.kde.org.gitLabDevClientId cd7cb4342c7cd83d8c2fcc22c87320f88d0bde14984432ffca07ee24d0bf0699
+git config --global credential.https://invent.kde.org.gitLabDevClientSecret 9cc8440b280c792ac429b3615ae1c8e0702e6b2479056f899d314f05afd94211
 # https://salsa.debian.org/
-git config --global credential.https://salsa.debian.org.gitlabdevclientid 213f5fd32c6a14a0328048c0a77cc12c19138cc165ab957fb83d0add74656f89
-git config --global credential.https://salsa.debian.org.gitlabdevclientsecret 3616b974b59451ecf553f951cb7b8e6e3c91c6d84dd3247dcb0183dac93c2a26
+git config --global credential.https://salsa.debian.org.gitLabDevClientId 213f5fd32c6a14a0328048c0a77cc12c19138cc165ab957fb83d0add74656f89
+git config --global credential.https://salsa.debian.org.gitLabDevClientSecret 3616b974b59451ecf553f951cb7b8e6e3c91c6d84dd3247dcb0183dac93c2a26
 # https://gitlab.haskell.org/
-git config --global credential.https://gitlab.haskell.org.gitlabdevclientid 57de5eaab72b3dc447fca8c19cea39527a08e82da5377c2d10a8ebb30b08fa5f
-git config --global credential.https://gitlab.haskell.org.gitlabdevclientsecret 5170a480da8fb7341e0daac94223d4fff549c702efb2f8873d950bb2b88e434f
+git config --global credential.https://gitlab.haskell.org.gitLabDevClientId 57de5eaab72b3dc447fca8c19cea39527a08e82da5377c2d10a8ebb30b08fa5f
+git config --global credential.https://gitlab.haskell.org.gitLabDevClientSecret 5170a480da8fb7341e0daac94223d4fff549c702efb2f8873d950bb2b88e434f
 # https://code.videolan.org/
-git config --global credential.https://code.videolan.org.gitlabdevclientid f35c379241cc20bf9dffecb47990491b62757db4fb96080cddf2461eacb40375
-git config --global credential.https://code.videolan.org.gitlabdevclientsecret 631558ec973c5ef65b78db9f41103f8247dc68d979c86f051c0fe4389e1995e8
+git config --global credential.https://code.videolan.org.gitLabDevClientId f35c379241cc20bf9dffecb47990491b62757db4fb96080cddf2461eacb40375
+git config --global credential.https://code.videolan.org.gitLabDevClientSecret 631558ec973c5ef65b78db9f41103f8247dc68d979c86f051c0fe4389e1995e8
 ```
 
 See also [issue #677](https://github.com/GitCredentialManager/git-credential-manager/issues/677).
@@ -74,7 +74,7 @@ If you have a preferred authentication mode, you can specify
 [credential.gitLabAuthModes][config-gitlab-auth-modes]:
 
 ```console
-git config --global credential.GitLabAuthModes browser
+git config --global credential.gitLabAuthModes browser
 ```
 
 ## Caveats

--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -17,7 +17,7 @@ _Unselect_ the 'Confidential' option. Set the 'read_repository' and
 `git config --global credential.https://gitlab.example.com.GitLabDevClientSecret
 <APPLICATION_SECRET>`
 1. Configure authentication modes to include 'browser'
-`git config --global credential.https://gitlab.example.com.gitLabAuthModes browser`
+`git config --global credential.https://gitlab.example.com.GitLabAuthModes browser`
 1. For good measure, configure
 `git config --global credential.https://gitlab.example.com.provider gitlab`.
 This may be necessary to recognise the domain as a GitLab instance.
@@ -74,7 +74,7 @@ If you have a preferred authentication mode, you can specify
 [credential.gitLabAuthModes][config-gitlab-auth-modes]:
 
 ```console
-git config --global credential.gitlabauthmodes browser
+git config --global credential.GitLabAuthModes browser
 ```
 
 ## Caveats

--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -16,7 +16,7 @@ _Unselect_ the 'Confidential' option. Set the 'read_repository' and
 1. Copy the application secret and configure
 `git config --global credential.https://gitlab.example.com.gitLabDevClientSecret
 <APPLICATION_SECRET>`
-1. Optional if you want to force OAuth:
+1. Optional if you want to force browser auth:
 `git config --global credential.https://gitlab.example.com.gitLabAuthModes browser`
 1. For good measure, configure
 `git config --global credential.https://gitlab.example.com.provider gitlab`.

--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -9,8 +9,7 @@ configuration:
 
 1. [Create an OAuth application][gitlab-oauth]. This can be at the user, group
 or instance level. Specify a name and use a redirect URI of `http://127.0.0.1/`.
-_Unselect_ the 'Confidential' option. Set the 'read_repository' and
-'write_repository' scopes.
+_Unselect_ the 'Confidential' option. Set the 'write_repository' scope.
 1. Copy the application ID and configure
 `git config --global credential.https://gitlab.example.com.GitLabDevClientId <APPLICATION_ID>`
 1. Copy the application secret and configure

--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -2,7 +2,7 @@
 
 Git Credential Manager supports [gitlab.com][gitlab] out the box.
 
-## Using on a another instance
+## Using on another instance
 
 To use on another instance, eg. `https://gitlab.example.com` requires setup and
 configuration:

--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -9,7 +9,8 @@ configuration:
 
 1. [Create an OAuth application][gitlab-oauth]. This can be at the user, group
 or instance level. Specify a name and use a redirect URI of `http://127.0.0.1/`.
-_Unselect_ the 'Confidential' option. Set the 'write_repository' scope.
+_Unselect_ the 'Confidential' option. Set the 'read_repository' and
+'write_repository' scopes.
 1. Copy the application ID and configure
 `git config --global credential.https://gitlab.example.com.GitLabDevClientId <APPLICATION_ID>`
 1. Copy the application secret and configure

--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -9,8 +9,8 @@ configuration:
 
 1. [Create an OAuth application][gitlab-oauth]. This can be at the user, group
 or instance level. Specify a name and use a redirect URI of `http://127.0.0.1/`.
-_Unselect_ the 'Confidential' option. Set the 'write_repository' and
-'read_repository' scopes.
+_Unselect_ the 'Confidential' option. Set the 'read_repository' and
+'write_repository' scopes.
 1. Copy the application ID and configure
 `git config --global credential.https://gitlab.example.com.GitLabDevClientId <APPLICATION_ID>`
 1. Copy the application secret and configure


### PR DESCRIPTION
- Swap scopes order to match GitLab UI
- Update casing to match https://github.com/GitCredentialManager/git-credential-manager/blob/main/docs/configuration.md