### PR TITLE
Git Credential Manager Path Update

### DIFF
--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -22,7 +22,7 @@ _Inside your WSL installation_, run the following command to set GCM as the Git
 credential helper:
 
 ```shell
-git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
+git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-wincred.exe"
 ```
 
 If you intend to use Azure DevOps you must _also_ set the following Git


### PR DESCRIPTION
I am running WSL2 and just installed the latest version of Git For Windows, and this was the path I needed to use.