### PR TITLE
trace2: add infrastructure and initial events

### DIFF
--- a/src/shared/Atlassian.Bitbucket.UI.Avalonia/Program.cs
+++ b/src/shared/Atlassian.Bitbucket.UI.Avalonia/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.CommandLine;
+using System.Diagnostics;
 using System.Threading;
 using Atlassian.Bitbucket.UI.Commands;
 using Atlassian.Bitbucket.UI.Controls;
@@ -45,9 +45,7 @@ namespace Atlassian.Bitbucket.UI
         {
             string[] args = (string[]) o;
 
-            string appPath = ApplicationBase.GetEntryApplicationPath();
-            string installDir = ApplicationBase.GetInstallationDirectory();
-            using (var context = new CommandContext(appPath, installDir))
+            using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {
                 app.RegisterCommand(new CredentialsCommandImpl(context));

--- a/src/shared/Core.Tests/EnvironmentTests.cs
+++ b/src/shared/Core.Tests/EnvironmentTests.cs
@@ -150,5 +150,37 @@ namespace GitCredentialManager.Tests
             Assert.True(actualResult);
             Assert.Equal(expectedPath, actualPath);
         }
+        
+        [PlatformFact(Platforms.Posix)]
+        public void PosixEnvironment_SetEnvironmentVariable_Sets_Expected_Value()
+        {
+            var variable = "FOO_BAR";
+            var value = "baz";
+                
+            var fs = new TestFileSystem();
+            var envars = new Dictionary<string, string>();
+            var env = new PosixEnvironment(fs, envars);
+
+            env.SetEnvironmentVariable(variable, value);
+
+            Assert.Contains(env.Variables, item 
+                => item.Key.Equals(variable) && item.Value.Equals(value));
+        }
+        
+        [PlatformFact(Platforms.Windows)]
+        public void WindowsEnvironment_SetEnvironmentVariable_Sets_Expected_Value()
+        {
+            var variable = "FOO_BAR";
+            var value = "baz";
+                
+            var fs = new TestFileSystem();
+            var envars = new Dictionary<string, string>();
+            var env = new WindowsEnvironment(fs, envars);
+
+            env.SetEnvironmentVariable(variable, value);
+
+            Assert.Contains(env.Variables, item 
+                => item.Key.Equals(variable) && item.Value.Equals(value));
+        }
     }
 }

--- a/src/shared/Core.Tests/StringExtensionsTests.cs
+++ b/src/shared/Core.Tests/StringExtensionsTests.cs
@@ -245,6 +245,7 @@ namespace GitCredentialManager.Tests
         [InlineData("foo://", "://", "")]
         [InlineData("foo://bar", "://", "bar")]
         [InlineData("foo://bar/", "://", "bar/")]
+        [InlineData("foo:/bar/baz", ":", "/bar/baz")]
         public void StringExtensions_TrimUntilLastIndexOf_String(string input, string trim, string expected)
         {
             string actual = StringExtensions.TrimUntilLastIndexOf(input, trim);

--- a/src/shared/Core.Tests/Trace2Tests.cs
+++ b/src/shared/Core.Tests/Trace2Tests.cs
@@ -1,0 +1,24 @@
+using System.Text.RegularExpressions;
+using GitCredentialManager.Tests.Objects;
+using Xunit;
+
+namespace GitCredentialManager.Tests;
+
+public class Trace2Tests
+{
+    [Theory]
+    [InlineData("20190408T191610.507018Z-H9b68c35f-P000059a8")]
+    [InlineData("")]
+    public void SetSid_Envar_Returns_Expected_Value(string parentSid)
+    {
+        Regex rx = new Regex(@$"{parentSid}\/[\d\w-]*");
+
+        var environment = new TestEnvironment();
+        environment.Variables.Add("GIT_TRACE2_PARENT_SID", parentSid);
+
+        var trace2 = new Trace2(environment);
+        var sid = trace2.SetSid();
+
+        Assert.Matches(rx, sid);
+    }
+}

--- a/src/shared/Core.Tests/Trace2Tests.cs
+++ b/src/shared/Core.Tests/Trace2Tests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 using GitCredentialManager.Tests.Objects;
 using Xunit;
@@ -6,6 +7,38 @@ namespace GitCredentialManager.Tests;
 
 public class Trace2Tests
 {
+    [PlatformTheory(Platforms.Posix)]
+    [InlineData("af_unix:foo", "foo")]
+    [InlineData("af_unix:stream:foo-bar", "foo-bar")]
+    [InlineData("af_unix:dgram:foo-bar-baz", "foo-bar-baz")]
+    public void TryParseEventTarget_Posix_Returns_Expected_Value(string input, string expected)
+    {
+        var environment = new TestEnvironment();
+        var settings = new TestSettings();
+
+        var trace2 = new Trace2(environment, settings.GetTrace2Settings(), new []{""}, DateTimeOffset.UtcNow);
+        var isSuccessful = trace2.TryGetPipeName(input, out var actual);
+
+        Assert.True(isSuccessful);
+        Assert.Matches(actual, expected);
+    }
+
+    [PlatformTheory(Platforms.Windows)]
+    [InlineData("\\\\.\\pipe\\git-foo", "git-foo")]
+    [InlineData("\\\\.\\pipe\\git-foo-bar", "git-foo-bar")]
+    [InlineData("\\\\.\\pipe\\foo\\git-bar", "git-bar")]
+    public void TryParseEventTarget_Windows_Returns_Expected_Value(string input, string expected)
+    {
+        var environment = new TestEnvironment();
+        var settings = new TestSettings();
+
+        var trace2 = new Trace2(environment, settings.GetTrace2Settings(), new []{""}, DateTimeOffset.UtcNow);
+        var isSuccessful = trace2.TryGetPipeName(input, out var actual);
+
+        Assert.True(isSuccessful);
+        Assert.Matches(actual, expected);
+    }
+
     [Theory]
     [InlineData("20190408T191610.507018Z-H9b68c35f-P000059a8")]
     [InlineData("")]
@@ -16,7 +49,8 @@ public class Trace2Tests
         var environment = new TestEnvironment();
         environment.Variables.Add("GIT_TRACE2_PARENT_SID", parentSid);
 
-        var trace2 = new Trace2(environment);
+        var settings = new TestSettings();
+        var trace2 = new Trace2(environment, settings.GetTrace2Settings(), new []{""}, DateTimeOffset.UtcNow);
         var sid = trace2.SetSid();
 
         Assert.Matches(rx, sid);

--- a/src/shared/Core.Tests/TraceUtilsTests.cs
+++ b/src/shared/Core.Tests/TraceUtilsTests.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace GitCredentialManager.Tests;
+
+public class TraceUtilsTests
+{
+    [Theory]
+    [InlineData("/foo/bar/baz/boo", 10, "...baz/boo")]
+    [InlineData("thisfileshouldbetruncated", 12, "...truncated")]
+    public void FormatSource_ReturnsExpectedSourceValues(string path, int sourceColumnMaxWidth, string expectedSource)
+    {
+        string actualSource = TraceUtils.FormatSource(path, sourceColumnMaxWidth);
+        Assert.Equal(actualSource, expectedSource);
+    }
+}

--- a/src/shared/Core/ApplicationBase.cs
+++ b/src/shared/Core/ApplicationBase.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.IO.Pipes;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -75,24 +77,15 @@ namespace GitCredentialManager
                 Context.Trace.WriteLine("Tracing of secrets is enabled. Trace output may contain sensitive information.");
             }
 
+            // Enable TRACE2 tracing
+            Context.Trace2.Start(Context.Streams.Error, Context.FileSystem, Context.ApplicationPath);
+
             return RunInternalAsync(args);
         }
 
         protected abstract Task<int> RunInternalAsync(string[] args);
 
         #region Helpers
-
-        public static string GetEntryApplicationPath()
-        {
-            return PlatformUtils.GetNativeEntryPath() ??
-                   Process.GetCurrentProcess().MainModule?.FileName ??
-                   Environment.GetCommandLineArgs()[0];
-        }
-
-        public static string GetInstallationDirectory()
-        {
-            return AppContext.BaseDirectory;
-        }
 
         /// <summary>
         /// Wait until a debugger has attached to the currently executing process.

--- a/src/shared/Core/AssemblyUtils.cs
+++ b/src/shared/Core/AssemblyUtils.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+
+namespace GitCredentialManager;
+
+public static class AssemblyUtils
+{
+    public static bool TryGetAssemblyVersion(out string version)
+    {
+        try
+        {
+            var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+            var assemblyVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            version = assemblyVersionAttribute is null
+                ? assembly.GetName().Version.ToString()
+                : assemblyVersionAttribute.InformationalVersion;
+            return true;
+        }
+        catch
+        {
+            version = null;
+            return false;
+        }
+    }
+}

--- a/src/shared/Core/Commands/DiagnoseCommand.cs
+++ b/src/shared/Core/Commands/DiagnoseCommand.cs
@@ -86,7 +86,7 @@ namespace GitCredentialManager.Commands
             fullLog.WriteLine($"AppPath: {_context.ApplicationPath}");
             fullLog.WriteLine($"InstallDir: {_context.InstallationDirectory}");
             fullLog.WriteLine(
-                TryGetAssemblyVersion(out string version)
+                AssemblyUtils.TryGetAssemblyVersion(out string version)
                     ? $"Version: {version}"
                     : "Version: [!] Failed to get version information [!]"
             );
@@ -196,24 +196,6 @@ namespace GitCredentialManager.Commands
 
             fullLog.Close();
             return numFailed;
-        }
-
-        private bool TryGetAssemblyVersion(out string version)
-        {
-            try
-            {
-                var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
-                var assemblyVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-                version = assemblyVersionAttribute is null
-                    ? assembly.GetName().Version.ToString()
-                    : assemblyVersionAttribute.InformationalVersion;
-                return true;
-            }
-            catch
-            {
-                version = null;
-                return false;
-            }
         }
 
         private static class ConsoleEx

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -54,6 +54,8 @@ namespace GitCredentialManager
             public const string GcmAuthority          = "GCM_AUTHORITY";
             public const string GitTerminalPrompts    = "GIT_TERMINAL_PROMPT";
             public const string GcmAllowWia           = "GCM_ALLOW_WINDOWSAUTH";
+            public const string GitTrace2Event        = "GIT_TRACE2_EVENT";
+            public const string GitTrace2Normal       = "GIT_TRACE2";
 
             /*
              * Unlike other environment variables, these proxy variables are normally lowercase only.
@@ -163,6 +165,13 @@ namespace GitCredentialManager
                 public const string SectionName = "remote";
                 public const string FetchUrl = "url";
                 public const string PushUrl = "pushUrl";
+            }
+
+            public static class Trace2
+            {
+                public const string SectionName = "trace2";
+                public const string EventTarget = "eventtarget";
+                public const string NormalTarget = "normaltarget";
             }
         }
 

--- a/src/shared/Core/EnvironmentBase.cs
+++ b/src/shared/Core/EnvironmentBase.cs
@@ -56,6 +56,15 @@ namespace GitCredentialManager
         /// <param name="workingDirectory">Working directory for the new process.</param>
         /// <returns><see cref="Process"/> object ready to start.</returns>
         Process CreateProcess(string path, string args, bool useShellExecute, string workingDirectory);
+
+        /// <summary>
+        /// Set an environment variable at the specified target level.
+        /// </summary>
+        /// <param name="variable">Name of the environment variable to set.</param>
+        /// <param name="value">Value of the environment variable to set.</param>
+        /// <param name="target">Target level of environment variable to set (Machine, Process, or User).</param>
+        void SetEnvironmentVariable(string variable, string value,
+            EnvironmentVariableTarget target = EnvironmentVariableTarget.Process);
     }
 
     public abstract class EnvironmentBase : IEnvironment
@@ -141,6 +150,16 @@ namespace GitCredentialManager
             path = null;
             return false;
         }
+
+        public void SetEnvironmentVariable(string variable, string value,
+            EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
+        {
+            if (Variables.Keys.Contains(variable)) return;
+            Environment.SetEnvironmentVariable(variable, value, target);
+            Variables = GetCurrentVariables();
+        }
+
+        protected abstract IReadOnlyDictionary<string, string> GetCurrentVariables();
     }
 
     public static class EnvironmentExtensions

--- a/src/shared/Core/ITrace2Writer.cs
+++ b/src/shared/Core/ITrace2Writer.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace GitCredentialManager;
+
+public interface ITrace2Writer : IDisposable
+{
+    bool Failed { get; }
+
+    void Write(Trace2Message message);
+}

--- a/src/shared/Core/Interop/Posix/PosixEnvironment.cs
+++ b/src/shared/Core/Interop/Posix/PosixEnvironment.cs
@@ -1,18 +1,18 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GitCredentialManager.Interop.Posix
 {
     public class PosixEnvironment : EnvironmentBase
     {
         public PosixEnvironment(IFileSystem fileSystem)
-            : this(fileSystem, GetCurrentVariables()) { }
+            : this(fileSystem, null) { }
 
         internal PosixEnvironment(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
             : base(fileSystem)
         {
-            EnsureArgument.NotNull(variables, nameof(variables));
-            Variables = variables;
+            Variables = variables ?? GetCurrentVariables();
         }
 
         #region EnvironmentBase
@@ -34,7 +34,7 @@ namespace GitCredentialManager.Interop.Posix
 
         #endregion
 
-        private static IReadOnlyDictionary<string, string> GetCurrentVariables()
+        protected override IReadOnlyDictionary<string, string> GetCurrentVariables()
         {
             var dict = new Dictionary<string, string>();
             var variables = Environment.GetEnvironmentVariables();

--- a/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
+++ b/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace GitCredentialManager.Interop.Windows
@@ -9,13 +10,12 @@ namespace GitCredentialManager.Interop.Windows
     public class WindowsEnvironment : EnvironmentBase
     {
         public WindowsEnvironment(IFileSystem fileSystem)
-            : this(fileSystem, GetCurrentVariables()) { }
+            : this(fileSystem, null) { }
 
         internal WindowsEnvironment(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
             : base(fileSystem)
         {
-            EnsureArgument.NotNull(variables, nameof(variables));
-            Variables = variables;
+            Variables = variables ?? GetCurrentVariables();
         }
 
         #region EnvironmentBase
@@ -84,7 +84,7 @@ namespace GitCredentialManager.Interop.Windows
 
         #endregion
 
-        private static IReadOnlyDictionary<string, string> GetCurrentVariables()
+        protected override IReadOnlyDictionary<string, string> GetCurrentVariables()
         {
             // On Windows it is technically possible to get env vars which differ only by case
             // even though the general assumption is that they are case insensitive on Windows.

--- a/src/shared/Core/Settings.cs
+++ b/src/shared/Core/Settings.cs
@@ -166,6 +166,12 @@ namespace GitCredentialManager
         /// of host provider auto-detection. Use a zero or negative value to disable probing.
         /// </summary>
         int AutoDetectProviderTimeout { get; }
+
+        /// <summary>
+        /// Get TRACE2 settings.
+        /// </summary>
+        /// <returns>TRACE2 settings object.</returns>
+        Trace2Settings GetTrace2Settings();
     }
 
     public class ProxyConfiguration
@@ -503,6 +509,25 @@ namespace GitCredentialManager
         }
 
         public bool GetTracingEnabled(out string value) => _environment.Variables.TryGetValue(KnownEnvars.GcmTrace, out value) && !value.IsFalsey();
+
+        public Trace2Settings GetTrace2Settings()
+        {
+            var settings = new Trace2Settings();
+
+            if (TryGetSetting(Constants.EnvironmentVariables.GitTrace2Event, KnownGitCfg.Trace2.SectionName,
+                    Constants.GitConfiguration.Trace2.EventTarget, out string value))
+            {
+                settings.FormatTargetsAndValues.Add(Trace2FormatTarget.Event, value);
+            }
+
+            if (TryGetSetting(Constants.EnvironmentVariables.GitTrace2Normal, KnownGitCfg.Trace2.SectionName,
+                    Constants.GitConfiguration.Trace2.NormalTarget, out value))
+            {
+                settings.FormatTargetsAndValues.Add(Trace2FormatTarget.Normal, value);
+            }
+
+            return settings;
+        }
 
         public bool IsSecretTracingEnabled => _environment.Variables.GetBooleanyOrDefault(KnownEnvars.GcmTraceSecrets, false);
 

--- a/src/shared/Core/StringExtensions.cs
+++ b/src/shared/Core/StringExtensions.cs
@@ -228,5 +228,17 @@ namespace GitCredentialManager
 
             return str;
         }
+
+        /// <summary>
+        /// Check whether string contains a specified substring.
+        /// </summary>
+        /// <param name="str">String to check.</param>
+        /// <param name="value">String to locate.</param>
+        /// <param name="comparisonType">Comparison rule for comparing the strings.</param>
+        /// <returns>True if the string contains the substring, false if not.</returns>
+        public static bool Contains(this string str, string value, StringComparison comparisonType)
+        {
+            return str?.IndexOf(value, comparisonType) >= 0;
+        }
     }
 }

--- a/src/shared/Core/Trace.cs
+++ b/src/shared/Core/Trace.cs
@@ -307,22 +307,7 @@ namespace GitCredentialManager
 
             if (source.Length > sourceColumnMaxWidth)
             {
-                int idx = 0;
-                int maxlen = sourceColumnMaxWidth - 3;
-                int srclen = source.Length;
-
-                while (idx >= 0 && (srclen - idx) > maxlen)
-                {
-                    idx = source.IndexOf('\\', idx + 1);
-                }
-
-                // If we cannot find a path separator which allows the path to be long enough, just truncate the file name
-                if (idx < 0)
-                {
-                    idx = srclen - maxlen;
-                }
-
-                source = "..." + source.Substring(idx);
+                source = TraceUtils.FormatSource(source, sourceColumnMaxWidth);
             }
 
             // Git's trace format is "{timestamp,-15} {source,-23} trace: {details}"

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+
+namespace GitCredentialManager;
+
+/// <summary>
+/// The different event types tracked in the TRACE2 tracing
+/// system.
+/// </summary>
+public enum Trace2Event
+{ }
+
+/// <summary>
+/// Represents the application's TRACE2 tracing system.
+/// </summary>
+public interface ITrace2 : IDisposable
+{ }
+
+public class Trace2 : DisposableObject, ITrace2
+{
+    private readonly object _writersLock = new object();
+    private List<ITrace2Writer> _writers = new List<ITrace2Writer>();
+
+    protected override void ReleaseManagedResources()
+    {
+        lock (_writersLock)
+        {
+            try
+            {
+                for (int i = 0; i < _writers.Count; i += 1)
+                {
+                    using (var writer = _writers[i])
+                    {
+                        _writers.Remove(writer);
+                    }
+                }
+            }
+            catch
+            {
+                /* squelch */
+            }
+        }
+
+        base.ReleaseManagedResources();
+    }
+
+    private void AddWriter(ITrace2Writer writer)
+    {
+        ThrowIfDisposed();
+
+        lock (_writersLock)
+        {
+            // Try not to add the same writer more than once
+            if (_writers.Contains(writer))
+                return;
+
+            _writers.Add(writer);
+        }
+    }
+
+    private void WriteMessage(Trace2Message message)
+    {
+        ThrowIfDisposed();
+
+        lock (_writersLock)
+        {
+            if (_writers.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var writer in _writers)
+            {
+                if (!writer.Failed)
+                {
+                    writer.Write(message);
+                }
+            }
+        }
+    }
+}
+
+public abstract class Trace2Message
+{
+    private const int SourceColumnMaxWidth = 23;
+    protected const string TimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'ffffff'Z'";
+
+    [JsonProperty("event", Order = 1)]
+    public Trace2Event Event { get; set; }
+
+    [JsonProperty("sid", Order = 2)]
+    public string Sid { get; set; }
+
+    [JsonProperty("thread", Order = 3)]
+    public string Thread { get; set; }
+
+    [JsonProperty("time", Order = 4)]
+    public DateTimeOffset Time { get; set; }
+
+    [JsonProperty("file", Order = 5)]
+    public string File { get; set; }
+
+    [JsonProperty("line", Order = 6)]
+    public int Line { get; set; }
+}

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -106,4 +106,6 @@ public abstract class Trace2Message
 
     [JsonProperty("line", Order = 6)]
     public int Line { get; set; }
+
+    public abstract string ToJson();
 }

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
 using System.Linq;
+using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
@@ -14,26 +18,54 @@ namespace GitCredentialManager;
 public enum Trace2Event
 { }
 
+public class Trace2Settings
+{
+    public IDictionary<Trace2FormatTarget, string> FormatTargetsAndValues { get; set; } =
+        new Dictionary<Trace2FormatTarget, string>();
+}
+
 /// <summary>
 /// Represents the application's TRACE2 tracing system.
 /// </summary>
 public interface ITrace2 : IDisposable
-{ }
+{
+    /// <summary>
+    /// Initialize TRACE2 tracing by setting up any configured target formats and
+    /// writing Version and Start events.
+    /// </summary>
+    /// <param name="error">The standard error text stream connected back to the calling process.</param>
+    /// <param name="fileSystem">File system abstraction.</param>
+    /// <param name="appPath">The path to the GCM application.</param>
+    void Start(TextWriter error, IFileSystem fileSystem, string appPath);
+}
 
 public class Trace2 : DisposableObject, ITrace2
 {
     private readonly object _writersLock = new object();
-    private List<ITrace2Writer> _writers = new List<ITrace2Writer>();
+    private readonly Encoding _utf8NoBomEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
     private const string GitSidVariable = "GIT_TRACE2_PARENT_SID";
 
+    private List<ITrace2Writer> _writers = new List<ITrace2Writer>();
     private IEnvironment _environment;
+    private Trace2Settings _settings;
+    private string[] _argv;
+    private DateTimeOffset _applicationStartTime;
     private string _sid;
 
-    public Trace2(IEnvironment environment)
+    public Trace2(IEnvironment environment, Trace2Settings settings, string[] argv, DateTimeOffset applicationStartTime)
     {
         _environment = environment;
+        _settings = settings;
+        _argv = argv;
+        _applicationStartTime = applicationStartTime;
+
         _sid = SetSid();
+    }
+
+    public void Start(TextWriter error, IFileSystem fileSystem, string appPath)
+    {
+        TryParseSettings(error, fileSystem);
     }
 
     protected override void ReleaseManagedResources()
@@ -59,20 +91,6 @@ public class Trace2 : DisposableObject, ITrace2
         base.ReleaseManagedResources();
     }
 
-    private void AddWriter(ITrace2Writer writer)
-    {
-        ThrowIfDisposed();
-
-        lock (_writersLock)
-        {
-            // Try not to add the same writer more than once
-            if (_writers.Contains(writer))
-                return;
-
-            _writers.Add(writer);
-        }
-    }
-
     internal string SetSid()
     {
         var sids = new List<string>();
@@ -87,6 +105,77 @@ public class Trace2 : DisposableObject, ITrace2
 
         _environment.SetEnvironmentVariable(GitSidVariable, combinedSid);
         return combinedSid;
+    }
+
+    internal bool TryGetPipeName(string eventTarget, out string name)
+    {
+        // Use prefixes to determine whether target is a named pipe/socket
+        if (eventTarget.Contains("af_unix:", StringComparison.OrdinalIgnoreCase) ||
+            eventTarget.Contains("\\\\.\\pipe\\", StringComparison.OrdinalIgnoreCase) ||
+            eventTarget.Contains("/./pipe/", StringComparison.OrdinalIgnoreCase))
+        {
+            name = PlatformUtils.IsWindows()
+                ? eventTarget.TrimUntilLastIndexOf("\\")
+                : eventTarget.TrimUntilLastIndexOf(":");
+            return true;
+        }
+
+        name = "";
+        return false;
+    }
+
+    private void TryParseSettings(TextWriter error, IFileSystem fileSystem)
+    {
+        // Set up the correct writer for every enabled format target.
+        foreach (var formatTarget in _settings.FormatTargetsAndValues)
+        {
+            if (TryGetPipeName(formatTarget.Value, out string name)) // Write to named pipe/socket
+            {
+                AddWriter(new Trace2CollectorWriter((
+                        () => new NamedPipeClientStream(".", name,
+                            PipeDirection.Out,
+                            PipeOptions.Asynchronous)
+                    )
+                ));
+            }
+            else if (formatTarget.Value.IsTruthy()) // Write to stderr
+            {
+                AddWriter(new Trace2StreamWriter(error, formatTarget.Key));
+            }
+            else if (Path.IsPathRooted(formatTarget.Value)) // Write to file
+            {
+                try
+                {
+                    Stream stream = fileSystem.OpenFileStream(formatTarget.Value, FileMode.Append,
+                        FileAccess.Write, FileShare.ReadWrite);
+                    AddWriter(new Trace2StreamWriter(new StreamWriter(stream, _utf8NoBomEncoding,
+                        4096, leaveOpen: false), formatTarget.Key));
+                }
+                catch (Exception ex)
+                {
+                    error.WriteLine($"warning: unable to trace to file '{formatTarget.Value}': {ex.Message}");
+                }
+            }
+        }
+
+        if (_writers.Count == 0)
+        {
+            error.WriteLine("warning: unable to set up TRACE2 tracing. No traces will be written.");
+        }
+    }
+
+    private void AddWriter(ITrace2Writer writer)
+    {
+        ThrowIfDisposed();
+
+        lock (_writersLock)
+        {
+            // Try not to add the same writer more than once
+            if (_writers.Contains(writer))
+                return;
+
+            _writers.Add(writer);
+        }
     }
 
     private void WriteMessage(Trace2Message message)
@@ -113,7 +202,6 @@ public class Trace2 : DisposableObject, ITrace2
 
 public abstract class Trace2Message
 {
-    private const int SourceColumnMaxWidth = 23;
     protected const string TimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'ffffff'Z'";
 
     [JsonProperty("event", Order = 1)]
@@ -129,6 +217,7 @@ public abstract class Trace2Message
     public DateTimeOffset Time { get; set; }
 
     [JsonProperty("file", Order = 5)]
+
     public string File { get; set; }
 
     [JsonProperty("line", Order = 6)]

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -108,4 +108,6 @@ public abstract class Trace2Message
     public int Line { get; set; }
 
     public abstract string ToJson();
+
+    public abstract string ToNormalString();
 }

--- a/src/shared/Core/Trace2CollectorWriter.cs
+++ b/src/shared/Core/Trace2CollectorWriter.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+using KnownGitCfg = GitCredentialManager.Constants.GitConfiguration;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Accepts string messages from multiple threads and dispatches them over a named pipe from a
+    /// background thread.
+    /// </summary>
+    public class Trace2CollectorWriter : DisposableObject, ITrace2Writer
+    {
+        private const int DefaultMaxQueueSize = 256;
+
+        private readonly Func<NamedPipeClientStream> _createPipeFunc;
+        private readonly BlockingCollection<string> _queue;
+
+        private Thread _writerThread;
+        private NamedPipeClientStream _pipeClient;
+
+        public bool Failed { get; private set; }
+
+        public Trace2CollectorWriter(Func<NamedPipeClientStream> createPipeFunc,
+            int maxQueueSize = DefaultMaxQueueSize)
+        {
+            EnsureArgument.NotNull(createPipeFunc, nameof(createPipeFunc));
+            EnsureArgument.Positive(maxQueueSize, nameof(maxQueueSize));
+
+            _createPipeFunc = createPipeFunc;
+            _queue = new BlockingCollection<string>(new ConcurrentQueue<string>(), boundedCapacity: maxQueueSize);
+
+            Start();
+        }
+        
+        public void Write(Trace2Message message)
+        {
+           _queue.TryAdd(message.ToJson());
+        }
+        
+        protected override void ReleaseManagedResources()
+        {
+            Stop();
+
+            _pipeClient.Dispose();
+            _queue.Dispose();
+            base.ReleaseManagedResources();
+
+            _pipeClient = null;
+            _writerThread = null;
+        }
+
+        private void Start()
+        {
+            try
+            {
+                _writerThread = new Thread(BackgroundWriterThreadProc)
+                {
+                    Name = nameof(Trace2CollectorWriter),
+                    IsBackground = true
+                };
+
+                _writerThread.Start();
+                // Create a new pipe stream instance using the provided factory
+                _pipeClient = _createPipeFunc();
+
+                // Specify an instantaneous timeout because we don't want to hold up the
+                // background thread loop if the pipe is not available.
+                _pipeClient.Connect(timeout: 0);
+            }
+            catch
+            {
+                // Start failed. Disable this writer for this run.
+                Failed = true;
+            }
+        }
+
+        private void Stop()
+        {
+            if (_queue.IsAddingCompleted)
+            {
+                return;
+            }
+
+            // Signal to the queue draining thread that it should drain once more and then terminate.
+            _queue.CompleteAdding();
+            _writerThread.Join();
+            ReleaseManagedResources();
+        }
+
+        private void BackgroundWriterThreadProc()
+        {
+            // Drain the queue of all messages currently in the queue.
+            // TryTake() using an infinite timeout will block until either a message is available (returns true)
+            // or the queue has been marked as completed _and_ is empty (returns false).
+            while (_queue.TryTake(out string message, Timeout.Infinite))
+            {
+                if (message != null)
+                {
+                    WriteMessage(message);
+                }
+            }
+        }
+
+        private void WriteMessage(string message)
+        {
+            try
+            {
+                // We should signal the end of each message with a line-feed (LF) character.
+                if (!message.EndsWith("\n"))
+                {
+                    message += '\n';
+                }
+
+                byte[] data = Encoding.UTF8.GetBytes(message);
+                _pipeClient.Write(data, 0, data.Length);
+                _pipeClient.Flush();
+            }
+            catch
+            {
+                // We can't send this message for some reason (e.g., broken pipe); we attempt no recovery or retry
+                // mechanism but rather disable the writer for the rest of this run.
+                Failed = true;
+            }
+        }
+    }
+}

--- a/src/shared/Core/Trace2StreamWriter.cs
+++ b/src/shared/Core/Trace2StreamWriter.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+
+namespace GitCredentialManager;
+
+/// <summary>
+/// The different format targets supported in the TRACE2 tracing
+/// system.
+/// </summary>
+public enum Trace2FormatTarget
+{
+    Event,
+    Normal
+}
+
+public class Trace2StreamWriter : DisposableObject, ITrace2Writer
+{
+    private readonly TextWriter _writer;
+    private readonly Trace2FormatTarget _formatTarget;
+
+    public bool Failed { get; private set; }
+
+    public Trace2StreamWriter(TextWriter writer, Trace2FormatTarget formatTarget)
+    {
+        _writer = writer;
+        _formatTarget = formatTarget;
+    }
+
+    public void Write(Trace2Message message)
+    {
+        try
+        {
+            _writer.Write(Format(message));
+            _writer.Write('\n');
+            _writer.Flush();
+        }
+        catch
+        {
+            Failed = true;
+        }
+    }
+
+    protected override void ReleaseManagedResources()
+    {
+        _writer.Dispose();
+        base.ReleaseManagedResources();
+    }
+
+    private string Format(Trace2Message message)
+    {
+        EnsureArgument.NotNull(message, nameof(message));
+
+        switch (_formatTarget)
+        {
+            case Trace2FormatTarget.Event:
+                return message.ToJson();
+            case Trace2FormatTarget.Normal:
+                return message.ToNormalString();
+            default:
+                Console.WriteLine($"warning: unrecognized format target '{_formatTarget}', disabling TRACE2 tracing.");
+                Failed = true;
+                return "";
+        }
+    }
+}

--- a/src/shared/Core/TraceUtils.cs
+++ b/src/shared/Core/TraceUtils.cs
@@ -1,0 +1,24 @@
+namespace GitCredentialManager;
+
+public static class TraceUtils
+{
+    public static string FormatSource(string source, int sourceColumnMaxWidth)
+    {
+        int idx = 0;
+        int maxlen = sourceColumnMaxWidth - 3;
+        int srclen = source.Length;
+
+        while (idx >= 0 && (srclen - idx) > maxlen)
+        {
+            idx = source.IndexOf('\\', idx + 1);
+        }
+
+        // If we cannot find a path separator which allows the path to be long enough, just truncate the file name
+        if (idx < 0)
+        {
+            idx = srclen - maxlen;
+        }
+
+        return "..." + source.Substring(idx);
+    }
+}

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using Avalonia;
 using GitCredentialManager.UI.Commands;
@@ -42,9 +43,7 @@ namespace GitCredentialManager.UI
         {
             string[] args = (string[]) o;
 
-            string appPath = ApplicationBase.GetEntryApplicationPath();
-            string installDir = ApplicationBase.GetInstallationDirectory();
-            using (var context = new CommandContext(appPath, installDir))
+            using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {
                 app.RegisterCommand(new CredentialsCommandImpl(context));

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -75,6 +75,7 @@ namespace GitCredentialManager
                                   .GetAwaiter()
                                   .GetResult();
 
+                context.Trace2.Stop(exitCode);
                 Environment.Exit(exitCode);
             }
         }

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -11,9 +11,7 @@ namespace GitCredentialManager
     {
         public static void Main(string[] args)
         {
-            string appPath = ApplicationBase.GetEntryApplicationPath();
-            string installDir = ApplicationBase.GetInstallationDirectory();
-            using (var context = new CommandContext(appPath, installDir))
+            using (var context = new CommandContext(args))
             using (var app = new Application(context))
             {
                 // Workaround for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2560
@@ -31,7 +29,7 @@ namespace GitCredentialManager
                         );
                     }
                 }
-
+                
                 //
                 // Git Credential Manager's executable used to be named "git-credential-manager-core" before
                 // dropping the "-core" suffix. In order to prevent "helper not found" errors for users who
@@ -43,18 +41,19 @@ namespace GitCredentialManager
                 //
                 // On UNIX systems we do the same check, except instead of a copy we use a symlink.
                 //
-
-                if (!string.IsNullOrWhiteSpace(appPath))
+                if (!string.IsNullOrWhiteSpace(context.ApplicationPath))
                 {
                     // Trim any (.exe) file extension if we're on Windows
                     // Note that in some circumstances (like being called by Git when config is set
                     // to just `helper = manager-core`) we don't always have ".exe" at the end.
-                    if (PlatformUtils.IsWindows() && appPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                    if (PlatformUtils.IsWindows() && context.ApplicationPath.EndsWith(".exe",
+                            StringComparison.OrdinalIgnoreCase))
                     {
-                        appPath = appPath.Substring(0, appPath.Length - 4);
+                        context.ApplicationPath = context.ApplicationPath
+                            .Substring(0, context.ApplicationPath.Length - 4);
                     }
-
-                    if (appPath.EndsWith("git-credential-manager-core", StringComparison.OrdinalIgnoreCase))
+                    if (context.ApplicationPath.EndsWith("git-credential-manager-core",
+                            StringComparison.OrdinalIgnoreCase))
                     {
                         context.Streams.Error.WriteLine(
                             "warning: git-credential-manager-core was renamed to git-credential-manager");

--- a/src/shared/GitHub.UI.Avalonia/Program.cs
+++ b/src/shared/GitHub.UI.Avalonia/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using Avalonia;
 using GitHub.UI.Controls;
@@ -44,9 +45,7 @@ namespace GitHub.UI
         {
             string[] args = (string[]) o;
 
-            string appPath = ApplicationBase.GetEntryApplicationPath();
-            string installDir = ApplicationBase.GetInstallationDirectory();
-            using (var context = new CommandContext(appPath, installDir))
+            using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {
                 app.RegisterCommand(new CredentialsCommandImpl(context));

--- a/src/shared/GitLab.UI.Avalonia/Program.cs
+++ b/src/shared/GitLab.UI.Avalonia/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using Avalonia;
 using GitLab.UI.Controls;
@@ -43,10 +44,7 @@ namespace GitLab.UI
         private static void AppMain(object o)
         {
             string[] args = (string[]) o;
-
-            string appPath = ApplicationBase.GetEntryApplicationPath();
-            string installDir = ApplicationBase.GetInstallationDirectory();
-            using (var context = new CommandContext(appPath, installDir))
+            using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {
                 app.RegisterCommand(new CredentialsCommandImpl(context));

--- a/src/shared/TestInfrastructure/Objects/NullTrace.cs
+++ b/src/shared/TestInfrastructure/Objects/NullTrace.cs
@@ -47,13 +47,17 @@ namespace GitCredentialManager.Tests.Objects
 
         #endregion
     }
-    
+
     public class NullTrace2 : ITrace2
     {
         #region ITrace2
         public void AddWriter(ITrace2Writer writer) { }
-        
-        public void Start(TextWriter error, IFileSystem fileSystem, string appPath) { }
+
+        public void Start(TextWriter error,
+            IFileSystem fileSystem,
+            string appPath,
+            string filePath = "",
+            int lineNumber = 0) { }
 
         #endregion
 

--- a/src/shared/TestInfrastructure/Objects/NullTrace.cs
+++ b/src/shared/TestInfrastructure/Objects/NullTrace.cs
@@ -59,6 +59,8 @@ namespace GitCredentialManager.Tests.Objects
             string filePath = "",
             int lineNumber = 0) { }
 
+        public void Stop(int exitCode, string fileName, int lineNumber) { }
+
         #endregion
 
         #region IDisposable

--- a/src/shared/TestInfrastructure/Objects/NullTrace.cs
+++ b/src/shared/TestInfrastructure/Objects/NullTrace.cs
@@ -47,4 +47,20 @@ namespace GitCredentialManager.Tests.Objects
 
         #endregion
     }
+    
+    public class NullTrace2 : ITrace2
+    {
+        #region ITrace2
+        public void AddWriter(ITrace2Writer writer) { }
+        
+        public void Start(TextWriter error, IFileSystem fileSystem, string appPath) { }
+
+        #endregion
+
+        #region IDisposable
+
+        void IDisposable.Dispose() { }
+
+        #endregion
+    }
 }

--- a/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
+++ b/src/shared/TestInfrastructure/Objects/TestCommandContext.cs
@@ -33,6 +33,7 @@ namespace GitCredentialManager.Tests.Objects
         public TestTerminal Terminal { get; set; }
         public TestSessionManager SessionManager { get; set; }
         public ITrace Trace { get; set; }
+        public ITrace2 Trace2 { get; set; }
         public TestFileSystem FileSystem { get; set; }
         public TestCredentialStore CredentialStore { get; set; }
         public TestHttpClientFactory HttpClientFactory { get; set; }
@@ -41,7 +42,11 @@ namespace GitCredentialManager.Tests.Objects
 
         #region ICommandContext
 
-        string ICommandContext.ApplicationPath => AppPath;
+        string ICommandContext.ApplicationPath
+        {
+            get => AppPath;
+            set => AppPath = value;
+        }
 
         string ICommandContext.InstallationDirectory => InstallDir;
 

--- a/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
+++ b/src/shared/TestInfrastructure/Objects/TestEnvironment.cs
@@ -116,6 +116,14 @@ namespace GitCredentialManager.Tests.Objects
 
             return new Process { StartInfo = psi };
         }
+        
+        public void SetEnvironmentVariable(string variable, string value,
+            EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
+        {
+            if (Variables.Keys.Contains(variable)) return;
+            Environment.SetEnvironmentVariable(variable, value, target);
+            Variables.Add(variable, value);
+        }
 
         #endregion
     }

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -46,6 +46,16 @@ namespace GitCredentialManager.Tests.Objects
         public bool UseCustomCertificateBundleWithSchannel { get; set; }
 
         public int AutoDetectProviderTimeout { get; set; } = Constants.DefaultAutoDetectProviderTimeoutMs;
+        public Trace2Settings GetTrace2Settings()
+        {
+            return new Trace2Settings()
+            {
+                FormatTargetsAndValues = new Dictionary<Trace2FormatTarget, string>()
+                {
+                    { Trace2FormatTarget.Event, "foo" }
+                }
+            };
+        }
 
         #region ISettings
 

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Atlassian.Bitbucket.UI.Commands;
 using Atlassian.Bitbucket.UI.Controls;
@@ -11,9 +12,7 @@ namespace Atlassian.Bitbucket.UI
     {
         public static async Task Main(string[] args)
         {
-            string appPath = ApplicationBase.GetEntryApplicationPath();
-            string installDir = ApplicationBase.GetInstallationDirectory();
-            using (var context = new CommandContext(appPath, installDir))
+            using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {
                 if (args.Length == 0)

--- a/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using GitCredentialManager.UI.Commands;
 using GitCredentialManager.UI.Controls;
@@ -9,9 +10,7 @@ namespace GitCredentialManager.UI
     {
         public static async Task Main(string[] args)
         {
-            string appPath = ApplicationBase.GetEntryApplicationPath();
-            string installDir = ApplicationBase.GetInstallationDirectory();
-            using (var context = new CommandContext(appPath, installDir))
+            using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {
                 if (args.Length == 0)

--- a/src/windows/GitHub.UI.Windows/Program.cs
+++ b/src/windows/GitHub.UI.Windows/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using GitHub.UI.Commands;
 using GitHub.UI.Controls;
@@ -11,9 +12,7 @@ namespace GitHub.UI
     {
         public static async Task Main(string[] args)
         {
-            string appPath = ApplicationBase.GetEntryApplicationPath();
-            string installDir = ApplicationBase.GetInstallationDirectory();
-            using (var context = new CommandContext(appPath, installDir))
+            using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {
                 if (args.Length == 0)

--- a/src/windows/GitLab.UI.Windows/Program.cs
+++ b/src/windows/GitLab.UI.Windows/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using GitLab.UI.Commands;
 using GitLab.UI.Controls;
@@ -11,9 +12,7 @@ namespace GitLab.UI
     {
         public static async Task Main(string[] args)
         {
-            string appPath = ApplicationBase.GetEntryApplicationPath();
-            string installDir = ApplicationBase.GetInstallationDirectory();
-            using (var context = new CommandContext(appPath, installDir))
+            using (var context = new CommandContext(args))
             using (var app = new HelperApplication(context))
             {
                 if (args.Length == 0)


### PR DESCRIPTION
Add initial `TRACE2` functionality, including:

1. Small refactorings to make `TryGetAssemblyVersion` accessible
outside of the `DiagnosticCommand` class and shared trace logic
accessible from a `TraceUtils` class.
2. Addition of a `Trace2CollectorWriter` class, which handles writing
to the Telemetry Tool/OTel collector and a `Trace2StreamWriter` class,
which handles writing to stderr/files.
3. Basic `TRACE2` functionality, including the ability to add writers to
different format targets, logic to send messages to these writers, and
the ability to release these writers before application exit.
4. Support for session IDs.
5. Ability for users to enable normal/event format targets.
6. Writing `Version`, `Start`, and `Exit` events.

While this patch series does not represent all the `TRACE2` events we plan
to implement, it does provide the opportunity to review and suggest changes
to the foundation these events are built on. It also provides the general pattern
that additional patches will use to implement new events, just in case that
needs to be tweaked.