### PR TITLE
docs: update git credential cache platforms

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,7 +442,7 @@ _(unset)_|Windows: `wincredman`, macOS: `keychain`, Linux: _(none)_|-
 `keychain`|macOS Keychain.|macOS
 `secretservice`|[freedesktop.org Secret Service API][freedesktop-ss] via [libsecret][libsecret] (requires a graphical interface to unlock secret collections).|Linux
 `gpg`|Use GPG to store encrypted files that are compatible with the [pass][pass] (requires GPG and `pass` to initialize the store).|macOS, Linux
-`cache`|Git's built-in [credential cache][credential-cache].|Windows, macOS, Linux
+`cache`|Git's built-in [credential cache][credential-cache].|macOS, Linux
 `plaintext`|Store credentials in plaintext files (**UNSECURE**). Customize the plaintext store location with [`credential.plaintextStorePath`][credential-plaintextstorepath].|Windows, macOS, Linux
 
 #### Example


### PR DESCRIPTION
GCM's documentation states that git's credential cache is supported on Windows. Unfortunately, due to lack of Unix socket support on Windows versions prior to Windows 10, this feature is not currently supported on Windows, so this change removes it from the list of platforms on which this credstore can be used. See [this issue](https://github.com/git-for-windows/git/issues/3892) for more details.