### PR TITLE
linux: ensure symbols tarball contains symbols

### DIFF
--- a/src/linux/Packaging.Linux/build.sh
+++ b/src/linux/Packaging.Linux/build.sh
@@ -44,6 +44,7 @@ fi
 
 OUTDIR="$INSTALLER_OUT/$CONFIGURATION"
 PAYLOAD="$OUTDIR/payload"
+SYMBOLS="$OUTDIR/payload.sym"
 
 # Lay out payload
 "$INSTALLER_SRC/layout.sh" --configuration="$CONFIGURATION" || exit 1
@@ -78,7 +79,7 @@ if [ $INSTALL_FROM_SOURCE = true ]; then
     echo "Install complete."
 else
     # Pack
-    "$INSTALLER_SRC/pack.sh" --configuration="$CONFIGURATION" --payload="$PAYLOAD" --version="$VERSION" || exit 1
+    "$INSTALLER_SRC/pack.sh" --configuration="$CONFIGURATION" --payload="$PAYLOAD" --symbols="$SYMBOLS" --version="$VERSION" || exit 1
 fi
 
 echo "Build of Packaging.Linux complete."

--- a/src/linux/Packaging.Linux/pack.sh
+++ b/src/linux/Packaging.Linux/pack.sh
@@ -24,6 +24,10 @@ case "$i" in
     PAYLOAD="${i#*=}"
     shift # past argument=value
     ;;
+    --symbols=*)
+    SYMBOLS="${i#*=}"
+    shift # past argument=value
+    ;;
     --configuration=*)
     CONFIGURATION="${i#*=}"
     shift # past argument=value
@@ -43,6 +47,9 @@ if [ -z "$PAYLOAD" ]; then
     die "--payload was not set"
 elif [ ! -d "$PAYLOAD" ]; then
     die "Could not find '$PAYLOAD'. Did you run layout.sh first?"
+fi
+if [ -z "$SYMBOLS" ]; then
+    die "--symbols was not set"
 fi
 
 ARCH="`dpkg-architecture -q DEB_HOST_ARCH`"
@@ -83,7 +90,7 @@ popd
 
 # Build symbols tarball
 echo "Building symbols tarball..."
-pushd "$SYMBOLOUT"
+pushd "$SYMBOLS"
 tar -czvf "$SYMTARBALL" * || exit 1
 popd
 


### PR DESCRIPTION
[A user pointed out](https://github.com/GitCredentialManager/git-credential-manager/issues/1028#issuecomment-1382862721) in a recent GCM issue that our symbols tarball does not actually contain symbols. Fix the `pack.sh` script to use a variable defined from a new input parameter to package the correct files into the symbols tarball.

I tested this fix locally and with [this workflow in my fork](https://github.com/ldennington/git-credential-manager/actions/runs/4027108956).