### PR TITLE
Add OAuth support to generic host provider

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ The following are links to GCM user support documentation:
 - [Host provider specification][gcm-host-provider]
 - [Azure Repos OAuth tokens][gcm-azure-tokens]
 - [GitLab support][gcm-gitlab]
+- [Generic OAuth support][gcm-oauth]
 
 [gcm-azure-tokens]: azrepos-users-and-tokens.md
 [gcm-config]: configuration.md
@@ -23,4 +24,5 @@ The following are links to GCM user support documentation:
 [gcm-gitlab]: gitlab.md
 [gcm-host-provider]: hostprovider.md
 [gcm-net-config]: netconfig.md
+[gcm-oauth]: generic-oauth.md
 [gcm-usage]: usage.md

--- a/docs/generic-oauth.md
+++ b/docs/generic-oauth.md
@@ -1,0 +1,116 @@
+# Generic Host Provider OAuth
+
+Many Git hosts use the popular standard OAuth2 or OpenID Connect (OIDC)
+authentication mechanisms to secure repositories they host.
+Git Credential Manager supports any generic OAuth2-based Git host by simply
+setting some configuration.
+
+## Registering an OAuth application
+
+In order to use GCM with a Git host that supports OAuth you must first have
+registered an OAuth application with your host. The instructions on how to do
+this can be found with your Git host provider's documentation.
+
+When registering a new application, you should make sure to set an HTTP-based
+redirect URL that points to `localhost`; for example:
+
+```text
+http://localhost
+http://localhost:<port>
+http://127.0.0.1
+http://127.0.0.1:<port>
+```
+
+Note that you cannot use an HTTPS redirect URL. GCM does not require a specific
+port number be used; if your Git host requires you to specify a port number in
+the redirect URL then GCM will use that. Otherwise an available port will be
+selected at the point authentication starts.
+
+You must ensure that all scopes required to read and write to Git repositories
+have been granted for the application or else credentials that are generated
+will cause errors when pushing or fetching using Git.
+
+As part of the registration process you should also be given a Client ID and,
+optionally, a Client Secret. You will need both of these to configure GCM.
+
+## Configure GCM
+
+In order to configure GCM to use OAuth with your Git host you need to set the
+following values in your Git configuration:
+
+- Client ID
+- Client Secret (optional)
+- Redirect URL
+- Scopes (optional)
+- OAuth Endpoints
+  - Authorization Endpoint
+  - Token Endpoint
+  - Device Code Authorization Endpoint (optional)
+
+OAuth endpoints can be found by consulting your Git host's OAuth app development
+documentation. The URLs can be either absolute or relative to the host name;
+for example: `https://example.com/oauth/authorize` or `/oauth/authorize`.
+
+In order to set these values, you can run the following commands, where `<HOST>`
+is the hostname of your Git host:
+
+```shell
+git config --global credential.<HOST>.oauthClientId <ClientID>
+git config --global credential.<HOST>.oauthClientSecret <ClientSecret>
+git config --global credential.<HOST>.oauthRedirectUri <RedirectURL>
+git config --global credential.<HOST>.oauthAuthorizeEndpoint <AuthEndpoint>
+git config --global credential.<HOST>.oauthTokenEndpoint <TokenEndpoint>
+git config --global credential.<HOST>.oauthScopes <Scopes>
+git config --global credential.<HOST>.oauthDeviceEndpoint <DeviceEndpoint>
+```
+
+**Example commands:**
+
+- `git config --global credential.https://example.com.oauthClientId C33F2751FB76`
+
+- `git config --global credential.https://example.com.oauthScopes "code:write profile:read"`
+
+**Example Git configuration**
+
+```ini
+[credential "https://example.com"]
+    oauthClientId = 9d886e36-5771-4f2b-8c8b-420c68ad5baa
+    oauthClientSecret = 4BC5BD4704EAE28FD832
+    oauthRedirectUri = "http://127.0.0.1"
+    oauthAuthorizeEndpoint = "/login/oauth/authorize"
+    oauthTokenEndpoint = "/login/oauth/token"
+    oauthDeviceEndpoint = "/login/oauth/device"
+    oauthScopes = "code:write profile:read"
+    oauthDefaultUserName = "OAUTH"
+    oauthUseClientAuthHeader = false
+```
+
+### Additional configuration
+
+Depending on the specific implementation of OAuth with your Git host you may
+also need to specify additional behavior.
+
+#### Token user name
+
+If your Git host requires that you specify a username to use with OAuth tokens
+you can either include the username in the Git remote URL, or specify a default
+option via Git configuration.
+
+Example Git remote with username: `https://username@example.com/repo.git`.
+In order to use special characters you need to URL encode the values; for
+example `@` becomes `%40`.
+
+By default GCM uses the value `OAUTH-USER` unless specified in the remote URL,
+or overriden using the `credential.<HOST>.oauthDefaultUserName` configuration.
+
+#### Include client authentication in headers
+
+If your Git host's OAuth implementation has specific requirements about whether
+the client ID and secret should or should not be included in an `Authorization`
+header during OAuth requests, you can control this using the following setting:
+
+```shell
+git config --global credential.<HOST>.oauthUseClientAuthHeader <true|false>
+```
+
+The default behavior is to include these values; i.e., `true`.

--- a/src/shared/Core.Tests/GenericHostProviderTests.cs
+++ b/src/shared/Core.Tests/GenericHostProviderTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using GitCredentialManager.Authentication;
+using GitCredentialManager.Authentication.OAuth;
 using GitCredentialManager.Tests.Objects;
 using Moq;
 using Xunit;
@@ -183,6 +185,90 @@ namespace GitCredentialManager.Tests
         public async Task GenericHostProvider_CreateCredentialAsync_WiaNotSupported_ReturnsBasicCredential()
         {
             await TestCreateCredentialAsync_ReturnsBasicCredential(wiaSupported: false);
+        }
+
+        [Fact]
+        public async Task GenericHostProvider_GenerateCredentialAsync_OAuth_CompleteOAuthConfig_UsesOAuth()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"]     = "git.example.com",
+                ["path"]     = "foo"
+            });
+
+            const string testUserName = "TEST_OAUTH_USER";
+            const string testAcessToken = "OAUTH_TOKEN";
+            const string testRefreshToken = "OAUTH_REFRESH_TOKEN";
+            const string testResource = "https://git.example.com/foo";
+            const string expectedRefreshTokenService = "https://refresh_token.git.example.com/foo";
+
+            var authMode = OAuthAuthenticationModes.Browser;
+            string[] scopes = { "code:write", "code:read" };
+            string clientId = "3eadfc62-9e91-45d3-8c60-20ccd6d0c7cf";
+            string clientSecret = "C1DA8B93CCB5F5B93DA";
+            string redirectUri = "http://localhost";
+            string authzEndpoint = "/oauth/authorize";
+            string tokenEndpoint = "/oauth/token";
+            string deviceEndpoint = "/oauth/device";
+
+            string GetKey(string name) => $"{Constants.GitConfiguration.Credential.SectionName}.https://example.com.{name}";
+
+            var context = new TestCommandContext
+            {
+                Git =
+                {
+                    Configuration =
+                    {
+                        Global =
+                        {
+                            [GetKey(Constants.GitConfiguration.Credential.OAuthClientId)] = new[] { clientId },
+                            [GetKey(Constants.GitConfiguration.Credential.OAuthClientSecret)] = new[] { clientSecret },
+                            [GetKey(Constants.GitConfiguration.Credential.OAuthRedirectUri)] = new[] { redirectUri },
+                            [GetKey(Constants.GitConfiguration.Credential.OAuthScopes)] = new[] { string.Join(' ', scopes) },
+                            [GetKey(Constants.GitConfiguration.Credential.OAuthAuthzEndpoint)] = new[] { authzEndpoint },
+                            [GetKey(Constants.GitConfiguration.Credential.OAuthTokenEndpoint)] = new[] { tokenEndpoint },
+                            [GetKey(Constants.GitConfiguration.Credential.OAuthDeviceEndpoint)] = new[] { deviceEndpoint },
+                            [GetKey(Constants.GitConfiguration.Credential.OAuthDefaultUserName)] = new[] { testUserName },
+                        }
+                    }
+                },
+                Settings =
+                {
+                    RemoteUri = new Uri(testResource)
+                }
+            };
+
+            var basicAuthMock = new Mock<IBasicAuthentication>();
+            var wiaAuthMock = new Mock<IWindowsIntegratedAuthentication>();
+            var oauthMock = new Mock<IOAuthAuthentication>();
+            oauthMock.Setup(x =>
+                x.GetAuthenticationModeAsync(It.IsAny<string>(), It.IsAny<OAuthAuthenticationModes>()))
+                .ReturnsAsync(authMode);
+            oauthMock.Setup(x => x.GetTokenByBrowserAsync(It.IsAny<OAuth2Client>(), It.IsAny<string[]>()))
+                .ReturnsAsync(new OAuth2TokenResult(testAcessToken, "access_token")
+                {
+                    Scopes = scopes,
+                    RefreshToken = testRefreshToken
+                });
+
+            var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object, oauthMock.Object);
+
+            ICredential credential = await provider.GenerateCredentialAsync(input);
+
+            Assert.NotNull(credential);
+            Assert.Equal(testUserName, credential.Account);
+            Assert.Equal(testAcessToken, credential.Password);
+
+            Assert.True(context.CredentialStore.TryGet(expectedRefreshTokenService, null, out TestCredential refreshToken));
+            Assert.Equal(testUserName, refreshToken.Account);
+            Assert.Equal(testRefreshToken, refreshToken.Password);
+
+            oauthMock.Verify(x => x.GetAuthenticationModeAsync(testResource, OAuthAuthenticationModes.All), Times.Once);
+            oauthMock.Verify(x => x.GetTokenByBrowserAsync(It.IsAny<OAuth2Client>(), scopes), Times.Once);
+            oauthMock.Verify(x => x.GetTokenByDeviceCodeAsync(It.IsAny<OAuth2Client>(), scopes), Times.Never);
+            wiaAuthMock.Verify(x => x.GetIsSupportedAsync(It.IsAny<Uri>()), Times.Never);
+            basicAuthMock.Verify(x => x.GetCredentialsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         #region Helpers

--- a/src/shared/Core.Tests/GenericHostProviderTests.cs
+++ b/src/shared/Core.Tests/GenericHostProviderTests.cs
@@ -87,8 +87,9 @@ namespace GitCredentialManager.Tests
                 .ReturnsAsync(basicCredential)
                 .Verifiable();
             var wiaAuthMock = new Mock<IWindowsIntegratedAuthentication>();
+            var oauthMock = new Mock<IOAuthAuthentication>();
 
-            var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object);
+            var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object, oauthMock.Object);
 
             ICredential credential = await provider.GenerateCredentialAsync(input);
 
@@ -121,8 +122,9 @@ namespace GitCredentialManager.Tests
                 .ReturnsAsync(basicCredential)
                 .Verifiable();
             var wiaAuthMock = new Mock<IWindowsIntegratedAuthentication>();
+            var oauthMock = new Mock<IOAuthAuthentication>();
 
-            var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object);
+            var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object, oauthMock.Object);
 
             ICredential credential = await provider.GenerateCredentialAsync(input);
 
@@ -152,8 +154,9 @@ namespace GitCredentialManager.Tests
                 .ReturnsAsync(basicCredential)
                 .Verifiable();
             var wiaAuthMock = new Mock<IWindowsIntegratedAuthentication>();
+            var oauthMock = new Mock<IOAuthAuthentication>();
 
-            var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object);
+            var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object, oauthMock.Object);
 
             ICredential credential = await provider.GenerateCredentialAsync(input);
 
@@ -199,8 +202,9 @@ namespace GitCredentialManager.Tests
             var wiaAuthMock = new Mock<IWindowsIntegratedAuthentication>();
             wiaAuthMock.Setup(x => x.GetIsSupportedAsync(It.IsAny<Uri>()))
                        .ReturnsAsync(wiaSupported);
+            var oauthMock = new Mock<IOAuthAuthentication>();
 
-            var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object);
+            var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object, oauthMock.Object);
 
             ICredential credential = await provider.GenerateCredentialAsync(input);
 
@@ -230,8 +234,9 @@ namespace GitCredentialManager.Tests
             var wiaAuthMock = new Mock<IWindowsIntegratedAuthentication>();
             wiaAuthMock.Setup(x => x.GetIsSupportedAsync(It.IsAny<Uri>()))
                        .ReturnsAsync(wiaSupported);
+            var oauthMock = new Mock<IOAuthAuthentication>();
 
-            var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object);
+            var provider = new GenericHostProvider(context, basicAuthMock.Object, wiaAuthMock.Object, oauthMock.Object);
 
             ICredential credential = await provider.GenerateCredentialAsync(input);
 

--- a/src/shared/Core.Tests/GenericOAuthConfigTests.cs
+++ b/src/shared/Core.Tests/GenericOAuthConfigTests.cs
@@ -1,0 +1,61 @@
+using System;
+using GitCredentialManager.Tests.Objects;
+using Xunit;
+
+namespace GitCredentialManager.Tests
+{
+    public class GenericOAuthConfigTests
+    {
+        [Fact]
+        public void GenericOAuthConfig_TryGet_Valid_ReturnsTrue()
+        {
+            var remoteUri = new Uri("https://example.com");
+            const string expectedClientId = "115845b0-77f8-4c06-a3dc-7d277381fad1";
+            const string expectedClientSecret = "4D35385D9F24";
+            const string expectedUserName = "TEST_USER";
+            const string authzEndpoint = "/oauth/authorize";
+            const string tokenEndpoint = "/oauth/token";
+            const string deviceEndpoint = "/oauth/device";
+            string[] expectedScopes = { "scope1", "scope2" };
+            var expectedRedirectUri = new Uri("http://localhost:12345");
+            var expectedAuthzEndpoint = new Uri(remoteUri, authzEndpoint);
+            var expectedTokenEndpoint = new Uri(remoteUri, tokenEndpoint);
+            var expectedDeviceEndpoint = new Uri(remoteUri, deviceEndpoint);
+
+            string GetKey(string name) => $"{Constants.GitConfiguration.Credential.SectionName}.https://example.com.{name}";
+
+            var trace = new NullTrace();
+            var settings = new TestSettings
+            {
+                GitConfiguration = new TestGitConfiguration
+                {
+                    Global =
+                    {
+                        [GetKey(Constants.GitConfiguration.Credential.OAuthClientId)] = new[] { expectedClientId },
+                        [GetKey(Constants.GitConfiguration.Credential.OAuthClientSecret)] = new[] { expectedClientSecret },
+                        [GetKey(Constants.GitConfiguration.Credential.OAuthRedirectUri)] = new[] { expectedRedirectUri.ToString() },
+                        [GetKey(Constants.GitConfiguration.Credential.OAuthScopes)] = new[] { string.Join(' ', expectedScopes) },
+                        [GetKey(Constants.GitConfiguration.Credential.OAuthAuthzEndpoint)] = new[] { authzEndpoint },
+                        [GetKey(Constants.GitConfiguration.Credential.OAuthTokenEndpoint)] = new[] { tokenEndpoint },
+                        [GetKey(Constants.GitConfiguration.Credential.OAuthDeviceEndpoint)] = new[] { deviceEndpoint },
+                        [GetKey(Constants.GitConfiguration.Credential.OAuthDefaultUserName)] = new[] { expectedUserName },
+                    }
+                },
+                RemoteUri = remoteUri
+            };
+
+            bool result = GenericOAuthConfig.TryGet(trace, settings, remoteUri, out GenericOAuthConfig config);
+
+            Assert.True(result);
+            Assert.Equal(expectedClientId, config.ClientId);
+            Assert.Equal(expectedClientSecret, config.ClientSecret);
+            Assert.Equal(expectedRedirectUri, config.RedirectUri);
+            Assert.Equal(expectedScopes, config.Scopes);
+            Assert.Equal(expectedAuthzEndpoint, config.Endpoints.AuthorizationEndpoint);
+            Assert.Equal(expectedTokenEndpoint, config.Endpoints.TokenEndpoint);
+            Assert.Equal(expectedDeviceEndpoint, config.Endpoints.DeviceAuthorizationEndpoint);
+            Assert.Equal(expectedUserName, config.DefaultUserName);
+            Assert.True(config.UseAuthHeader);
+        }
+    }
+}

--- a/src/shared/Core.UI/Commands/DeviceCodeCommand.cs
+++ b/src/shared/Core.UI/Commands/DeviceCodeCommand.cs
@@ -1,0 +1,52 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager.UI.ViewModels;
+
+namespace GitCredentialManager.UI.Commands
+{
+    public abstract class DeviceCodeCommand : HelperCommand
+    {
+        protected DeviceCodeCommand(ICommandContext context)
+            : base(context, "device", "Show device code prompt.")
+        {
+            AddOption(
+                new Option<string>("--code", "User code.")
+            );
+
+            AddOption(
+                new Option<string>("--url", "Verification URL.")
+            );
+
+            AddOption(
+                new Option("--no-logo", "Hide the Git Credential Manager logo and logotype.")
+            );
+
+            Handler = CommandHandler.Create<string, string, bool>(ExecuteAsync);
+        }
+
+        private async Task<int> ExecuteAsync(string code, string url, bool noLogo)
+        {
+            var viewModel = new DeviceCodeViewModel(Context.Environment)
+            {
+                UserCode = code,
+                VerificationUrl = url,
+            };
+
+            viewModel.ShowProductHeader = !noLogo;
+
+            await ShowAsync(viewModel, CancellationToken.None);
+
+            if (!viewModel.WindowResult)
+            {
+                throw new Exception("User cancelled dialog.");
+            }
+
+            return 0;
+        }
+
+        protected abstract Task ShowAsync(DeviceCodeViewModel viewModel, CancellationToken ct);
+    }
+}

--- a/src/shared/Core.UI/Commands/OAuthCommand.cs
+++ b/src/shared/Core.UI/Commands/OAuthCommand.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager.Authentication;
+using GitCredentialManager.UI.ViewModels;
+
+namespace GitCredentialManager.UI.Commands
+{
+    public abstract class OAuthCommand : HelperCommand
+    {
+        protected OAuthCommand(ICommandContext context)
+            : base(context, "oauth", "Show OAuth authentication prompt.")
+        {
+            AddOption(
+                new Option<string>("--title", "Window title (optional).")
+            );
+
+            AddOption(
+                new Option<string>("--resource", "Resource name or URL (optional).")
+            );
+
+            AddOption(
+                new Option("--browser", "Show browser authentication option.")
+            );
+
+            AddOption(
+                new Option("--device-code", "Show device code authentication option.")
+            );
+
+            AddOption(
+                new Option("--no-logo", "Hide the Git Credential Manager logo and logotype.")
+            );
+
+            Handler = CommandHandler.Create<CommandOptions>(ExecuteAsync);
+        }
+
+        private class CommandOptions
+        {
+            public string Title { get; set; }
+            public string Resource { get; set; }
+            public bool Browser { get; set; }
+            public bool DeviceCode { get; set; }
+            public bool NoLogo { get; set; }
+        }
+
+        private async Task<int> ExecuteAsync(CommandOptions options)
+        {
+            var viewModel = new OAuthViewModel();
+
+            viewModel.Title = !string.IsNullOrWhiteSpace(options.Title)
+                ? options.Title
+                : "Git Credential Manager";
+
+            viewModel.Description = !string.IsNullOrWhiteSpace(options.Resource)
+                ? $"Sign in to '{options.Resource}'"
+                : "Select a sign-in option";
+
+            viewModel.ShowBrowserLogin = options.Browser;
+            viewModel.ShowDeviceCodeLogin = options.DeviceCode;
+            viewModel.ShowProductHeader = !options.NoLogo;
+
+            await ShowAsync(viewModel, CancellationToken.None);
+
+            if (!viewModel.WindowResult)
+            {
+                throw new Exception("User cancelled dialog.");
+            }
+
+            var result = new Dictionary<string, string>();
+            switch (viewModel.SelectedMode)
+            {
+                case OAuthAuthenticationModes.Browser:
+                    result["mode"] = "browser";
+                    break;
+
+                case OAuthAuthenticationModes.DeviceCode:
+                    result["mode"] = "devicecode";
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            WriteResult(result);
+            return 0;
+        }
+
+        protected abstract Task ShowAsync(OAuthViewModel viewModel, CancellationToken ct);
+    }
+}

--- a/src/shared/Core.UI/ViewModels/CredentialsViewModel.cs
+++ b/src/shared/Core.UI/ViewModels/CredentialsViewModel.cs
@@ -56,7 +56,7 @@ namespace GitCredentialManager.UI.ViewModels
         public bool ShowProductHeader
         {
             get => _showProductHeader;
-            set => _showProductHeader = value;
+            set => SetAndRaisePropertyChanged(ref _showProductHeader, value);
         }
 
         public RelayCommand SignInCommand

--- a/src/shared/Core.UI/ViewModels/DeviceCodeViewModel.cs
+++ b/src/shared/Core.UI/ViewModels/DeviceCodeViewModel.cs
@@ -1,0 +1,58 @@
+using System.Windows.Input;
+
+namespace GitCredentialManager.UI.ViewModels
+{
+    public class DeviceCodeViewModel : WindowViewModel
+    {
+        private readonly IEnvironment _environment;
+
+        private ICommand _verificationUrlCommand;
+        private string _verificationUrl;
+        private string _userCode;
+        private bool _showProductHeader;
+
+        public DeviceCodeViewModel()
+        {
+            // Constructor the XAML designer
+        }
+
+        public DeviceCodeViewModel(IEnvironment environment)
+        {
+            EnsureArgument.NotNull(environment, nameof(environment));
+
+            _environment = environment;
+
+            Title = "Device code authentication";
+            VerificationUrlCommand = new RelayCommand(OpenVerificationUrl);
+        }
+
+        private void OpenVerificationUrl()
+        {
+            BrowserUtils.OpenDefaultBrowser(_environment, VerificationUrl);
+        }
+
+        public string UserCode
+        {
+            get => _userCode;
+            set => SetAndRaisePropertyChanged(ref _userCode, value);
+        }
+
+        public string VerificationUrl
+        {
+            get => _verificationUrl;
+            set => SetAndRaisePropertyChanged(ref _verificationUrl, value);
+        }
+
+        public ICommand VerificationUrlCommand
+        {
+            get => _verificationUrlCommand;
+            set => SetAndRaisePropertyChanged(ref _verificationUrlCommand, value);
+        }
+
+        public bool ShowProductHeader
+        {
+            get => _showProductHeader;
+            set => SetAndRaisePropertyChanged(ref _showProductHeader, value);
+        }
+    }
+}

--- a/src/shared/Core.UI/ViewModels/OAuthViewModel.cs
+++ b/src/shared/Core.UI/ViewModels/OAuthViewModel.cs
@@ -1,0 +1,70 @@
+using GitCredentialManager.Authentication;
+
+namespace GitCredentialManager.UI.ViewModels
+{
+    public class OAuthViewModel : WindowViewModel
+    {
+        private string _description;
+        private bool _showProductHeader;
+        private bool _showBrowserLogin;
+        private bool _showDeviceCodeLogin;
+        private RelayCommand _signInBrowserCommand;
+        private RelayCommand _signInDeviceCodeCommand;
+
+        public OAuthViewModel()
+        {
+            SignInBrowserCommand = new RelayCommand(SignInWithBrowser);
+            SignInDeviceCodeCommand = new RelayCommand(SignInWithDeviceCode);
+        }
+
+        private void SignInWithBrowser()
+        {
+            SelectedMode = OAuthAuthenticationModes.Browser;
+            Accept();
+        }
+
+        private void SignInWithDeviceCode()
+        {
+            SelectedMode = OAuthAuthenticationModes.DeviceCode;
+            Accept();
+        }
+
+        public string Description
+        {
+            get => _description;
+            set => SetAndRaisePropertyChanged(ref _description, value);
+        }
+
+        public bool ShowProductHeader
+        {
+            get => _showProductHeader;
+            set => SetAndRaisePropertyChanged(ref _showProductHeader, value);
+        }
+
+        public bool ShowBrowserLogin
+        {
+            get => _showBrowserLogin;
+            set => SetAndRaisePropertyChanged(ref _showBrowserLogin, value);
+        }
+
+        public bool ShowDeviceCodeLogin
+        {
+            get => _showDeviceCodeLogin;
+            set => SetAndRaisePropertyChanged(ref _showDeviceCodeLogin, value);
+        }
+
+        public RelayCommand SignInBrowserCommand
+        {
+            get => _signInBrowserCommand;
+            set => SetAndRaisePropertyChanged(ref _signInBrowserCommand, value);
+        }
+
+        public RelayCommand SignInDeviceCodeCommand
+        {
+            get => _signInDeviceCodeCommand;
+            set => SetAndRaisePropertyChanged(ref _signInDeviceCodeCommand, value);
+        }
+
+        public OAuthAuthenticationModes SelectedMode { get; private set; }
+    }
+}

--- a/src/shared/Core/Authentication/OAuthAuthentication.cs
+++ b/src/shared/Core/Authentication/OAuthAuthentication.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager.Authentication.OAuth;
+
+namespace GitCredentialManager.Authentication
+{
+    [Flags]
+    public enum OAuthAuthenticationModes
+    {
+        None        = 0,
+        Browser     = 1 << 0,
+        DeviceCode  = 1 << 1,
+
+        All = Browser | DeviceCode
+    }
+
+    public interface IOAuthAuthentication
+    {
+        Task<OAuthAuthenticationModes> GetAuthenticationModeAsync(string resource, OAuthAuthenticationModes modes);
+
+        Task<OAuth2TokenResult> GetTokenByBrowserAsync(OAuth2Client client, string[] scopes);
+
+        Task<OAuth2TokenResult> GetTokenByDeviceCodeAsync(OAuth2Client client, string[] scopes);
+    }
+
+    public class OAuthAuthentication : AuthenticationBase, IOAuthAuthentication
+    {
+        public OAuthAuthentication(ICommandContext context)
+            : base (context) { }
+
+        public async Task<OAuthAuthenticationModes> GetAuthenticationModeAsync(
+            string resource, OAuthAuthenticationModes modes)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(resource, nameof(resource));
+
+            ThrowIfUserInteractionDisabled();
+
+            // Browser requires a desktop session!
+            if (!Context.SessionManager.IsDesktopSession)
+            {
+                modes &= ~OAuthAuthenticationModes.Browser;
+            }
+
+            // We need at least one mode!
+            if (modes == OAuthAuthenticationModes.None)
+            {
+                throw new ArgumentException(@$"Must specify at least one {nameof(OAuthAuthenticationModes)}", nameof(modes));
+            }
+
+            // If there is no mode choice to be made then just return that result
+            if (modes == OAuthAuthenticationModes.Browser ||
+                modes == OAuthAuthenticationModes.DeviceCode)
+            {
+                return modes;
+            }
+
+            ThrowIfTerminalPromptsDisabled();
+
+            switch (modes)
+            {
+                case OAuthAuthenticationModes.Browser:
+                    return OAuthAuthenticationModes.Browser;
+
+                case OAuthAuthenticationModes.DeviceCode:
+                    return OAuthAuthenticationModes.DeviceCode;
+
+                default:
+                    var menuTitle = $"Select an authentication method for '{resource}'";
+                    var menu = new TerminalMenu(Context.Terminal, menuTitle);
+
+                    TerminalMenuItem browserItem = null;
+                    TerminalMenuItem deviceItem = null;
+
+                    if ((modes & OAuthAuthenticationModes.Browser)    != 0) browserItem = menu.Add("Web browser");
+                    if ((modes & OAuthAuthenticationModes.DeviceCode) != 0) deviceItem  = menu.Add("Device code");
+
+                    // Default to the 'first' choice in the menu
+                    TerminalMenuItem choice = menu.Show(0);
+
+                    if (choice == browserItem) goto case OAuthAuthenticationModes.Browser;
+                    if (choice == deviceItem)  goto case OAuthAuthenticationModes.DeviceCode;
+
+                    throw new Exception();
+            }
+            
+        }
+
+        public async Task<OAuth2TokenResult> GetTokenByBrowserAsync(OAuth2Client client, string[] scopes)
+        {
+            ThrowIfUserInteractionDisabled();
+
+            // We require a desktop session to launch the user's default web browser
+            if (!Context.SessionManager.IsDesktopSession)
+            {
+                throw new InvalidOperationException("Browser authentication requires a desktop session");
+            }
+
+            var browserOptions = new OAuth2WebBrowserOptions();
+            var browser = new OAuth2SystemWebBrowser(Context.Environment, browserOptions);
+            var authCode = await client.GetAuthorizationCodeAsync(scopes, browser, CancellationToken.None);
+            return await client.GetTokenByAuthorizationCodeAsync(authCode, CancellationToken.None);
+        }
+
+        public async Task<OAuth2TokenResult> GetTokenByDeviceCodeAsync(OAuth2Client client, string[] scopes)
+        {
+            ThrowIfUserInteractionDisabled();
+
+            OAuth2DeviceCodeResult dcr = await client.GetDeviceCodeAsync(scopes, CancellationToken.None);
+
+            ThrowIfTerminalPromptsDisabled();
+
+            string deviceMessage = $"To complete authentication please visit {dcr.VerificationUri} and enter the following code:" +
+                                    Environment.NewLine +
+                                    dcr.UserCode;
+            Context.Terminal.WriteLine(deviceMessage);
+
+            return await client.GetTokenByDeviceCodeAsync(dcr, CancellationToken.None);
+        }
+    }
+}

--- a/src/shared/Core/Constants.cs
+++ b/src/shared/Core/Constants.cs
@@ -89,6 +89,16 @@ namespace GitCredentialManager
             public const string GcmAutoDetectTimeout  = "GCM_AUTODETECT_TIMEOUT";
             public const string GcmGuiPromptsEnabled  = "GCM_GUI_PROMPT";
             public const string GcmUiHelper           = "GCM_UI_HELPER";
+            public const string OAuthAuthenticationModes = "GCM_OAUTH_AUTHMODES";
+            public const string OAuthClientId            = "GCM_OAUTH_CLIENTID";
+            public const string OAuthClientSecret        = "GCM_OAUTH_CLIENTSECRET";
+            public const string OAuthRedirectUri         = "GCM_OAUTH_REDIRECTURI";
+            public const string OAuthScopes              = "GCM_OAUTH_SCOPES";
+            public const string OAuthAuthzEndpoint       = "GCM_OAUTH_AUTHORIZE_ENDPOINT";
+            public const string OAuthTokenEndpoint       = "GCM_OAUTH_TOKEN_ENDPOINT";
+            public const string OAuthDeviceEndpoint      = "GCM_OAUTH_DEVICE_ENDPOINT";
+            public const string OAuthClientAuthHeader    = "GCM_OAUTH_USE_CLIENT_AUTH_HEADER";
+            public const string OAuthDefaultUserName     = "GCM_OAUTH_DEFAULT_USERNAME";
         }
 
         public static class Http
@@ -125,6 +135,17 @@ namespace GitCredentialManager
                 public const string AutoDetectTimeout = "autoDetectTimeout";
                 public const string GuiPromptsEnabled = "guiPrompt";
                 public const string UiHelper = "uiHelper";
+
+                public const string OAuthAuthenticationModes = "oauthAuthModes";
+                public const string OAuthClientId            = "oauthClientId";
+                public const string OAuthClientSecret        = "oauthClientSecret";
+                public const string OAuthRedirectUri         = "oauthRedirectUri";
+                public const string OAuthScopes              = "oauthScopes";
+                public const string OAuthAuthzEndpoint       = "oauthAuthorizeEndpoint";
+                public const string OAuthTokenEndpoint       = "oauthTokenEndpoint";
+                public const string OAuthDeviceEndpoint      = "oauthDeviceEndpoint";
+                public const string OAuthClientAuthHeader    = "oauthUseClientAuthHeader";
+                public const string OAuthDefaultUserName     = "oauthDefaultUserName";
             }
 
             public static class Http

--- a/src/shared/Core/GenericHostProvider.cs
+++ b/src/shared/Core/GenericHostProvider.cs
@@ -26,8 +26,6 @@ namespace GitCredentialManager
             _winAuth = winAuth;
         }
 
-        #region HostProvider
-
         public override string Id => "generic";
 
         public override string Name => "Generic";
@@ -50,12 +48,29 @@ namespace GitCredentialManager
 
             Uri uri = input.GetRemoteUri();
 
-            // Determine the if the host supports Windows Integration Authentication (WIA)
+            // Determine the if the host supports Windows Integration Authentication (WIA) or OAuth
             if (!StringComparer.OrdinalIgnoreCase.Equals(uri.Scheme, "http") &&
                 !StringComparer.OrdinalIgnoreCase.Equals(uri.Scheme, "https"))
             {
-                // Cannot check WIA support for non-HTTP based protocols
+                // Cannot check WIA or OAuth support for non-HTTP based protocols
             }
+            // Check for an OAuth configuration for this remote
+            else if (GenericOAuthConfig.TryGet(Context.Trace, Context.Settings, uri, out GenericOAuthConfig oauthConfig))
+            {
+                Context.Trace.WriteLine($"Found generic OAuth configuration for '{uri}':");
+                Context.Trace.WriteLine($"\tAuthzEndpoint   = {oauthConfig.Endpoints.AuthorizationEndpoint}");
+                Context.Trace.WriteLine($"\tTokenEndpoint   = {oauthConfig.Endpoints.TokenEndpoint}");
+                Context.Trace.WriteLine($"\tDeviceEndpoint  = {oauthConfig.Endpoints.DeviceAuthorizationEndpoint}");
+                Context.Trace.WriteLine($"\tClientId        = {oauthConfig.ClientId}");
+                Context.Trace.WriteLine($"\tClientSecret    = {oauthConfig.ClientSecret}");
+                Context.Trace.WriteLine($"\tRedirectUri     = {oauthConfig.RedirectUri}");
+                Context.Trace.WriteLine($"\tScopes          = [{string.Join(", ", oauthConfig.Scopes)}]");
+                Context.Trace.WriteLine($"\tUseAuthHeader   = {oauthConfig.UseAuthHeader}");
+                Context.Trace.WriteLine($"\tDefaultUserName = {oauthConfig.DefaultUserName}");
+
+                throw new NotImplementedException();
+            }
+            // Try detecting WIA for this remote, if permitted
             else if (IsWindowsAuthAllowed)
             {
                 if (PlatformUtils.IsWindows())
@@ -86,6 +101,7 @@ namespace GitCredentialManager
                 Context.Trace.WriteLine("Windows Integrated Authentication detection has been disabled.");
             }
 
+            // Use basic authentication
             Context.Trace.WriteLine("Prompting for basic credentials...");
             return await _basicAuth.GetCredentialsAsync(uri.AbsoluteUri, input.UserName);
         }
@@ -120,7 +136,5 @@ namespace GitCredentialManager
             _winAuth.Dispose();
             base.ReleaseManagedResources();
         }
-
-        #endregion
     }
 }

--- a/src/shared/Core/GenericOAuthConfig.cs
+++ b/src/shared/Core/GenericOAuthConfig.cs
@@ -1,0 +1,138 @@
+using System;
+using GitCredentialManager.Authentication.OAuth;
+
+namespace GitCredentialManager
+{
+    public class GenericOAuthConfig
+    {
+        public static bool TryGet(ITrace trace, ISettings settings, Uri remoteUri, out GenericOAuthConfig config)
+        {
+            config = new GenericOAuthConfig();
+
+            if (!settings.TryGetSetting(
+                    Constants.EnvironmentVariables.OAuthAuthzEndpoint,
+                    Constants.GitConfiguration.Credential.SectionName,
+                    Constants.GitConfiguration.Credential.OAuthAuthzEndpoint,
+                    out string authzEndpoint) ||
+                !Uri.TryCreate(remoteUri, authzEndpoint, out Uri authzEndpointUri))
+            {
+                trace.WriteLine($"Invalid OAuth configuration - missing/invalid authorize endpoint: {authzEndpoint}");
+                config = null;
+                return false;
+            }
+
+            if (!settings.TryGetSetting(
+                    Constants.EnvironmentVariables.OAuthTokenEndpoint,
+                    Constants.GitConfiguration.Credential.SectionName,
+                    Constants.GitConfiguration.Credential.OAuthTokenEndpoint,
+                    out string tokenEndpoint) ||
+                !Uri.TryCreate(remoteUri, tokenEndpoint, out Uri tokenEndpointUri))
+            {
+                trace.WriteLine($"Invalid OAuth configuration - missing/invalid token endpoint: {tokenEndpoint}");
+                config = null;
+                return false;
+            }
+
+            // Device code endpoint is optional
+            Uri deviceEndpointUri = null;
+            if (settings.TryGetSetting(
+                    Constants.EnvironmentVariables.OAuthDeviceEndpoint,
+                    Constants.GitConfiguration.Credential.SectionName,
+                    Constants.GitConfiguration.Credential.OAuthDeviceEndpoint,
+                    out string deviceEndpoint))
+            {
+                if (!Uri.TryCreate(remoteUri, deviceEndpoint, out deviceEndpointUri))
+                {
+                    trace.WriteLine($"Invalid OAuth configuration - invalid device endpoint: {deviceEndpoint}");
+                }
+            }
+
+            config.Endpoints = new OAuth2ServerEndpoints(authzEndpointUri, tokenEndpointUri)
+            {
+                DeviceAuthorizationEndpoint = deviceEndpointUri
+            };
+
+            if (settings.TryGetSetting(
+                    Constants.EnvironmentVariables.OAuthClientId,
+                    Constants.GitConfiguration.Credential.SectionName,
+                    Constants.GitConfiguration.Credential.OAuthClientId,
+                    out string clientId))
+            {
+                config.ClientId = clientId;
+            }
+
+            if (settings.TryGetSetting(
+                    Constants.EnvironmentVariables.OAuthClientSecret,
+                    Constants.GitConfiguration.Credential.SectionName,
+                    Constants.GitConfiguration.Credential.OAuthClientSecret,
+                    out string clientSecret))
+            {
+                config.ClientSecret = clientSecret;
+            }
+
+            if (settings.TryGetSetting(
+                    Constants.EnvironmentVariables.OAuthRedirectUri,
+                    Constants.GitConfiguration.Credential.SectionName,
+                    Constants.GitConfiguration.Credential.OAuthRedirectUri,
+                    out string redirectUrl) &&
+                Uri.TryCreate(redirectUrl, UriKind.Absolute, out Uri redirectUri))
+            {
+                config.RedirectUri = redirectUri;
+            }
+            else
+            {
+                trace.WriteLine($"Invalid OAuth configuration - missing/invalid redirect URI: {redirectUrl}");
+                config = null;
+                return false;
+            }
+
+            if (settings.TryGetSetting(
+                    Constants.EnvironmentVariables.OAuthScopes,
+                    Constants.GitConfiguration.Credential.SectionName,
+                    Constants.GitConfiguration.Credential.OAuthScopes,
+                    out string scopesStr) && !string.IsNullOrWhiteSpace(scopesStr))
+            {
+                config.Scopes = scopesStr.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                config.Scopes = Array.Empty<string>();
+            }
+
+            if (settings.TryGetSetting(
+                    Constants.EnvironmentVariables.OAuthClientAuthHeader,
+                    Constants.GitConfiguration.Credential.SectionName,
+                    Constants.GitConfiguration.Credential.OAuthClientAuthHeader,
+                    out string useHeader))
+            {
+                config.UseAuthHeader = useHeader.IsTruthy();
+            }
+            else
+            {
+                // Default to true
+                config.UseAuthHeader = true;
+            }
+
+            config.DefaultUserName = settings.TryGetSetting(
+                Constants.EnvironmentVariables.OAuthDefaultUserName,
+                Constants.GitConfiguration.Credential.SectionName,
+                Constants.GitConfiguration.Credential.OAuthDefaultUserName,
+                out string userName)
+                ? userName
+                : "OAUTH_USER";
+
+            return true;
+        }
+
+
+        public OAuth2ServerEndpoints Endpoints { get; set; }
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+        public Uri RedirectUri { get; set; }
+        public string[] Scopes { get; set; }
+        public bool UseAuthHeader { get; set; }
+        public string DefaultUserName { get; set; }
+
+        public bool SupportsDeviceCode => Endpoints.DeviceAuthorizationEndpoint != null;
+    }
+}

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Commands/DeviceCodeCommandImpl.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Commands/DeviceCodeCommandImpl.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager.UI.ViewModels;
+using GitCredentialManager.UI.Views;
+
+namespace GitCredentialManager.UI.Commands
+{
+    public class DeviceCodeCommandImpl : DeviceCodeCommand
+    {
+        public DeviceCodeCommandImpl(ICommandContext context) : base(context) { }
+
+        protected override Task ShowAsync(DeviceCodeViewModel viewModel, CancellationToken ct)
+        {
+            return AvaloniaUi.ShowViewAsync<DeviceCodeView>(viewModel, GetParentHandle(), ct);
+        }
+    }
+}

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Commands/OAuthCommandImpl.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Commands/OAuthCommandImpl.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager.UI.ViewModels;
+using GitCredentialManager.UI.Views;
+
+namespace GitCredentialManager.UI.Commands
+{
+    public class OAuthCommandImpl : OAuthCommand
+    {
+        public OAuthCommandImpl(ICommandContext context) : base(context) { }
+
+        protected override Task ShowAsync(OAuthViewModel viewModel, CancellationToken ct)
+        {
+            return AvaloniaUi.ShowViewAsync<OAuthView>(viewModel, GetParentHandle(), ct);
+        }
+    }
+}

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Controls/TesterWindow.axaml
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Controls/TesterWindow.axaml
@@ -45,5 +45,54 @@
                 <Button Classes="accent" Content="Show" Click="ShowBasic" />
             </StackPanel>
         </TabItem>
+        <TabItem Header="OAuth">
+            <StackPanel>
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
+                    <Label Grid.Row="0" Grid.Column="0"
+                           Content="Window Title" />
+                    <TextBox Grid.Row="0" Grid.Column="1"
+                             x:Name="oauthTitle" Text="Git Credential Manager" />
+                    <Label Grid.Row="1" Grid.Column="0"
+                           Content="Description" />
+                    <TextBox Grid.Row="1" Grid.Column="1"
+                             x:Name="oauthDescription" Text="Sign in to 'https://example.com'" />
+                    <Label Grid.Row="2" Grid.Column="0"
+                           Content="Modes" />
+                    <StackPanel Grid.Row="2" Grid.Column="1"
+                                Orientation="Horizontal" VerticalAlignment="Center">
+                        <CheckBox Content="Browser" x:Name="oauthBrowser" MinWidth="90" IsChecked="True" />
+                        <CheckBox Content="Device Code" x:Name="oauthDeviceCode" MinWidth="80" IsChecked="True" />
+                    </StackPanel>
+                    <Label Grid.Row="3" Grid.Column="0"
+                           Content="Show Logo" />
+                    <CheckBox Grid.Row="3" Grid.Column="1"
+                              x:Name="oauthShowLogo" IsChecked="True" />
+                </Grid>
+                <Button Classes="accent" Content="Show" Click="ShowOAuth" />
+            </StackPanel>
+        </TabItem>
+        <TabItem Header="Device Code">
+            <StackPanel>
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
+                    <Label Grid.Row="0" Grid.Column="0"
+                           Content="Window Title" />
+                    <TextBox Grid.Row="0" Grid.Column="1"
+                             x:Name="deviceTitle" Text="Git Credential Manager" />
+                    <Label Grid.Row="1" Grid.Column="0"
+                           Content="User Code" />
+                    <TextBox Grid.Row="1" Grid.Column="1"
+                             x:Name="deviceUserCode" Text="ABCD-EFGH-1234" />
+                    <Label Grid.Row="2" Grid.Column="0"
+                           Content="Verification URL" />
+                    <TextBox Grid.Row="2" Grid.Column="1"
+                             x:Name="deviceVerificationUrl" Text="https://example.com/signin/device" />
+                    <Label Grid.Row="3" Grid.Column="0"
+                           Content="Show Logo" />
+                    <CheckBox Grid.Row="3" Grid.Column="1"
+                              x:Name="deviceShowLogo" IsChecked="True" />
+                </Grid>
+                <Button Classes="accent" Content="Show" Click="ShowDeviceCode" />
+            </StackPanel>
+        </TabItem>
     </TabControl>
 </Window>

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Controls/TesterWindow.axaml.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Controls/TesterWindow.axaml.cs
@@ -3,6 +3,10 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using GitCredentialManager.Interop.Linux;
+using GitCredentialManager.Interop.MacOS;
+using GitCredentialManager.Interop.Posix;
+using GitCredentialManager.Interop.Windows;
 using GitCredentialManager.UI.ViewModels;
 using GitCredentialManager.UI.Views;
 
@@ -10,12 +14,33 @@ namespace GitCredentialManager.UI.Controls
 {
     public class TesterWindow : Window
     {
+        private readonly IEnvironment _environment;
+
         public TesterWindow()
         {
             InitializeComponent();
 #if DEBUG
             this.AttachDevTools();
 #endif
+
+            if (PlatformUtils.IsWindows())
+            {
+                _environment = new WindowsEnvironment(new WindowsFileSystem());
+            }
+            else
+            {
+                IFileSystem fs;
+                if (PlatformUtils.IsMacOS())
+                {
+                    fs = new MacOSFileSystem();
+                }
+                else
+                {
+                    fs = new LinuxFileSystem();
+                }
+
+                _environment = new PosixEnvironment(fs);
+            }
         }
 
         private void InitializeComponent()
@@ -33,6 +58,35 @@ namespace GitCredentialManager.UI.Controls
                 ShowProductHeader = this.FindControl<CheckBox>("showLogo").IsChecked ?? false
             };
             var view = new CredentialsView();
+            var window = new DialogWindow(view) {DataContext = vm};
+            window.ShowDialog(this);
+        }
+
+        private void ShowOAuth(object sender, RoutedEventArgs e)
+        {
+            var vm = new OAuthViewModel
+            {
+                Title = this.FindControl<TextBox>("oauthTitle").Text,
+                Description = this.FindControl<TextBox>("oauthDescription").Text,
+                ShowBrowserLogin = this.FindControl<CheckBox>("oauthBrowser").IsChecked ?? false,
+                ShowDeviceCodeLogin = this.FindControl<CheckBox>("oauthDeviceCode").IsChecked ?? false,
+                ShowProductHeader = this.FindControl<CheckBox>("oauthShowLogo").IsChecked ?? false
+            };
+            var view = new OAuthView();
+            var window = new DialogWindow(view) {DataContext = vm};
+            window.ShowDialog(this);
+        }
+
+        private void ShowDeviceCode(object sender, RoutedEventArgs e)
+        {
+            var vm = new DeviceCodeViewModel(_environment)
+            {
+                Title = this.FindControl<TextBox>("deviceTitle").Text,
+                UserCode = this.FindControl<TextBox>("deviceUserCode").Text,
+                VerificationUrl = this.FindControl<TextBox>("deviceVerificationUrl").Text,
+                ShowProductHeader = this.FindControl<CheckBox>("deviceShowLogo").IsChecked ?? false
+            };
+            var view = new DeviceCodeView();
             var window = new DialogWindow(view) {DataContext = vm};
             window.ShowDialog(this);
         }

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Git-Credential-Manager.UI.Avalonia.csproj
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Git-Credential-Manager.UI.Avalonia.csproj
@@ -21,6 +21,14 @@
       <DependentUpon>TesterWindow.axaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Update="Views\OAuthView.axaml.cs">
+      <DependentUpon>OAuthView.axaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Update="Views\DeviceCodeView.axaml.cs">
+      <DependentUpon>DeviceCodeView.axaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
   </ItemGroup>
 
 </Project>

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
@@ -48,6 +48,8 @@ namespace GitCredentialManager.UI
             using (var app = new HelperApplication(context))
             {
                 app.RegisterCommand(new CredentialsCommandImpl(context));
+                app.RegisterCommand(new OAuthCommandImpl(context));
+                app.RegisterCommand(new DeviceCodeCommandImpl(context));
 
                 int exitCode = app.RunAsync(args)
                     .ConfigureAwait(false)

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Views/DeviceCodeView.axaml
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Views/DeviceCodeView.axaml
@@ -1,0 +1,44 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sharedVms="clr-namespace:GitCredentialManager.UI.ViewModels;assembly=gcmcoreui"
+             mc:Ignorable="d" d:DesignWidth="420"
+             x:Class="GitCredentialManager.UI.Views.DeviceCodeView">
+    <Design.DataContext>
+        <sharedVms:DeviceCodeViewModel/>
+    </Design.DataContext>
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,15">
+            <StackPanel Margin="0"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        IsVisible="{Binding ShowProductHeader}">
+                <Image Margin="0,0,10,0"
+                       VerticalAlignment="Center"
+                       Source="{StaticResource GcmLogo}"
+                       Width="32" Height="32" />
+                <TextBlock Text="Git Credential Manager"
+                           VerticalAlignment="Center"
+                           FontSize="18"
+                           FontWeight="Light"/>
+            </StackPanel>
+        </StackPanel>
+
+        <StackPanel Orientation="Vertical" VerticalAlignment="Center">
+            <TextBlock Text="Visit the URL below, sign in, and enter the following device code to continue."
+                       Margin="0,0,0,20"
+                       TextWrapping="Wrap" TextAlignment="Center"/>
+            <TextBox Text="{Binding UserCode}"
+                     Margin="0,0,0,20"
+                     HorizontalAlignment="Center"
+                     FontSize="24"
+                     TextAlignment="Center"
+                     Classes="label monospace"/>
+            <Button Content="{Binding VerificationUrl}"
+                    Command="{Binding VerificationUrlCommand}"
+                    HorizontalAlignment="Center"
+                    Classes="hyperlink" />
+        </StackPanel>
+    </DockPanel>
+</UserControl>

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Views/DeviceCodeView.axaml.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Views/DeviceCodeView.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace GitCredentialManager.UI.Views
+{
+    public class DeviceCodeView : UserControl
+    {
+        public DeviceCodeView()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Views/OAuthView.axaml
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Views/OAuthView.axaml
@@ -1,0 +1,49 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:GitCredentialManager.UI.ViewModels;assembly=gcmcoreui"
+             mc:Ignorable="d" d:DesignWidth="420"
+             x:Class="GitCredentialManager.UI.Views.OAuthView">
+    <Design.DataContext>
+        <vm:OAuthViewModel/>
+    </Design.DataContext>
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="10,0,10,10">
+            <StackPanel Margin="0"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        IsVisible="{Binding ShowProductHeader}">
+                <Image Margin="0,0,10,0"
+                       VerticalAlignment="Center"
+                       Source="{StaticResource GcmLogo}"
+                       Width="32" Height="32" />
+                <TextBlock Text="Git Credential Manager"
+                           VerticalAlignment="Center"
+                           FontSize="18"
+                           FontWeight="Light"/>
+            </StackPanel>
+
+            <TextBlock Text="{Binding Description}"
+                       FontSize="14"
+                       HorizontalAlignment="Center"
+                       TextWrapping="Wrap"
+                       Margin="0,15,0,15"/>
+        </StackPanel>
+
+        <StackPanel Margin="20,0">
+            <Button Content="Sign in with your browser"
+                    IsDefault="True"
+                    Command="{Binding SignInBrowserCommand}"
+                    HorizontalAlignment="Center"
+                    Classes="accent"
+                    Margin="0,0,0,10"
+                    IsVisible="{Binding ShowBrowserLogin}"/>
+            <Button Content="Sign in with a code"
+                    IsDefault="True"
+                    Command="{Binding SignInDeviceCodeCommand}"
+                    HorizontalAlignment="Center"
+                    IsVisible="{Binding ShowDeviceCodeLogin}"/>
+        </StackPanel>
+    </DockPanel>
+</UserControl>

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Views/OAuthView.axaml.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Views/OAuthView.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace GitCredentialManager.UI.Views
+{
+    public class OAuthView : UserControl
+    {
+        public OAuthView()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/shared/TestInfrastructure/Objects/TestSettings.cs
+++ b/src/shared/TestInfrastructure/Objects/TestSettings.cs
@@ -58,6 +58,18 @@ namespace GitCredentialManager.Tests.Objects
                 return true;
             }
 
+            if (RemoteUri != null)
+            {
+                foreach (string scope in RemoteUri.GetGitConfigurationScopes())
+                {
+                    string key = $"{section}.{scope}.{property}";
+                    if (GitConfiguration?.TryGet(key, false, out value) ?? false)
+                    {
+                        return true;
+                    }
+                }
+            }
+
             if (GitConfiguration?.TryGet($"{section}.{property}", false, out value) ?? false)
             {
                 return true;
@@ -79,15 +91,25 @@ namespace GitCredentialManager.Tests.Objects
                 yield return envarValue;
             }
 
-            foreach (string scope in RemoteUri.GetGitConfigurationScopes())
+            IEnumerable<string> configValues;
+            if (RemoteUri != null)
             {
-                string key = $"{section}.{scope}.{property}";
-
-                IEnumerable<string> configValues = GitConfiguration.GetAll(key);
-                foreach (string value in configValues)
+                foreach (string scope in RemoteUri.GetGitConfigurationScopes())
                 {
-                    yield return value;
+                    string key = $"{section}.{scope}.{property}";
+
+                    configValues = GitConfiguration.GetAll(key);
+                    foreach (string value in configValues)
+                    {
+                        yield return value;
+                    }
                 }
+            }
+
+            configValues = GitConfiguration.GetAll($"{section}.{property}");
+            foreach (string value in configValues)
+            {
+                yield return value;
             }
         }
 

--- a/src/windows/Git-Credential-Manager.UI.Windows/Commands/DeviceCodeCommandImpl.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Commands/DeviceCodeCommandImpl.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager.UI.ViewModels;
+using GitCredentialManager.UI.Views;
+
+namespace GitCredentialManager.UI.Commands
+{
+    public class DeviceCodeCommandImpl : DeviceCodeCommand
+    {
+        public DeviceCodeCommandImpl(ICommandContext context) : base(context) { }
+
+        protected override Task ShowAsync(DeviceCodeViewModel viewModel, CancellationToken ct)
+        {
+            return Gui.ShowDialogWindow(viewModel, () => new DeviceCodeView(), GetParentHandle());
+        }
+    }
+}

--- a/src/windows/Git-Credential-Manager.UI.Windows/Commands/OAuthCommandImpl.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Commands/OAuthCommandImpl.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager.UI.ViewModels;
+using GitCredentialManager.UI.Views;
+
+namespace GitCredentialManager.UI.Commands
+{
+    public class OAuthCommandImpl : OAuthCommand
+    {
+        public OAuthCommandImpl(ICommandContext context) : base(context) { }
+
+        protected override Task ShowAsync(OAuthViewModel viewModel, CancellationToken ct)
+        {
+            return Gui.ShowDialogWindow(viewModel, () => new OAuthView(), GetParentHandle());
+        }
+    }
+}

--- a/src/windows/Git-Credential-Manager.UI.Windows/Controls/TesterWindow.xaml
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Controls/TesterWindow.xaml
@@ -44,5 +44,84 @@
                 </StackPanel>
             </StackPanel>
         </TabItem>
+
+        <TabItem Header="OAuth">
+            <StackPanel>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Grid.Column="0"
+                           Content="Window Title" />
+                    <TextBox Grid.Row="0" Grid.Column="1"
+                             x:Name="oauthTitle" Text="Git Credential Manager" />
+                    <Label Grid.Row="1" Grid.Column="0"
+                           Content="Description" />
+                    <TextBox Grid.Row="1" Grid.Column="1"
+                             x:Name="oauthDescription" Text="Sign in to 'https://example.com'" />
+                    <Label Grid.Row="2" Grid.Column="0"
+                           Content="Modes" />
+                    <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                        <CheckBox Content="Browser" x:Name="oauthBrowser" MinWidth="90" IsChecked="True" />
+                        <CheckBox Content="Device Code" x:Name="oauthDeviceCode" MinWidth="80" IsChecked="True" />
+                    </StackPanel>
+                    <Label Grid.Row="3" Grid.Column="0"
+                           Content="Show Logo" />
+                    <CheckBox Grid.Row="3" Grid.Column="1"
+                             x:Name="oauthShowLogo" IsChecked="True" />
+                </Grid>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                            Margin="0,10">
+                    <Button Content="Show" Click="ShowOAuth"
+                            Padding="8,4"/>
+                </StackPanel>
+            </StackPanel>
+        </TabItem>
+
+
+        <TabItem Header="Device Code">
+            <StackPanel>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Grid.Column="0"
+                           Content="Window Title" />
+                    <TextBox Grid.Row="0" Grid.Column="1"
+                             x:Name="deviceTitle" Text="Git Credential Manager" />
+                    <Label Grid.Row="1" Grid.Column="0"
+                           Content="User Code" />
+                    <TextBox Grid.Row="1" Grid.Column="1"
+                             x:Name="deviceUserCode" Text="ABCD-EFGH-1234" />
+                    <Label Grid.Row="2" Grid.Column="0"
+                           Content="Verification URL" />
+                    <TextBox Grid.Row="2" Grid.Column="1"
+                             x:Name="deviceVerificationUrl" Text="https://example.com/signin/device" />
+                    <Label Grid.Row="3" Grid.Column="0"
+                           Content="Show Logo" />
+                    <CheckBox Grid.Row="3" Grid.Column="1"
+                             x:Name="deviceShowLogo" IsChecked="True" />
+                </Grid>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                            Margin="0,10">
+                    <Button Content="Show" Click="ShowDeviceCode"
+                            Padding="8,4"/>
+                </StackPanel>
+            </StackPanel>
+        </TabItem>
     </TabControl>
 </Window>

--- a/src/windows/Git-Credential-Manager.UI.Windows/Controls/TesterWindow.xaml.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Controls/TesterWindow.xaml.cs
@@ -1,6 +1,9 @@
 using System.Windows;
 using GitCredentialManager.UI.ViewModels;
 using GitCredentialManager.UI.Views;
+using GitCredentialManager.Interop.Linux;
+using GitCredentialManager.Interop.MacOS;
+using GitCredentialManager.Interop.Posix;
 using GitCredentialManager.Interop.Windows;
 using GitCredentialManager.UI.Controls;
 
@@ -8,9 +11,30 @@ namespace GitCredentialManager.UI.Controls
 {
     public partial class TesterWindow : Window
     {
+        private readonly IEnvironment _environment;
+
         public TesterWindow()
         {
             InitializeComponent();
+
+            if (PlatformUtils.IsWindows())
+            {
+                _environment = new WindowsEnvironment(new WindowsFileSystem());
+            }
+            else
+            {
+                IFileSystem fs;
+                if (PlatformUtils.IsMacOS())
+                {
+                    fs = new MacOSFileSystem();
+                }
+                else
+                {
+                    fs = new LinuxFileSystem();
+                }
+
+                _environment = new PosixEnvironment(fs);
+            }
         }
 
         private void ShowBasic(object sender, RoutedEventArgs e)
@@ -24,6 +48,35 @@ namespace GitCredentialManager.UI.Controls
             };
             var view = new CredentialsView();
             var window = new DialogWindow(view) {DataContext = vm};
+            window.ShowDialog();
+        }
+
+        private void ShowOAuth(object sender, RoutedEventArgs e)
+        {
+            var vm = new OAuthViewModel
+            {
+                Title = oauthTitle.Text,
+                Description = oauthDescription.Text,
+                ShowBrowserLogin = oauthBrowser.IsChecked ?? false,
+                ShowDeviceCodeLogin = oauthDeviceCode.IsChecked ?? false,
+                ShowProductHeader = oauthShowLogo.IsChecked ?? false
+            };
+            var view = new OAuthView();
+            var window = new DialogWindow(view) { DataContext = vm };
+            window.ShowDialog();
+        }
+
+        private void ShowDeviceCode(object sender, RoutedEventArgs e)
+        {
+            var vm = new DeviceCodeViewModel(_environment)
+            {
+                Title = deviceTitle.Text,
+                UserCode = deviceUserCode.Text,
+                VerificationUrl = deviceVerificationUrl.Text,
+                ShowProductHeader = deviceShowLogo.IsChecked ?? false
+            };
+            var view = new DeviceCodeView();
+            var window = new DialogWindow(view) { DataContext = vm };
             window.ShowDialog();
         }
     }

--- a/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
@@ -21,6 +21,8 @@ namespace GitCredentialManager.UI
                 }
 
                 app.RegisterCommand(new CredentialsCommandImpl(context));
+                app.RegisterCommand(new OAuthCommandImpl(context));
+                app.RegisterCommand(new DeviceCodeCommandImpl(context));
 
                 int exitCode = app.RunAsync(args)
                     .ConfigureAwait(false)

--- a/src/windows/Git-Credential-Manager.UI.Windows/Views/DeviceCodeView.xaml
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Views/DeviceCodeView.xaml
@@ -1,0 +1,54 @@
+<UserControl x:Class="GitCredentialManager.UI.Views.DeviceCodeView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:viewModels="clr-namespace:GitCredentialManager.UI.ViewModels;assembly=Core.UI"
+             xmlns:converters="clr-namespace:GitCredentialManager.UI.Converters;assembly=gcmcoreuiwpf"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance viewModels:DeviceCodeViewModel}"
+             d:DesignHeight="300" d:DesignWidth="300">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Assets/Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="10,0,0,10">
+            <StackPanel Margin="0"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        Visibility="{Binding ShowProductHeader, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Image Source="{StaticResource GcmLogo}"
+                       Height="32" VerticalAlignment="Center"
+                       Margin="0,0,10,0"/>
+                <TextBlock Text="Git Credential Manager"
+                           VerticalAlignment="Center"
+                           FontSize="18"
+                           FontWeight="Light" />
+            </StackPanel>
+        </StackPanel>
+
+        <StackPanel Orientation="Vertical" VerticalAlignment="Center">
+            <TextBlock Text="Visit the URL below, sign in, and enter the following device code to continue."
+                       Margin="0,0,0,20"
+                       TextWrapping="Wrap" TextAlignment="Center" FontSize="14"/>
+            <TextBox Text="{Binding UserCode}"
+                     Margin="0,0,0,20"
+                     HorizontalAlignment="Center"
+                     FontSize="24"
+                     TextAlignment="Center"
+                     Style="{StaticResource DeviceCodeBox}"/>
+            <TextBlock FontSize="14"
+                       HorizontalAlignment="Center">
+                <Hyperlink Command="{Binding VerificationUrlCommand}">
+                    <Run Text="{Binding VerificationUrl}"/>
+                </Hyperlink>
+            </TextBlock>
+        </StackPanel>
+    </DockPanel>
+</UserControl>

--- a/src/windows/Git-Credential-Manager.UI.Windows/Views/DeviceCodeView.xaml.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Views/DeviceCodeView.xaml.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace GitCredentialManager.UI.Views
+{
+    public partial class DeviceCodeView : UserControl
+    {
+        public DeviceCodeView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/windows/Git-Credential-Manager.UI.Windows/Views/OAuthView.xaml
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Views/OAuthView.xaml
@@ -1,0 +1,66 @@
+<UserControl x:Class="GitCredentialManager.UI.Views.OAuthView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:viewModels="clr-namespace:GitCredentialManager.UI.ViewModels;assembly=gcmcoreui"
+             xmlns:converters="clr-namespace:GitCredentialManager.UI.Converters;assembly=gcmcoreuiwpf"
+             xmlns:controls="clr-namespace:GitCredentialManager.UI.Controls"
+             xmlns:sharedControls="clr-namespace:GitCredentialManager.UI.Controls;assembly=gcmcoreuiwpf"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance viewModels:CredentialsViewModel}"
+             d:DesignWidth="300">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Assets/Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <converters:NonEmptyStringToVisibleConverter x:Key="NonEmptyStringToVisibleConverter"/>
+            <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+            <converters:BooleanOrToVisibilityConverter x:Key="BooleanOrToVisibilityConverter"/>
+            <converters:BooleanOrConverter x:Key="BooleanOrConverter"/>
+            <converters:BooleanNotConverter x:Key="BooleanNotConverter"/>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="10,0,0,10">
+            <StackPanel Margin="0"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        Visibility="{Binding ShowProductHeader, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Image Source="{StaticResource GcmLogo}"
+                       Height="32" VerticalAlignment="Center"
+                       Margin="0,0,10,0"/>
+                <TextBlock Text="Git Credential Manager"
+                           VerticalAlignment="Center"
+                           FontSize="18"
+                           FontWeight="Light" />
+            </StackPanel>
+
+            <TextBlock Text="{Binding Description}"
+                       HorizontalAlignment="Center"
+                       FontSize="14"
+                       Margin="0,15,0,15"/>
+        </StackPanel>
+
+            <StackPanel x:Name="oauthPanel"
+                        Margin="0,10">
+                <Button x:Name="browserButton"
+                        Content="Sign in with your browser"
+                        IsDefault="True"
+                        Command="{Binding SignInBrowserCommand}"
+                        Visibility="{Binding ShowBrowserLogin, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        HorizontalAlignment="Center"
+                        Margin="0,0,0,10"
+                        Style="{StaticResource AccentButton}"/>
+                <Button x:Name="deviceButton"
+                        Content="Sign in with a code"
+                        IsDefault="{Binding ShowBrowserLogin, Converter={StaticResource BooleanNotConverter}}"
+                        Command="{Binding SignInDeviceCodeCommand}"
+                        Visibility="{Binding ShowDeviceCodeLogin, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        HorizontalAlignment="Center"
+                        Margin="0,10,0,10"/>
+            </StackPanel>
+    </DockPanel>
+</UserControl>

--- a/src/windows/Git-Credential-Manager.UI.Windows/Views/OAuthView.xaml.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Views/OAuthView.xaml.cs
@@ -1,0 +1,14 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace GitCredentialManager.UI.Views
+{
+    public partial class OAuthView : UserControl
+    {
+        public OAuthView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Add ability to provide OAuth-based authentication for generic hosts by way of simple Git configuration.

When a remote URL does not match any known host provider plugin, the generic provider will now first check for OAuth configuration in the Git config or environment variables. If such config is available then we try and perform OAuth authentication. Support for device code flow is optional, and refresh tokens will be used if the service supports and returns them.

Users can make use of existing Git config `include` to easily organise and share custom OAuth configurations:

_~/.gitconfig_

```ini
[include]
    path = ~/.gcm/oauth/example.ini
```

_example.ini_

```ini
[credential "https://example.com"]
	provider = generic
	oauthClientId = <client-id>
	oauthClientSecret = <client-secret>
	oauthRedirectUri = <redirect-uri>
	oauthAuthorizeEndpoint = <auth-endpoint>
	oauthTokenEndpoint = <token-endpoint>
	oauthScopes = <scopes>
	oauthDeviceEndpoint = <device-endpoint>
	oauthDefaultUserName = <username>
	oauthUseClientAuthHeader = <true|false>
```


<img width="532" alt="image" src="https://user-images.githubusercontent.com/5658207/215227155-d6be63e5-2765-43cc-917c-d7cc30743d5e.png">

<img width="532" alt="image" src="https://user-images.githubusercontent.com/5658207/215227162-b8117ead-283d-430c-ae19-91bdb98edf01.png">


Fixes https://github.com/GitCredentialManager/git-credential-manager/issues/1047