### PR TITLE
Warn that using the secure keystore on Linux might fail

### DIFF
--- a/docs/credstores.md
+++ b/docs/credstores.md
@@ -106,6 +106,8 @@ using the Keychain Access application.
 
 **:warning: Requires a graphical user interface session.**
 
+**:warning: Per February 2023 this might be affected by [#694](https://github.com/GitCredentialManager/git-credential-manager/issues/694). Use GPG or plaintext as alternatives.**
+
 ```shell
 export GCM_CREDENTIAL_STORE=secretservice
 # or


### PR DESCRIPTION
I was trying to get working for the longest time, until I tried to diagnose and found it failed on #694.