### PR TITLE
Pipe install script directly to sh

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -125,8 +125,7 @@ to install it.
 Download and run the script:
 
 ```shell
-curl -LO https://aka.ms/gcm/linux-install-source.sh &&
-sh ./linux-install-source.sh &&
+curl -L https://aka.ms/gcm/linux-install-source.sh | sh
 git-credential-manager-core configure
 ```
 


### PR DESCRIPTION
Hi there! First of all, thanks for the Git Credential Manager, essential tool 🙌 

This pipes the install script on Linux directly to `sh`, similar to [the `flyctl` installation instructions](https://fly.io/docs/hands-on/install-flyctl/#linux)