### PR TITLE
trace2: remove inaccurate warning and add UI helper exit calls

### DIFF
--- a/src/shared/Atlassian.Bitbucket.UI.Avalonia/Program.cs
+++ b/src/shared/Atlassian.Bitbucket.UI.Avalonia/Program.cs
@@ -55,6 +55,7 @@ namespace Atlassian.Bitbucket.UI
                     .GetAwaiter()
                     .GetResult();
 
+                context.Trace2.Stop(exitCode);
                 Environment.Exit(exitCode);
             }
         }

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -309,8 +309,9 @@ public abstract class Trace2Message
     [JsonProperty("sid", Order = 2)]
     public string Sid { get; set; }
 
+    // TODO: Remove this default value when TRACE2 regions are introduced.
     [JsonProperty("thread", Order = 3)]
-    public string Thread { get; set; }
+    public string Thread { get; set; } = "main";
 
     [JsonProperty("time", Order = 4)]
     public DateTimeOffset Time { get; set; }

--- a/src/shared/Core/Trace2.cs
+++ b/src/shared/Core/Trace2.cs
@@ -200,11 +200,6 @@ public class Trace2 : DisposableObject, ITrace2
                 }
             }
         }
-
-        if (_writers.Count == 0)
-        {
-            error.WriteLine("warning: unable to set up TRACE2 tracing. No traces will be written.");
-        }
     }
 
     private void WriteVersion(

--- a/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
+++ b/src/shared/Git-Credential-Manager.UI.Avalonia/Program.cs
@@ -55,6 +55,7 @@ namespace GitCredentialManager.UI
                     .GetAwaiter()
                     .GetResult();
 
+                context.Trace2.Stop(exitCode);
                 Environment.Exit(exitCode);
             }
         }

--- a/src/shared/Git-Credential-Manager/Program.cs
+++ b/src/shared/Git-Credential-Manager/Program.cs
@@ -29,7 +29,7 @@ namespace GitCredentialManager
                         );
                     }
                 }
-                
+
                 //
                 // Git Credential Manager's executable used to be named "git-credential-manager-core" before
                 // dropping the "-core" suffix. In order to prevent "helper not found" errors for users who

--- a/src/shared/GitHub.UI.Avalonia/Program.cs
+++ b/src/shared/GitHub.UI.Avalonia/Program.cs
@@ -57,6 +57,7 @@ namespace GitHub.UI
                     .GetAwaiter()
                     .GetResult();
 
+                context.Trace2.Stop(exitCode);
                 Environment.Exit(exitCode);
             }
         }

--- a/src/shared/GitLab.UI.Avalonia/Program.cs
+++ b/src/shared/GitLab.UI.Avalonia/Program.cs
@@ -54,6 +54,7 @@ namespace GitLab.UI
                     .GetAwaiter()
                     .GetResult();
 
+                context.Trace2.Stop(exitCode);
                 Environment.Exit(exitCode);
             }
         }

--- a/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
+++ b/src/windows/Atlassian.Bitbucket.UI.Windows/Program.cs
@@ -28,6 +28,7 @@ namespace Atlassian.Bitbucket.UI
                     .GetAwaiter()
                     .GetResult();
 
+                context.Trace2.Stop(exitCode);
                 Environment.Exit(exitCode);
             }
         }

--- a/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
+++ b/src/windows/Git-Credential-Manager.UI.Windows/Program.cs
@@ -28,6 +28,7 @@ namespace GitCredentialManager.UI
                     .GetAwaiter()
                     .GetResult();
 
+                context.Trace2.Stop(exitCode);
                 Environment.Exit(exitCode);
             }
         }

--- a/src/windows/GitHub.UI.Windows/Program.cs
+++ b/src/windows/GitHub.UI.Windows/Program.cs
@@ -30,6 +30,7 @@ namespace GitHub.UI
                     .GetAwaiter()
                     .GetResult();
 
+                context.Trace2.Stop(exitCode);
                 Environment.Exit(exitCode);
             }
         }

--- a/src/windows/GitLab.UI.Windows/Program.cs
+++ b/src/windows/GitLab.UI.Windows/Program.cs
@@ -28,6 +28,7 @@ namespace GitLab.UI
                     .GetAwaiter()
                     .GetResult();
 
+                context.Trace2.Stop(exitCode);
                 Environment.Exit(exitCode);
             }
         }


### PR DESCRIPTION
Remove warning about being unable to set up tracing from Trace2 TryParseSettings method. This method should just check to see whether TRACE2 is enabled - if it is not, it does not need to warn the user, as we only collect traces from those who actively choose to opt in.

Additionally, GCM's UI helpers are connected to the TRACE2 system via the Start() call in `ApplicationBase.cs`. Since this call records `Version` and `Start` events, ensure a corresponding `Exit` event is called before the helper process completes.