### PR TITLE
.net tool: clarify install instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -204,10 +204,11 @@ tool][dotnet-tool]. This is
 the preferred install method for Linux because you can use it to install on any
 [.NET-supported
 distribution][dotnet-supported-distributions]. You
-can also use this method on macOS or Windows if you so choose.
+can also use this method on macOS if you so choose.
 
-**Note:** Make sure you have installed .NET before attempting to run the
-following `dotnet tool` commands.
+**Note:** Make sure you have installed the [latest version of the .NET 6.0
+SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) before attempting
+to run the following `dotnet tool` commands.
 
 #### Install
 


### PR DESCRIPTION
Because we use dotnet publish (which requires a specific framework) to create the payload of our .NET tool package, the package is tied to the framework specified. This means that it will only work with the corresponding .NET SDK for that framework.

In light of this, update the .NET tool install instructions to specify that users must download the latest .NET 6.0 SDK as a prerequisite for installing the package, since that is the framework for which we currently publish. This will also need to be updated whenever we upgrade to a new Target Framework.

Additionally, remove Windows as a supported .NET tool platform. Since we currently target .NET Framework rather than .NET, the package cannot actually be installed on Windows.