### PR TITLE
trace2: guard against null pipe client in dispose

### DIFF
--- a/src/shared/Core/Trace2CollectorWriter.cs
+++ b/src/shared/Core/Trace2CollectorWriter.cs
@@ -35,17 +35,17 @@ namespace GitCredentialManager
 
             Start();
         }
-        
+
         public void Write(Trace2Message message)
         {
            _queue.TryAdd(message.ToJson());
         }
-        
+
         protected override void ReleaseManagedResources()
         {
             Stop();
 
-            _pipeClient.Dispose();
+            _pipeClient?.Dispose();
             _queue.Dispose();
             base.ReleaseManagedResources();
 


### PR DESCRIPTION
Ensure that we don't try to dispose of the pipe client in the `Trace2CollectorWriter` when it hasn't been created yet.