### PR TITLE
git: consistently read from stdout before exit wait

### DIFF
--- a/src/shared/Core/GitConfiguration.cs
+++ b/src/shared/Core/GitConfiguration.cs
@@ -199,6 +199,9 @@ namespace GitCredentialManager
             using (Process git = _git.CreateProcess($"config --null {levelArg} {typeArg} {QuoteCmdArg(name)}"))
             {
                 git.Start();
+                // To avoid deadlocks, always read the output stream first and then wait
+                // TODO: don't read in all the data at once; stream it
+                string data = git.StandardOutput.ReadToEnd();
                 git.WaitForExit();
 
                 switch (git.ExitCode)
@@ -214,7 +217,6 @@ namespace GitCredentialManager
                         return false;
                 }
 
-                string data = git.StandardOutput.ReadToEnd();
                 string[] entries = data.Split('\0');
                 if (entries.Length > 0)
                 {
@@ -301,7 +303,7 @@ namespace GitCredentialManager
             using (Process git = _git.CreateProcess(gitArgs))
             {
                 git.Start();
-
+                // To avoid deadlocks, always read the output stream first and then wait
                 // TODO: don't read in all the data at once; stream it
                 string data = git.StandardOutput.ReadToEnd();
                 git.WaitForExit();


### PR DESCRIPTION
We should always try and drain standard output before waiting for the Git process to exit. We do this for all other calls that expect output, but missed the `TryGet` method.

This is important if Git ever writes out so much data to stdout that we buffer the output, and then Git will not exit until it can finish writing (and we'd be waiting for Git to exit).