### PR TITLE
Add login hint support for GitHub browser-based OAuth authentication

### DIFF
--- a/src/shared/Atlassian.Bitbucket/BitbucketOAuth2Client.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketOAuth2Client.cs
@@ -27,9 +27,9 @@ namespace Atlassian.Bitbucket
             return uri.AbsoluteUri.TrimEnd('/');
         }
 
-        public Task<OAuth2AuthorizationCodeResult> GetAuthorizationCodeAsync(IOAuth2WebBrowser browser, CancellationToken ct) 
+        public Task<OAuth2AuthorizationCodeResult> GetAuthorizationCodeAsync(IOAuth2WebBrowser browser, CancellationToken ct)
         {
-            return GetAuthorizationCodeAsync(Scopes, browser, ct);
+            return this.GetAuthorizationCodeAsync(Scopes, browser, ct);
         }
 
         protected override bool TryCreateTokenEndpointResult(string json, out OAuth2TokenResult result)

--- a/src/shared/Atlassian.Bitbucket/BitbucketOAuth2Client.cs
+++ b/src/shared/Atlassian.Bitbucket/BitbucketOAuth2Client.cs
@@ -10,7 +10,7 @@ namespace Atlassian.Bitbucket
 {
     public abstract class BitbucketOAuth2Client : OAuth2Client
     {
-        public BitbucketOAuth2Client(HttpClient httpClient, OAuth2ServerEndpoints endpoints, string clientId, Uri redirectUri, string clientSecret, ITrace trace) : base(httpClient, endpoints, clientId, redirectUri, clientSecret, trace, false)
+        public BitbucketOAuth2Client(HttpClient httpClient, OAuth2ServerEndpoints endpoints, string clientId, Uri redirectUri, string clientSecret, ITrace trace) : base(httpClient, endpoints, clientId, redirectUri, clientSecret, false)
         {
         }
 

--- a/src/shared/Core.Tests/Authentication/OAuth2ClientTests.cs
+++ b/src/shared/Core.Tests/Authentication/OAuth2ClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,7 +38,52 @@ namespace GitCredentialManager.Tests.Authentication
 
             OAuth2Client client = CreateClient(httpHandler, endpoints);
 
-            OAuth2AuthorizationCodeResult result = await client.GetAuthorizationCodeAsync(expectedScopes, browser, CancellationToken.None);
+            OAuth2AuthorizationCodeResult result = await client.GetAuthorizationCodeAsync(expectedScopes, browser, null, CancellationToken.None);
+
+            Assert.Equal(expectedAuthCode, result.Code);
+        }
+
+        [Fact]
+        public async Task OAuth2Client_GetAuthorizationCodeAsync_ExtraQueryParams()
+        {
+            const string expectedAuthCode = "68c39cbd8d";
+
+            var baseUri = new Uri("https://example.com");
+            OAuth2ServerEndpoints endpoints = CreateEndpoints(baseUri);
+
+            var httpHandler = new TestHttpMessageHandler {ThrowOnUnexpectedRequest = true};
+
+            string[] expectedScopes = {"read", "write", "delete"};
+
+            var extraParams = new Dictionary<string, string>
+            {
+                ["param1"] = "value1",
+                ["param2"] = "value2",
+                ["param3"] = "value3"
+            };
+
+            OAuth2Application app = CreateTestApplication();
+
+            var server = new TestOAuth2Server(endpoints);
+            server.RegisterApplication(app);
+            server.Bind(httpHandler);
+            server.TokenGenerator.AuthCodes.Add(expectedAuthCode);
+
+            server.AuthorizationEndpointInvoked += (_, request) =>
+            {
+                IDictionary<string, string> actualParams = request.RequestUri.GetQueryParameters();
+                foreach (var expected in extraParams)
+                {
+                    Assert.True(actualParams.TryGetValue(expected.Key, out string actualValue));
+                    Assert.Equal(expected.Value, actualValue);
+                }
+            };
+
+            IOAuth2WebBrowser browser = new TestOAuth2WebBrowser(httpHandler);
+
+            OAuth2Client client = CreateClient(httpHandler, endpoints);
+
+            OAuth2AuthorizationCodeResult result = await client.GetAuthorizationCodeAsync(expectedScopes, browser, extraParams, CancellationToken.None);
 
             Assert.Equal(expectedAuthCode, result.Code);
         }
@@ -217,7 +263,7 @@ namespace GitCredentialManager.Tests.Authentication
             OAuth2Client client = CreateClient(httpHandler, endpoints);
 
             OAuth2AuthorizationCodeResult authCodeResult = await client.GetAuthorizationCodeAsync(
-                expectedScopes, browser, CancellationToken.None);
+                expectedScopes, browser, null, CancellationToken.None);
 
             OAuth2TokenResult result1 = await client.GetTokenByAuthorizationCodeAsync(authCodeResult, CancellationToken.None);
 

--- a/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
+++ b/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
@@ -65,19 +65,17 @@ namespace GitCredentialManager.Authentication.OAuth
         private readonly Uri _redirectUri;
         private readonly string _clientId;
         private readonly string _clientSecret;
-        private readonly ITrace _trace;
         private readonly bool _addAuthHeader;
 
         private IOAuth2CodeGenerator _codeGenerator;
 
-        public OAuth2Client(HttpClient httpClient, OAuth2ServerEndpoints endpoints, string clientId, Uri redirectUri = null, string clientSecret = null, ITrace trace = null, bool addAuthHeader = true)
+        public OAuth2Client(HttpClient httpClient, OAuth2ServerEndpoints endpoints, string clientId, Uri redirectUri = null, string clientSecret = null, bool addAuthHeader = true)
         {
             _httpClient = httpClient;
             _endpoints = endpoints;
             _clientId = clientId;
             _redirectUri = redirectUri;
             _clientSecret = clientSecret;
-            _trace = trace;
             _addAuthHeader = addAuthHeader;
         }
 
@@ -86,18 +84,6 @@ namespace GitCredentialManager.Authentication.OAuth
             get => _codeGenerator ?? (_codeGenerator = new OAuth2CryptographicCodeGenerator());
             set => _codeGenerator = value;
         }
-
-        protected string ClientId => _clientId;
-
-        protected string ClientSecret => _clientSecret;
-
-        protected ITrace Trace => _trace;
-
-        protected OAuth2ServerEndpoints Endpoints => _endpoints;
-
-        protected HttpClient HttpClient => _httpClient;
-
-        protected Uri RedirectUri => _redirectUri;
 
         #region IOAuth2Client
 

--- a/src/shared/Core/GenericHostProvider.cs
+++ b/src/shared/Core/GenericHostProvider.cs
@@ -125,7 +125,6 @@ namespace GitCredentialManager
                 config.ClientId,
                 config.RedirectUri,
                 config.ClientSecret,
-                Context.Trace,
                 config.UseAuthHeader);
 
             //

--- a/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
+++ b/src/shared/GitHub.Tests/GitHubHostProviderTests.cs
@@ -196,7 +196,7 @@ namespace GitHub.Tests
             ghAuthMock.Setup(x => x.GetAuthenticationAsync(expectedTargetUri, null, It.IsAny<AuthenticationModes>()))
                       .ReturnsAsync(new AuthenticationPromptResult(AuthenticationModes.Browser));
 
-            ghAuthMock.Setup(x => x.GetOAuthTokenViaBrowserAsync(expectedTargetUri, It.IsAny<IEnumerable<string>>()))
+            ghAuthMock.Setup(x => x.GetOAuthTokenViaBrowserAsync(expectedTargetUri, It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
                       .ReturnsAsync(response);
 
             var ghApiMock = new Mock<IGitHubRestApi>(MockBehavior.Strict);
@@ -213,7 +213,56 @@ namespace GitHub.Tests
 
             ghAuthMock.Verify(
                 x => x.GetOAuthTokenViaBrowserAsync(
-                    expectedTargetUri, expectedOAuthScopes),
+                    expectedTargetUri, expectedOAuthScopes, null),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GitHubHostProvider_GenerateCredentialAsync_Browser_LoginHint_IncludesHintAndReturnsCredential()
+        {
+            var input = new InputArguments(new Dictionary<string, string>
+            {
+                ["protocol"] = "https",
+                ["host"] = "github.com",
+                ["username"] = "john.doe"
+            });
+
+            var expectedTargetUri = new Uri("https://github.com/");
+            IEnumerable<string> expectedOAuthScopes = new[]
+            {
+                GitHubConstants.OAuthScopes.Repo,
+                GitHubConstants.OAuthScopes.Gist,
+                GitHubConstants.OAuthScopes.Workflow,
+            };
+
+            var expectedUserName = "john.doe";
+            var tokenValue = "OAUTH-TOKEN";
+            var response = new OAuth2TokenResult(tokenValue, "bearer");
+
+            var context = new TestCommandContext();
+
+            var ghAuthMock = new Mock<IGitHubAuthentication>(MockBehavior.Strict);
+            ghAuthMock.Setup(x => x.GetAuthenticationAsync(expectedTargetUri, expectedUserName, It.IsAny<AuthenticationModes>()))
+                      .ReturnsAsync(new AuthenticationPromptResult(AuthenticationModes.Browser));
+
+            ghAuthMock.Setup(x => x.GetOAuthTokenViaBrowserAsync(expectedTargetUri, It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
+                      .ReturnsAsync(response);
+
+            var ghApiMock = new Mock<IGitHubRestApi>(MockBehavior.Strict);
+            ghApiMock.Setup(x => x.GetUserInfoAsync(expectedTargetUri, tokenValue))
+                     .ReturnsAsync(new GitHubUserInfo{Login = expectedUserName});
+
+            var provider = new GitHubHostProvider(context, ghApiMock.Object, ghAuthMock.Object);
+
+            ICredential credential = await provider.GenerateCredentialAsync(input);
+
+            Assert.NotNull(credential);
+            Assert.Equal(expectedUserName, credential.Account);
+            Assert.Equal(tokenValue, credential.Password);
+
+            ghAuthMock.Verify(
+                x => x.GetOAuthTokenViaBrowserAsync(
+                    expectedTargetUri, expectedOAuthScopes, expectedUserName),
                 Times.Once);
         }
 

--- a/src/shared/GitHub/GitHubHostProvider.cs
+++ b/src/shared/GitHub/GitHubHostProvider.cs
@@ -150,10 +150,10 @@ namespace GitHub
                     return patCredential;
 
                 case AuthenticationModes.Browser:
-                    return await GenerateOAuthCredentialAsync(remoteUri, useBrowser: true);
+                    return await GenerateOAuthCredentialAsync(remoteUri, loginHint: input.UserName, useBrowser: true);
 
                 case AuthenticationModes.Device:
-                    return await GenerateOAuthCredentialAsync(remoteUri, useBrowser: false);
+                    return await GenerateOAuthCredentialAsync(remoteUri, loginHint: input.UserName, useBrowser: false);
 
                 case AuthenticationModes.Pat:
                     // The token returned by the user should be good to use directly as the password for Git
@@ -176,10 +176,10 @@ namespace GitHub
             }
         }
 
-        private async Task<GitCredential> GenerateOAuthCredentialAsync(Uri targetUri, bool useBrowser)
+        private async Task<GitCredential> GenerateOAuthCredentialAsync(Uri targetUri, string loginHint, bool useBrowser)
         {
             OAuth2TokenResult result = useBrowser
-                ? await _gitHubAuth.GetOAuthTokenViaBrowserAsync(targetUri, GitHubOAuthScopes)
+                ? await _gitHubAuth.GetOAuthTokenViaBrowserAsync(targetUri, GitHubOAuthScopes, loginHint)
                 : await _gitHubAuth.GetOAuthTokenViaDeviceCodeAsync(targetUri, GitHubOAuthScopes);
 
             // Resolve the GitHub user handle

--- a/src/shared/TestInfrastructure/Objects/TestOAuth2Server.cs
+++ b/src/shared/TestInfrastructure/Objects/TestOAuth2Server.cs
@@ -27,6 +27,10 @@ namespace GitCredentialManager.Tests.Objects
 
         public TestOAuth2ServerTokenGenerator TokenGenerator = new TestOAuth2ServerTokenGenerator();
 
+        public event EventHandler<HttpRequestMessage> AuthorizationEndpointInvoked;
+        public event EventHandler<HttpRequestMessage> DeviceAuthorizationEndpointInvoked;
+        public event EventHandler<HttpRequestMessage> TokenEndpointInvoked;
+
         public void RegisterApplication(OAuth2Application application)
         {
             _apps[application.Id] = application;
@@ -52,6 +56,8 @@ namespace GitCredentialManager.Tests.Objects
 
         private Task<HttpResponseMessage> OnAuthorizationEndpointAsync(HttpRequestMessage request)
         {
+            AuthorizationEndpointInvoked?.Invoke(this, request);
+
             IDictionary<string, string> reqQuery = request.RequestUri.GetQueryParameters();
 
             // The only support response type so far is 'code'
@@ -128,6 +134,8 @@ namespace GitCredentialManager.Tests.Objects
 
         private async Task<HttpResponseMessage> OnDeviceAuthorizationEndpointAsync(HttpRequestMessage request)
         {
+            DeviceAuthorizationEndpointInvoked?.Invoke(this, request);
+
             IDictionary<string, string> formData = await request.Content.ReadAsFormContentAsync();
 
             // The client/app ID must be specified and must match a known application
@@ -162,6 +170,8 @@ namespace GitCredentialManager.Tests.Objects
 
         private async Task<HttpResponseMessage> OnTokenEndpointAsync(HttpRequestMessage request)
         {
+            TokenEndpointInvoked?.Invoke(this, request);
+
             IDictionary<string, string> formData = await request.Content.ReadAsFormContentAsync();
 
             if (!formData.TryGetValue(OAuth2Constants.TokenEndpoint.GrantTypeParameter, out string grantType))


### PR DESCRIPTION
If a username is specified in the remote URL then include this as a login hint when performing OAuth authentication for GitHub. This can help users of multiple accounts select the correct account before the OAuth flow completes and returns a token for the wrong account.

GitHub shows this nice prompt when a login hint is provided that does _not match the currently logged-in user_:

![image](https://user-images.githubusercontent.com/5658207/222230310-25c0e53e-ffab-4d42-bd4a-19d652e59835.png)

At the same time, if there is no logged-in user, then the login page's username box is already filled in:

![image](https://user-images.githubusercontent.com/5658207/222231085-21c10d7d-bd38-4374-8ed8-da2e6f1429ee.png)

The login hint is specified to GitHub via the extra `login` query parameter to the authorization endpoint.